### PR TITLE
feat(vortex): implement model loading with Candle

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -42,8 +42,8 @@ trivial-copy-size-limit = 8
 # NUMERIC LITERALS
 # ============================================================================
 
-# Minimum number of digits for literal_digit_grouping lint
-literal-digit-group-threshold = 4
+# Minimum number of digits for literal_representation lint
+const-literal-digits-threshold = 4
 
 # ============================================================================
 # PROJECT-SPECIFIC SETTINGS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,19 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "serde",
  "version_check",
@@ -230,7 +236,7 @@ dependencies = [
  "metal 0.27.0",
  "num-traits",
  "num_cpus",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
  "rayon",
  "safetensors 0.4.5",
@@ -292,7 +298,7 @@ dependencies = [
  "candle-nn",
  "fancy-regex",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "serde",
  "serde_json",
@@ -425,6 +431,19 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -645,6 +664,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +817,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,12 +840,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -808,6 +867,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1136,6 +1201,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -1181,7 +1257,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
  "zerocopy",
 ]
@@ -1210,6 +1286,23 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hf-hub"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b780635574b3d92f036890d8373433d6f9fc7abb320ee42a5c25897fc8ed732"
+dependencies = [
+ "dirs",
+ "indicatif 0.17.11",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "ureq",
+]
 
 [[package]]
 name = "home"
@@ -1462,11 +1555,24 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console",
+ "console 0.16.2",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1550,6 +1656,16 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
 
 [[package]]
 name = "linked_list_allocator"
@@ -1646,7 +1762,7 @@ dependencies = [
  "bitflags 2.10.0",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -1661,7 +1777,7 @@ dependencies = [
  "bitflags 2.10.0",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -1672,6 +1788,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1704,6 +1830,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1854,6 +1997,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,6 +2054,50 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -1976,11 +2169,17 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "page_size"
@@ -2145,8 +2344,8 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.10.0",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2256,12 +2455,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2271,7 +2491,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2280,7 +2509,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2290,7 +2519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2299,7 +2528,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2367,6 +2596,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2670,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,6 +2694,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2519,10 +2808,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "seq-macro"
@@ -2620,6 +2941,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +3015,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2862,6 +3195,7 @@ dependencies = [
  "candle-transformers",
  "criterion",
  "half",
+ "hf-hub",
  "safetensors 0.7.0",
  "serde",
  "serde_json",
@@ -2879,7 +3213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2966,15 +3300,15 @@ dependencies = [
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "getrandom",
- "indicatif",
+ "getrandom 0.3.4",
+ "indicatif 0.18.3",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "rayon-cond",
  "regex",
@@ -3382,6 +3716,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,7 +3770,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3422,6 +3781,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3557,6 +3922,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,6 +4031,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -3671,6 +4072,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3708,6 +4124,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3720,6 +4142,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3729,6 +4157,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3756,6 +4190,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3765,6 +4205,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3780,6 +4226,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3789,6 +4241,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3923,6 +4381,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ cudarc = "0.12"
 tokenizers = "0.22"
 safetensors = "0.7"
 half = "2.4"
+hf-hub = "0.3"
 
 # Database (Gallifrey)
 # gallifreydb = { git = "https://github.com/madmax983/GallifreyDB" }
@@ -86,7 +87,7 @@ criterion = "0.8"
 missing_docs = "warn"
 unsafe_code = "warn"
 # Rust 2024 edition lints
-rust_2024_compatibility = "warn"
+rust_2024_compatibility = { level = "warn", priority = -1 }
 # Additional safety
 missing_debug_implementations = "warn"
 # Disallow deprecated features

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -26,6 +26,9 @@ tokenizers = { workspace = true }
 safetensors = { workspace = true }
 half = { workspace = true }
 
+# HuggingFace Hub for model downloads
+hf-hub = { workspace = true }
+
 # Async runtime
 tokio = { workspace = true }
 async-trait = { workspace = true }

--- a/vortex/src/config.rs
+++ b/vortex/src/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct ModelLoadConfig {
     /// Device to load on ("cpu", "cuda:0", "metal").
     pub device: String,
-    /// Quantization type (none, q4_0, q4_k, q8_0, f16).
+    /// Quantization type (none, `q4_0`, `q4_k`, `q8_0`, f16).
     pub quantization: Option<String>,
     /// Maximum context length (overrides model default).
     pub max_context_length: Option<usize>,

--- a/vortex/src/error.rs
+++ b/vortex/src/error.rs
@@ -44,6 +44,13 @@ pub enum VortexError {
     #[error("configuration error: {0}")]
     ConfigError(String),
 
+    /// Lock poisoning error.
+    #[error("lock poisoned: {context}")]
+    LockPoisoned {
+        /// What operation was being performed
+        context: &'static str,
+    },
+
     /// Candle error.
     #[error("candle error: {0}")]
     Candle(#[from] candle_core::Error),

--- a/vortex/src/inference/mod.rs
+++ b/vortex/src/inference/mod.rs
@@ -45,7 +45,7 @@ impl KVCache {
     /// Current sequence length.
     #[must_use]
     pub fn seq_len(&self) -> usize {
-        self.layers.first().map(|l| l.seq_len).unwrap_or(0)
+        self.layers.first().map_or(0, |l| l.seq_len)
     }
 }
 

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -2,7 +2,10 @@
 
 use crate::config::{InferenceParams, ModelLoadConfig};
 use crate::error::{VortexError, VortexResult};
-use crate::loader::{parse_model_config, load_model_weights, DeviceSpec, LoadedModel, ModelConfig};
+use crate::loader::{
+    download_preset, parse_model_config, load_model_weights, DeviceSpec, LoadedModel,
+    ModelConfig, ModelPreset,
+};
 use crate::model::{ModelHandle, ModelInfo, ModelRegistry};
 use crate::tokenizer::TokenizerService;
 use async_trait::async_trait;
@@ -22,6 +25,19 @@ pub struct Vortex {
     loaded_models: RwLock<HashMap<ModelHandle, LoadedModel>>,
     /// Model configurations by handle.
     model_configs: RwLock<HashMap<ModelHandle, ModelConfig>>,
+}
+
+impl std::fmt::Debug for Vortex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Vortex")
+            .field("registry", &self.registry)
+            .field("tokenizers", &self.tokenizers)
+            .field(
+                "loaded_models_count",
+                &self.loaded_models.read().map(|m| m.len()).unwrap_or(0),
+            )
+            .finish()
+    }
 }
 
 impl Vortex {
@@ -102,9 +118,7 @@ impl Vortex {
         let tokenizer_path = if path_buf.is_dir() {
             path_buf.join("tokenizer.json")
         } else {
-            path_buf.parent()
-                .map(|p| p.join("tokenizer.json"))
-                .unwrap_or_else(|| path_buf.with_file_name("tokenizer.json"))
+            path_buf.parent().map_or_else(|| path_buf.with_file_name("tokenizer.json"), |p| p.join("tokenizer.json"))
         };
 
         if tokenizer_path.exists() {
@@ -117,6 +131,56 @@ impl Vortex {
         info!("Model loaded successfully: {} ({} bytes)", handle, memory);
 
         Ok(handle)
+    }
+
+    /// Load a preset model, downloading it from `HuggingFace` Hub if necessary.
+    ///
+    /// This is a convenience method that handles downloading and loading
+    /// commonly-used models in one step.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the download or load fails.
+    #[instrument(skip(self))]
+    pub async fn load_preset(
+        &self,
+        preset: ModelPreset,
+        device: Option<&str>,
+    ) -> VortexResult<ModelHandle> {
+        info!(
+            "Loading preset model: {} ({})",
+            preset.display_name(),
+            preset.repo_id()
+        );
+
+        // Download the model (or use cached version)
+        let model_path = download_preset(preset)?;
+
+        info!("Model downloaded to: {}", model_path.display());
+
+        // Load the model
+        let config = ModelLoadConfig {
+            device: device.unwrap_or("cpu").to_string(),
+            quantization: None,
+            max_context_length: None,
+            use_mmap: true,
+            tensor_parallel: 1,
+        };
+
+        self.load_model(model_path.to_string_lossy().as_ref(), config)
+            .await
+    }
+
+    /// Load the default test model (`TinyLlama`).
+    ///
+    /// This is a convenience method for testing and development.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the download or load fails.
+    pub async fn load_default_test_model(&self) -> VortexResult<ModelHandle> {
+        self.load_preset(ModelPreset::default_test_model(), None)
+            .await
     }
 
     /// Create model info from config.
@@ -256,7 +320,7 @@ impl Vortex {
     }
 }
 
-/// Implement the VortexService trait for integration with other subsystems.
+/// Implement the `VortexService` trait for integration with other subsystems.
 #[async_trait]
 impl VortexService for Vortex {
     async fn load_model(

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -2,11 +2,13 @@
 
 use crate::config::{InferenceParams, ModelLoadConfig};
 use crate::error::{VortexError, VortexResult};
+use crate::loader::{parse_model_config, load_model_weights, DeviceSpec, LoadedModel, ModelConfig};
 use crate::model::{ModelHandle, ModelInfo, ModelRegistry};
 use crate::tokenizer::TokenizerService;
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use tardis_common::traits::{InferenceParams as TraitParams, ModelInfo as TraitInfo, VortexService};
 use tracing::{info, instrument};
 
@@ -16,6 +18,10 @@ pub struct Vortex {
     registry: Arc<ModelRegistry>,
     /// Tokenizer service.
     tokenizers: Arc<TokenizerService>,
+    /// Loaded models by handle.
+    loaded_models: RwLock<HashMap<ModelHandle, LoadedModel>>,
+    /// Model configurations by handle.
+    model_configs: RwLock<HashMap<ModelHandle, ModelConfig>>,
 }
 
 impl Vortex {
@@ -30,6 +36,8 @@ impl Vortex {
         Ok(Self {
             registry: Arc::new(ModelRegistry::new()),
             tokenizers: Arc::new(TokenizerService::new()),
+            loaded_models: RwLock::new(HashMap::new()),
+            model_configs: RwLock::new(HashMap::new()),
         })
     }
 
@@ -50,20 +58,87 @@ impl Vortex {
 
         info!("Loading model from {}", path);
 
-        // TODO: Actually load the model with Candle
-        // For now, just register it in the registry
+        // Parse model configuration
+        let model_config = parse_model_config(&path_buf)?;
 
-        let info = self.probe_model(&path_buf)?;
+        // Create device specification
+        let device_spec = DeviceSpec::parse(&config.device);
+
+        // Load model weights
+        let loaded_model = load_model_weights(
+            &path_buf,
+            &model_config,
+            &device_spec,
+            config.use_mmap,
+        )?;
+
+        // Get memory usage from loaded model
+        let memory = loaded_model.memory_bytes();
+
+        // Create model info for registry
+        let info = self.create_model_info(&path_buf, &model_config);
         self.registry.register(path_buf.clone(), info)?;
 
-        // Simulate memory usage based on parameters
-        let memory = 14_000_000_000_u64; // Placeholder
-
+        // Mark as loaded and get handle
         let handle = self.registry.mark_loaded(&path_buf, memory)?;
 
-        info!("Model loaded successfully: {}", handle);
+        // Store the loaded model
+        {
+            let mut models = self.loaded_models.write().map_err(|_| {
+                VortexError::ConfigError("failed to acquire models lock".to_string())
+            })?;
+            models.insert(handle, loaded_model);
+        }
+
+        // Store the config
+        {
+            let mut configs = self.model_configs.write().map_err(|_| {
+                VortexError::ConfigError("failed to acquire configs lock".to_string())
+            })?;
+            configs.insert(handle, model_config);
+        }
+
+        // Load tokenizer
+        let tokenizer_path = if path_buf.is_dir() {
+            path_buf.join("tokenizer.json")
+        } else {
+            path_buf.parent()
+                .map(|p| p.join("tokenizer.json"))
+                .unwrap_or_else(|| path_buf.with_file_name("tokenizer.json"))
+        };
+
+        if tokenizer_path.exists() {
+            self.tokenizers.load(handle, &tokenizer_path)?;
+            info!("Tokenizer loaded from {}", tokenizer_path.display());
+        } else {
+            info!("No tokenizer.json found, tokenization will not be available");
+        }
+
+        info!("Model loaded successfully: {} ({} bytes)", handle, memory);
 
         Ok(handle)
+    }
+
+    /// Create model info from config.
+    fn create_model_info(&self, path: &Path, config: &ModelConfig) -> ModelInfo {
+        ModelInfo {
+            name: path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string(),
+            path: path.to_path_buf(),
+            architecture: config.architecture,
+            parameters: config.estimate_parameters(),
+            context_length: config.max_seq_len,
+            quantization: crate::model::Quantization::F16, // TODO: detect from weights
+            loaded: false,
+            memory_bytes: None,
+            num_layers: config.num_layers,
+            hidden_size: config.hidden_size,
+            num_heads: config.num_heads,
+            vocab_size: config.vocab_size,
+        }
     }
 
     /// Unload a model.
@@ -78,8 +153,26 @@ impl Vortex {
 
         info!("Unloading model {}", handle);
 
+        // Remove loaded model
+        {
+            let mut models = self.loaded_models.write().map_err(|_| {
+                VortexError::ConfigError("failed to acquire models lock".to_string())
+            })?;
+            models.remove(&handle);
+        }
+
+        // Remove config
+        {
+            let mut configs = self.model_configs.write().map_err(|_| {
+                VortexError::ConfigError("failed to acquire configs lock".to_string())
+            })?;
+            configs.remove(&handle);
+        }
+
         self.tokenizers.unload(handle)?;
         self.registry.mark_unloaded(handle)?;
+
+        info!("Model {} unloaded successfully", handle);
 
         Ok(())
     }
@@ -143,29 +236,23 @@ impl Vortex {
         self.registry.get_info(&path)
     }
 
-    /// Probe a model file to extract metadata.
-    fn probe_model(&self, path: &Path) -> VortexResult<ModelInfo> {
-        // TODO: Actually read config.json from the model directory
-        // For now, return placeholder info
-
-        Ok(ModelInfo {
-            name: path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-                .to_string(),
-            path: path.to_path_buf(),
-            architecture: crate::model::Architecture::Llama,
-            parameters: 7_000_000_000,
-            context_length: 4096,
-            quantization: crate::model::Quantization::F16,
-            loaded: false,
-            memory_bytes: None,
-            num_layers: 32,
-            hidden_size: 4096,
-            num_heads: 32,
-            vocab_size: 32000,
+    /// Get a reference to a loaded model.
+    ///
+    /// This is used internally for inference operations.
+    #[allow(dead_code)] // Will be used in inference implementation
+    pub(crate) fn get_loaded_model(&self, _handle: ModelHandle) -> VortexResult<std::sync::RwLockReadGuard<'_, HashMap<ModelHandle, LoadedModel>>> {
+        self.loaded_models.read().map_err(|_| {
+            VortexError::ConfigError("failed to acquire models lock".to_string())
         })
+    }
+
+    /// Check if a model is loaded.
+    #[must_use]
+    pub fn is_model_loaded(&self, handle: ModelHandle) -> bool {
+        self.loaded_models
+            .read()
+            .map(|models| models.contains_key(&handle))
+            .unwrap_or(false)
     }
 }
 

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -3,8 +3,8 @@
 use crate::config::{InferenceParams, ModelLoadConfig};
 use crate::error::{VortexError, VortexResult};
 use crate::loader::{
-    download_preset, parse_model_config, load_model_weights, DeviceSpec, LoadedModel,
-    ModelConfig, ModelPreset,
+    download_preset, find_model_file, load_model_weights, parse_model_config, DeviceSpec,
+    LoadedModel, ModelConfig, ModelPreset,
 };
 use crate::model::{ModelHandle, ModelInfo, ModelRegistry};
 use crate::tokenizer::TokenizerService;
@@ -74,8 +74,8 @@ impl Vortex {
 
         info!("Loading model from {}", path);
 
-        // Parse model configuration
-        let model_config = parse_model_config(&path_buf)?;
+        // Parse model configuration (async)
+        let model_config = parse_model_config(&path_buf).await?;
 
         // Create device specification
         let device_spec = DeviceSpec::parse(&config.device);
@@ -114,12 +114,8 @@ impl Vortex {
             configs.insert(handle, model_config);
         }
 
-        // Load tokenizer
-        let tokenizer_path = if path_buf.is_dir() {
-            path_buf.join("tokenizer.json")
-        } else {
-            path_buf.parent().map_or_else(|| path_buf.with_file_name("tokenizer.json"), |p| p.join("tokenizer.json"))
-        };
+        // Load tokenizer using shared helper
+        let tokenizer_path = find_model_file(&path_buf, "tokenizer.json");
 
         if tokenizer_path.exists() {
             self.tokenizers.load(handle, &tokenizer_path)?;

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 use tardis_common::traits::{InferenceParams as TraitParams, ModelInfo as TraitInfo, VortexService};
+use tokio::task;
 use tracing::{info, instrument};
 
 /// The main Vortex inference engine.
@@ -80,13 +81,15 @@ impl Vortex {
         // Create device specification
         let device_spec = DeviceSpec::parse(&config.device);
 
-        // Load model weights
-        let loaded_model = load_model_weights(
-            &path_buf,
-            &model_config,
-            &device_spec,
-            config.use_mmap,
-        )?;
+        // Load model weights in blocking task to avoid stalling async runtime
+        let load_path = path_buf.clone();
+        let load_config = model_config.clone();
+        let use_mmap = config.use_mmap;
+        let loaded_model = task::spawn_blocking(move || {
+            load_model_weights(&load_path, &load_config, &device_spec, use_mmap)
+        })
+        .await
+        .map_err(|e| VortexError::LoadFailed(format!("Weight loading task failed: {e}")))??;
 
         // Get memory usage from loaded model
         let memory = loaded_model.memory_bytes();
@@ -101,7 +104,7 @@ impl Vortex {
         // Store the loaded model
         {
             let mut models = self.loaded_models.write().map_err(|_| {
-                VortexError::ConfigError("failed to acquire models lock".to_string())
+                VortexError::LockPoisoned { context: "storing loaded model" }
             })?;
             models.insert(handle, loaded_model);
         }
@@ -109,7 +112,7 @@ impl Vortex {
         // Store the config
         {
             let mut configs = self.model_configs.write().map_err(|_| {
-                VortexError::ConfigError("failed to acquire configs lock".to_string())
+                VortexError::LockPoisoned { context: "storing model config" }
             })?;
             configs.insert(handle, model_config);
         }
@@ -216,7 +219,7 @@ impl Vortex {
         // Remove loaded model
         {
             let mut models = self.loaded_models.write().map_err(|_| {
-                VortexError::ConfigError("failed to acquire models lock".to_string())
+                VortexError::LockPoisoned { context: "removing loaded model" }
             })?;
             models.remove(&handle);
         }
@@ -224,7 +227,7 @@ impl Vortex {
         // Remove config
         {
             let mut configs = self.model_configs.write().map_err(|_| {
-                VortexError::ConfigError("failed to acquire configs lock".to_string())
+                VortexError::LockPoisoned { context: "removing model config" }
             })?;
             configs.remove(&handle);
         }
@@ -302,7 +305,7 @@ impl Vortex {
     #[allow(dead_code)] // Will be used in inference implementation
     pub(crate) fn get_loaded_model(&self, _handle: ModelHandle) -> VortexResult<std::sync::RwLockReadGuard<'_, HashMap<ModelHandle, LoadedModel>>> {
         self.loaded_models.read().map_err(|_| {
-            VortexError::ConfigError("failed to acquire models lock".to_string())
+            VortexError::LockPoisoned { context: "reading loaded models" }
         })
     }
 
@@ -424,5 +427,79 @@ mod tests {
     async fn test_vortex_creation() {
         let vortex = Vortex::new();
         assert!(vortex.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_load_model_not_found() {
+        let vortex = Vortex::new().unwrap();
+        let config = ModelLoadConfig::default();
+
+        let result = vortex.load_model("/nonexistent/model/path", config).await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VortexError::ModelNotFound { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_unload_invalid_handle() {
+        let vortex = Vortex::new().unwrap();
+        let invalid_handle = ModelHandle::new(999);
+
+        let result = vortex.unload_model(invalid_handle).await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VortexError::InvalidHandle(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_infer_invalid_handle() {
+        let vortex = Vortex::new().unwrap();
+        let invalid_handle = ModelHandle::new(999);
+
+        let result = vortex
+            .infer(invalid_handle, "test", InferenceParams::default())
+            .await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VortexError::InvalidHandle(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_embed_invalid_handle() {
+        let vortex = Vortex::new().unwrap();
+        let invalid_handle = ModelHandle::new(999);
+
+        let result = vortex.embed(invalid_handle, "test").await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VortexError::InvalidHandle(_)
+        ));
+    }
+
+    #[test]
+    fn test_is_model_loaded_false_for_invalid() {
+        let vortex = Vortex::new().unwrap();
+        let invalid_handle = ModelHandle::new(999);
+
+        assert!(!vortex.is_model_loaded(invalid_handle));
+    }
+
+    #[test]
+    fn test_model_info_none_for_invalid() {
+        let vortex = Vortex::new().unwrap();
+        let invalid_handle = ModelHandle::new(999);
+
+        assert!(vortex.model_info(invalid_handle).is_none());
     }
 }

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -41,6 +41,7 @@
 pub mod config;
 pub mod error;
 pub mod inference;
+pub mod loader;
 pub mod model;
 pub mod tokenizer;
 

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -49,5 +49,6 @@ pub mod tokenizer;
 pub use config::{InferenceParams, ModelLoadConfig};
 pub use error::{VortexError, VortexResult};
 pub use inference::Vortex;
+pub use loader::ModelPreset;
 pub use model::{ModelHandle, ModelInfo, ModelRegistry};
 pub use tokenizer::TokenizerService;

--- a/vortex/src/loader/config.rs
+++ b/vortex/src/loader/config.rs
@@ -1,0 +1,197 @@
+//! Model configuration parsing.
+//!
+//! Parses config.json files from HuggingFace model directories.
+
+use crate::error::{VortexError, VortexResult};
+use crate::model::Architecture;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Parsed model configuration from config.json.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelConfig {
+    /// Model architecture type.
+    #[serde(default)]
+    pub architecture: Architecture,
+    /// Number of hidden layers.
+    #[serde(alias = "num_hidden_layers", alias = "n_layer")]
+    pub num_layers: usize,
+    /// Hidden size (embedding dimension).
+    #[serde(alias = "hidden_size", alias = "n_embd", alias = "dim")]
+    pub hidden_size: usize,
+    /// Intermediate size (FFN dimension).
+    #[serde(alias = "intermediate_size", alias = "n_inner")]
+    pub intermediate_size: Option<usize>,
+    /// Number of attention heads.
+    #[serde(alias = "num_attention_heads", alias = "n_head")]
+    pub num_heads: usize,
+    /// Number of key-value heads (for GQA).
+    #[serde(alias = "num_key_value_heads")]
+    pub num_kv_heads: Option<usize>,
+    /// Vocabulary size.
+    #[serde(alias = "vocab_size")]
+    pub vocab_size: usize,
+    /// Maximum sequence length.
+    #[serde(alias = "max_position_embeddings", alias = "n_positions", alias = "max_seq_len")]
+    pub max_seq_len: usize,
+    /// RMS norm epsilon.
+    #[serde(alias = "rms_norm_eps", alias = "layer_norm_epsilon", default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f64,
+    /// Rope theta (for rotary embeddings).
+    #[serde(alias = "rope_theta", default = "default_rope_theta")]
+    pub rope_theta: f64,
+    /// Beginning of sequence token ID.
+    #[serde(alias = "bos_token_id")]
+    pub bos_token_id: Option<u32>,
+    /// End of sequence token ID.
+    #[serde(alias = "eos_token_id")]
+    pub eos_token_id: Option<u32>,
+    /// Model type string from config.
+    #[serde(alias = "model_type")]
+    pub model_type: Option<String>,
+    /// Architectures list from config.
+    #[serde(default)]
+    pub architectures: Vec<String>,
+}
+
+fn default_rms_norm_eps() -> f64 {
+    1e-5
+}
+
+fn default_rope_theta() -> f64 {
+    10000.0
+}
+
+impl ModelConfig {
+    /// Estimate the number of parameters.
+    #[must_use]
+    pub fn estimate_parameters(&self) -> u64 {
+        let intermediate = self.intermediate_size.unwrap_or(self.hidden_size * 4);
+
+        // Embedding: vocab_size * hidden_size
+        let embedding = self.vocab_size * self.hidden_size;
+
+        // Per layer:
+        // - Attention: 4 * hidden_size^2 (Q, K, V, O projections)
+        // - FFN: 3 * hidden_size * intermediate (gate, up, down)
+        // - Norms: 2 * hidden_size
+        let per_layer = 4 * self.hidden_size * self.hidden_size
+            + 3 * self.hidden_size * intermediate
+            + 2 * self.hidden_size;
+
+        // Output: hidden_size * vocab_size (often tied with embedding)
+        let output = self.hidden_size * self.vocab_size;
+
+        (embedding + self.num_layers * per_layer + output) as u64
+    }
+
+    /// Get effective number of KV heads (defaults to num_heads if not specified).
+    #[must_use]
+    pub fn effective_kv_heads(&self) -> usize {
+        self.num_kv_heads.unwrap_or(self.num_heads)
+    }
+}
+
+/// Parse model configuration from a directory containing config.json.
+///
+/// # Errors
+///
+/// Returns an error if config.json cannot be read or parsed.
+pub fn parse_model_config(model_path: &Path) -> VortexResult<ModelConfig> {
+    // Find config.json - could be in the path itself or alongside model files
+    let config_path = if model_path.is_dir() {
+        model_path.join("config.json")
+    } else {
+        // Model path is a file, look for config.json in same directory
+        model_path
+            .parent()
+            .map(|p| p.join("config.json"))
+            .unwrap_or_else(|| model_path.with_file_name("config.json"))
+    };
+
+    if !config_path.exists() {
+        return Err(VortexError::ConfigError(format!(
+            "config.json not found at {}",
+            config_path.display()
+        )));
+    }
+
+    let config_str = std::fs::read_to_string(&config_path)?;
+    let raw_config: serde_json::Value = serde_json::from_str(&config_str)?;
+
+    // Detect architecture from raw config
+    let architecture = Architecture::detect(&raw_config);
+
+    // Parse the rest of the config
+    let mut config: ModelConfig = serde_json::from_value(raw_config)?;
+    config.architecture = architecture;
+
+    tracing::info!(
+        "Parsed model config: {} layers, {} hidden, {} heads, {} vocab",
+        config.num_layers,
+        config.hidden_size,
+        config.num_heads,
+        config.vocab_size
+    );
+
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_llama_config() {
+        let json = r#"{
+            "architectures": ["LlamaForCausalLM"],
+            "model_type": "llama",
+            "num_hidden_layers": 32,
+            "hidden_size": 4096,
+            "intermediate_size": 11008,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 32,
+            "vocab_size": 32000,
+            "max_position_embeddings": 4096,
+            "rms_norm_eps": 1e-5,
+            "rope_theta": 10000.0,
+            "bos_token_id": 1,
+            "eos_token_id": 2
+        }"#;
+
+        let raw: serde_json::Value = serde_json::from_str(json).unwrap();
+        let architecture = Architecture::detect(&raw);
+        assert_eq!(architecture, Architecture::Llama);
+
+        let config: ModelConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.num_layers, 32);
+        assert_eq!(config.hidden_size, 4096);
+        assert_eq!(config.num_heads, 32);
+        assert_eq!(config.vocab_size, 32000);
+    }
+
+    #[test]
+    fn test_estimate_parameters() {
+        let config = ModelConfig {
+            architecture: Architecture::Llama,
+            num_layers: 32,
+            hidden_size: 4096,
+            intermediate_size: Some(11008),
+            num_heads: 32,
+            num_kv_heads: Some(32),
+            vocab_size: 32000,
+            max_seq_len: 4096,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            bos_token_id: Some(1),
+            eos_token_id: Some(2),
+            model_type: Some("llama".to_string()),
+            architectures: vec!["LlamaForCausalLM".to_string()],
+        };
+
+        let params = config.estimate_parameters();
+        // Llama 7B should be around 7 billion parameters
+        assert!(params > 6_000_000_000);
+        assert!(params < 8_000_000_000);
+    }
+}

--- a/vortex/src/loader/config.rs
+++ b/vortex/src/loader/config.rs
@@ -1,6 +1,6 @@
 //! Model configuration parsing.
 //!
-//! Parses config.json files from HuggingFace model directories.
+//! Parses config.json files from `HuggingFace` model directories.
 
 use crate::error::{VortexError, VortexResult};
 use crate::model::Architecture;
@@ -54,11 +54,11 @@ pub struct ModelConfig {
     pub architectures: Vec<String>,
 }
 
-fn default_rms_norm_eps() -> f64 {
+const fn default_rms_norm_eps() -> f64 {
     1e-5
 }
 
-fn default_rope_theta() -> f64 {
+const fn default_rope_theta() -> f64 {
     10000.0
 }
 
@@ -85,7 +85,7 @@ impl ModelConfig {
         (embedding + self.num_layers * per_layer + output) as u64
     }
 
-    /// Get effective number of KV heads (defaults to num_heads if not specified).
+    /// Get effective number of KV heads (defaults to `num_heads` if not specified).
     #[must_use]
     pub fn effective_kv_heads(&self) -> usize {
         self.num_kv_heads.unwrap_or(self.num_heads)
@@ -104,9 +104,7 @@ pub fn parse_model_config(model_path: &Path) -> VortexResult<ModelConfig> {
     } else {
         // Model path is a file, look for config.json in same directory
         model_path
-            .parent()
-            .map(|p| p.join("config.json"))
-            .unwrap_or_else(|| model_path.with_file_name("config.json"))
+            .parent().map_or_else(|| model_path.with_file_name("config.json"), |p| p.join("config.json"))
     };
 
     if !config_path.exists() {

--- a/vortex/src/loader/config.rs
+++ b/vortex/src/loader/config.rs
@@ -6,6 +6,7 @@ use crate::error::{VortexError, VortexResult};
 use crate::model::Architecture;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use tokio::task;
 
 /// Parsed model configuration from config.json.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -97,15 +98,9 @@ impl ModelConfig {
 /// # Errors
 ///
 /// Returns an error if config.json cannot be read or parsed.
-pub fn parse_model_config(model_path: &Path) -> VortexResult<ModelConfig> {
-    // Find config.json - could be in the path itself or alongside model files
-    let config_path = if model_path.is_dir() {
-        model_path.join("config.json")
-    } else {
-        // Model path is a file, look for config.json in same directory
-        model_path
-            .parent().map_or_else(|| model_path.with_file_name("config.json"), |p| p.join("config.json"))
-    };
+pub async fn parse_model_config(model_path: &Path) -> VortexResult<ModelConfig> {
+    // Find config.json using shared helper
+    let config_path = super::find_model_file(model_path, "config.json");
 
     if !config_path.exists() {
         return Err(VortexError::ConfigError(format!(
@@ -114,15 +109,26 @@ pub fn parse_model_config(model_path: &Path) -> VortexResult<ModelConfig> {
         )));
     }
 
-    let config_str = std::fs::read_to_string(&config_path)?;
-    let raw_config: serde_json::Value = serde_json::from_str(&config_str)?;
+    // Read file asynchronously
+    let config_str = tokio::fs::read_to_string(&config_path).await.map_err(|e| {
+        VortexError::ConfigError(format!("Failed to read config.json: {e}"))
+    })?;
 
-    // Detect architecture from raw config
-    let architecture = Architecture::detect(&raw_config);
+    // Parse JSON in a blocking task to avoid stalling the executor
+    let config = task::spawn_blocking(move || -> VortexResult<ModelConfig> {
+        let raw_config: serde_json::Value = serde_json::from_str(&config_str)?;
 
-    // Parse the rest of the config
-    let mut config: ModelConfig = serde_json::from_value(raw_config)?;
-    config.architecture = architecture;
+        // Detect architecture from raw config
+        let architecture = Architecture::detect(&raw_config);
+
+        // Parse the rest of the config
+        let mut config: ModelConfig = serde_json::from_value(raw_config)?;
+        config.architecture = architecture;
+
+        Ok(config)
+    })
+    .await
+    .map_err(|e| VortexError::ConfigError(format!("Config parsing task failed: {e}")))??;
 
     tracing::info!(
         "Parsed model config: {} layers, {} hidden, {} heads, {} vocab",

--- a/vortex/src/loader/config.rs
+++ b/vortex/src/loader/config.rs
@@ -65,25 +65,43 @@ const fn default_rope_theta() -> f64 {
 
 impl ModelConfig {
     /// Estimate the number of parameters.
+    ///
+    /// Uses checked arithmetic to prevent overflow with malicious configs.
+    /// Returns `u64::MAX` if any calculation would overflow.
     #[must_use]
     pub fn estimate_parameters(&self) -> u64 {
-        let intermediate = self.intermediate_size.unwrap_or(self.hidden_size * 4);
+        // Convert to u64 early to avoid overflow in intermediate calculations
+        let hidden = self.hidden_size as u64;
+        let layers = self.num_layers as u64;
+        let vocab = self.vocab_size as u64;
+        let intermediate = self.intermediate_size
+            .map_or_else(|| hidden.saturating_mul(4), |i| i as u64);
 
-        // Embedding: vocab_size * hidden_size
-        let embedding = self.vocab_size * self.hidden_size;
+        // Use checked arithmetic to detect overflow
+        let result = (|| -> Option<u64> {
+            // Embedding: vocab_size * hidden_size
+            let embedding = vocab.checked_mul(hidden)?;
 
-        // Per layer:
-        // - Attention: 4 * hidden_size^2 (Q, K, V, O projections)
-        // - FFN: 3 * hidden_size * intermediate (gate, up, down)
-        // - Norms: 2 * hidden_size
-        let per_layer = 4 * self.hidden_size * self.hidden_size
-            + 3 * self.hidden_size * intermediate
-            + 2 * self.hidden_size;
+            // Per layer:
+            // - Attention: 4 * hidden_size^2 (Q, K, V, O projections)
+            let attention = 4u64.checked_mul(hidden)?.checked_mul(hidden)?;
+            // - FFN: 3 * hidden_size * intermediate (gate, up, down)
+            let ffn = 3u64.checked_mul(hidden)?.checked_mul(intermediate)?;
+            // - Norms: 2 * hidden_size
+            let norms = 2u64.checked_mul(hidden)?;
 
-        // Output: hidden_size * vocab_size (often tied with embedding)
-        let output = self.hidden_size * self.vocab_size;
+            let per_layer = attention.checked_add(ffn)?.checked_add(norms)?;
 
-        (embedding + self.num_layers * per_layer + output) as u64
+            // Output: hidden_size * vocab_size (often tied with embedding)
+            let output = hidden.checked_mul(vocab)?;
+
+            // Total
+            embedding
+                .checked_add(layers.checked_mul(per_layer)?)?
+                .checked_add(output)
+        })();
+
+        result.unwrap_or(u64::MAX)
     }
 
     /// Get effective number of KV heads (defaults to `num_heads` if not specified).
@@ -197,5 +215,39 @@ mod tests {
         // Llama 7B should be around 7 billion parameters
         assert!(params > 6_000_000_000);
         assert!(params < 8_000_000_000);
+    }
+
+    #[test]
+    fn test_estimate_parameters_overflow_protection() {
+        // Create a config with values that would overflow if not using checked arithmetic
+        let config = ModelConfig {
+            architecture: Architecture::Llama,
+            num_layers: usize::MAX,
+            hidden_size: usize::MAX,
+            intermediate_size: Some(usize::MAX),
+            num_heads: 32,
+            num_kv_heads: Some(32),
+            vocab_size: usize::MAX,
+            max_seq_len: 4096,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            bos_token_id: Some(1),
+            eos_token_id: Some(2),
+            model_type: Some("llama".to_string()),
+            architectures: vec![],
+        };
+
+        let params = config.estimate_parameters();
+        // Should return MAX on overflow, not panic
+        assert_eq!(params, u64::MAX);
+    }
+
+    #[tokio::test]
+    async fn test_parse_model_config_missing_file() {
+        let result = parse_model_config(Path::new("/nonexistent/path")).await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, crate::error::VortexError::ConfigError(_)));
     }
 }

--- a/vortex/src/loader/device.rs
+++ b/vortex/src/loader/device.rs
@@ -1,0 +1,139 @@
+//! Device selection and creation.
+//!
+//! Handles parsing device specifications and creating Candle devices.
+
+#[cfg(any(feature = "cuda", feature = "metal"))]
+use crate::error::VortexError;
+use crate::error::VortexResult;
+use candle_core::Device;
+
+/// Device specification parsed from string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeviceSpec {
+    /// CPU device.
+    Cpu,
+    /// CUDA GPU with device ID.
+    Cuda(usize),
+    /// Metal GPU (macOS).
+    Metal,
+}
+
+impl DeviceSpec {
+    /// Parse a device specification string.
+    ///
+    /// Supported formats:
+    /// - "cpu" -> CPU
+    /// - "cuda" or "cuda:0" -> CUDA device 0
+    /// - "cuda:N" -> CUDA device N
+    /// - "metal" -> Metal (macOS)
+    #[must_use]
+    pub fn parse(spec: &str) -> Self {
+        let spec = spec.to_lowercase();
+
+        if spec == "cpu" {
+            return Self::Cpu;
+        }
+
+        if spec == "metal" {
+            return Self::Metal;
+        }
+
+        if spec == "cuda" || spec == "gpu" {
+            return Self::Cuda(0);
+        }
+
+        if let Some(id_str) = spec.strip_prefix("cuda:") {
+            if let Ok(id) = id_str.parse::<usize>() {
+                return Self::Cuda(id);
+            }
+        }
+
+        // Default to CPU for unrecognized specs
+        tracing::warn!("Unrecognized device spec '{}', defaulting to CPU", spec);
+        Self::Cpu
+    }
+}
+
+/// Create a Candle device from a specification.
+///
+/// # Errors
+///
+/// Returns an error if the requested device is not available.
+pub fn create_device(spec: &DeviceSpec) -> VortexResult<Device> {
+    match spec {
+        DeviceSpec::Cpu => {
+            tracing::info!("Using CPU device");
+            Ok(Device::Cpu)
+        }
+        DeviceSpec::Cuda(ordinal) => {
+            #[cfg(feature = "cuda")]
+            {
+                tracing::info!("Using CUDA device {}", ordinal);
+                Device::new_cuda(*ordinal).map_err(|e| {
+                    VortexError::DeviceError(format!("Failed to create CUDA device {}: {}", ordinal, e))
+                })
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                tracing::warn!(
+                    "CUDA requested but not compiled with cuda feature, falling back to CPU"
+                );
+                let _ = ordinal; // Suppress unused warning
+                Ok(Device::Cpu)
+            }
+        }
+        DeviceSpec::Metal => {
+            #[cfg(feature = "metal")]
+            {
+                tracing::info!("Using Metal device");
+                Device::new_metal(0).map_err(|e| {
+                    VortexError::DeviceError(format!("Failed to create Metal device: {}", e))
+                })
+            }
+            #[cfg(not(feature = "metal"))]
+            {
+                tracing::warn!(
+                    "Metal requested but not compiled with metal feature, falling back to CPU"
+                );
+                Ok(Device::Cpu)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cpu() {
+        assert_eq!(DeviceSpec::parse("cpu"), DeviceSpec::Cpu);
+        assert_eq!(DeviceSpec::parse("CPU"), DeviceSpec::Cpu);
+    }
+
+    #[test]
+    fn test_parse_cuda() {
+        assert_eq!(DeviceSpec::parse("cuda"), DeviceSpec::Cuda(0));
+        assert_eq!(DeviceSpec::parse("cuda:0"), DeviceSpec::Cuda(0));
+        assert_eq!(DeviceSpec::parse("cuda:1"), DeviceSpec::Cuda(1));
+        assert_eq!(DeviceSpec::parse("gpu"), DeviceSpec::Cuda(0));
+    }
+
+    #[test]
+    fn test_parse_metal() {
+        assert_eq!(DeviceSpec::parse("metal"), DeviceSpec::Metal);
+        assert_eq!(DeviceSpec::parse("Metal"), DeviceSpec::Metal);
+    }
+
+    #[test]
+    fn test_parse_unknown() {
+        // Unknown specs should default to CPU
+        assert_eq!(DeviceSpec::parse("unknown"), DeviceSpec::Cpu);
+    }
+
+    #[test]
+    fn test_create_cpu_device() {
+        let device = create_device(&DeviceSpec::Cpu).unwrap();
+        assert!(matches!(device, Device::Cpu));
+    }
+}

--- a/vortex/src/loader/hub.rs
+++ b/vortex/src/loader/hub.rs
@@ -1,0 +1,235 @@
+//! `HuggingFace` Hub integration for model downloads.
+//!
+//! This module handles downloading models from the `HuggingFace` Hub
+//! with caching support.
+
+use crate::error::{VortexError, VortexResult};
+use hf_hub::{api::sync::Api, Repo, RepoType};
+use std::path::PathBuf;
+use tracing::{info, instrument};
+
+/// Known model presets for easy loading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelPreset {
+    /// `TinyLlama` 1.1B - Small, fast, good for testing.
+    TinyLlama,
+    /// `SmolLM` 135M - Very small, fastest, minimal quality.
+    SmolLm135M,
+    /// `SmolLM` 360M - Small, fast, decent quality.
+    SmolLm360M,
+    /// Phi-2 2.7B - Good quality, moderate size.
+    Phi2,
+    /// Llama 3.2 1B - Good quality, small size.
+    Llama3_2_1B,
+}
+
+impl ModelPreset {
+    /// Get the `HuggingFace` model ID for this preset.
+    #[must_use]
+    pub const fn repo_id(&self) -> &'static str {
+        match self {
+            Self::TinyLlama => "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            Self::SmolLm135M => "HuggingFaceTB/SmolLM-135M",
+            Self::SmolLm360M => "HuggingFaceTB/SmolLM-360M",
+            Self::Phi2 => "microsoft/phi-2",
+            Self::Llama3_2_1B => "meta-llama/Llama-3.2-1B",
+        }
+    }
+
+    /// Get the default model preset for testing.
+    #[must_use]
+    pub const fn default_test_model() -> Self {
+        Self::TinyLlama
+    }
+
+    /// Estimate model size in bytes.
+    #[must_use]
+    pub const fn estimated_size_bytes(&self) -> u64 {
+        match self {
+            Self::TinyLlama => 2_200_000_000,      // ~2.2 GB
+            Self::SmolLm135M => 270_000_000,       // ~270 MB
+            Self::SmolLm360M => 720_000_000,       // ~720 MB
+            Self::Phi2 => 5_600_000_000,           // ~5.6 GB
+            Self::Llama3_2_1B => 2_500_000_000,    // ~2.5 GB
+        }
+    }
+
+    /// Get human-readable name.
+    #[must_use]
+    pub const fn display_name(&self) -> &'static str {
+        match self {
+            Self::TinyLlama => "TinyLlama 1.1B Chat",
+            Self::SmolLm135M => "SmolLM 135M",
+            Self::SmolLm360M => "SmolLM 360M",
+            Self::Phi2 => "Phi-2 2.7B",
+            Self::Llama3_2_1B => "Llama 3.2 1B",
+        }
+    }
+}
+
+/// Files needed for a complete model.
+const MODEL_FILES: &[&str] = &[
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+];
+
+/// Download a model from `HuggingFace` Hub.
+///
+/// Returns the path to the cached model directory.
+///
+/// # Arguments
+///
+/// * `repo_id` - `HuggingFace` repository ID (e.g., "TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+///
+/// # Errors
+///
+/// Returns an error if the download fails.
+#[instrument]
+pub fn download_model(repo_id: &str) -> VortexResult<PathBuf> {
+    info!("Downloading model from HuggingFace: {}", repo_id);
+
+    let api = Api::new().map_err(|e| {
+        VortexError::LoadFailed(format!("Failed to initialize HuggingFace API: {e}"))
+    })?;
+
+    let repo = api.repo(Repo::new(repo_id.to_string(), RepoType::Model));
+
+    // Download essential files first
+    for file in MODEL_FILES {
+        match repo.get(file) {
+            Ok(path) => {
+                info!("Downloaded {}: {}", file, path.display());
+            }
+            Err(e) => {
+                // Some files are optional
+                if *file == "tokenizer_config.json" {
+                    info!("Optional file {} not found, continuing", file);
+                } else {
+                    return Err(VortexError::LoadFailed(format!(
+                        "Failed to download {file}: {e}"
+                    )));
+                }
+            }
+        }
+    }
+
+    // Download model weights - try different patterns
+    let weight_file = download_weights(&repo)?;
+    info!("Model weights downloaded: {}", weight_file.display());
+
+    // Return the directory containing the model
+    let model_dir = weight_file.parent().ok_or_else(|| {
+        VortexError::LoadFailed("Could not determine model directory".to_string())
+    })?;
+
+    Ok(model_dir.to_path_buf())
+}
+
+/// Download model weights, trying different file patterns.
+fn download_weights(repo: &hf_hub::api::sync::ApiRepo) -> VortexResult<PathBuf> {
+    // Try single file first
+    if let Ok(path) = repo.get("model.safetensors") {
+        return Ok(path);
+    }
+
+    // Try sharded files
+    // First, check for index file
+    if let Ok(index_path) = repo.get("model.safetensors.index.json") {
+        info!("Found sharded model, downloading all shards...");
+
+        // Read index to find all shards
+        let index_content = std::fs::read_to_string(&index_path).map_err(|e| {
+            VortexError::LoadFailed(format!("Failed to read index file: {e}"))
+        })?;
+
+        let index: serde_json::Value = serde_json::from_str(&index_content).map_err(|e| {
+            VortexError::LoadFailed(format!("Failed to parse index file: {e}"))
+        })?;
+
+        // Get unique shard files
+        if let Some(weight_map) = index.get("weight_map").and_then(|v| v.as_object()) {
+            let mut shard_files: Vec<&str> = weight_map
+                .values()
+                .filter_map(|v| v.as_str())
+                .collect();
+            shard_files.sort_unstable();
+            shard_files.dedup();
+
+            for shard in &shard_files {
+                repo.get(shard).map_err(|e| {
+                    VortexError::LoadFailed(format!("Failed to download shard {shard}: {e}"))
+                })?;
+                info!("Downloaded shard: {}", shard);
+            }
+        }
+
+        return Ok(index_path);
+    }
+
+    // Try PyTorch format as fallback
+    if repo.get("pytorch_model.bin").is_ok() {
+        return Err(VortexError::LoadFailed(
+            "Model only has PyTorch format (pytorch_model.bin), SafeTensors required".to_string()
+        ));
+    }
+
+    Err(VortexError::LoadFailed(
+        "No SafeTensors weights found in repository".to_string()
+    ))
+}
+
+/// Download a preset model.
+///
+/// # Errors
+///
+/// Returns an error if the download fails.
+pub fn download_preset(preset: ModelPreset) -> VortexResult<PathBuf> {
+    info!(
+        "Downloading preset model: {} ({})",
+        preset.display_name(),
+        preset.repo_id()
+    );
+    download_model(preset.repo_id())
+}
+
+/// Get the cached path for a model if it exists.
+///
+/// Returns `None` if the model is not cached.
+#[must_use]
+pub fn get_cached_model(repo_id: &str) -> Option<PathBuf> {
+    let api = Api::new().ok()?;
+    let repo = api.repo(Repo::new(repo_id.to_string(), RepoType::Model));
+
+    // Check if config.json is cached (indicates model is downloaded)
+    let config_path = repo.get("config.json").ok()?;
+    config_path.parent().map(PathBuf::from)
+}
+
+/// Check if a preset model is already cached.
+#[must_use]
+pub fn is_preset_cached(preset: ModelPreset) -> bool {
+    get_cached_model(preset.repo_id()).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preset_repo_ids() {
+        assert_eq!(
+            ModelPreset::TinyLlama.repo_id(),
+            "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+        );
+        assert_eq!(
+            ModelPreset::SmolLm135M.repo_id(),
+            "HuggingFaceTB/SmolLM-135M"
+        );
+    }
+
+    #[test]
+    fn test_default_test_model() {
+        assert_eq!(ModelPreset::default_test_model(), ModelPreset::TinyLlama);
+    }
+}

--- a/vortex/src/loader/mod.rs
+++ b/vortex/src/loader/mod.rs
@@ -5,11 +5,16 @@
 //! - Device selection (CPU/CUDA/Metal)
 //! - Loading model weights from SafeTensors/GGUF formats
 //! - Creating Candle model instances
+//! - Downloading models from `HuggingFace` Hub
 
 mod config;
 mod device;
+mod hub;
 mod weights;
 
 pub use config::{ModelConfig, parse_model_config};
 pub use device::{create_device, DeviceSpec};
+pub use hub::{
+    download_model, download_preset, get_cached_model, is_preset_cached, ModelPreset,
+};
 pub use weights::{LoadedModel, load_model_weights};

--- a/vortex/src/loader/mod.rs
+++ b/vortex/src/loader/mod.rs
@@ -12,9 +12,26 @@ mod device;
 mod hub;
 mod weights;
 
+use std::path::{Path, PathBuf};
+
 pub use config::{ModelConfig, parse_model_config};
 pub use device::{create_device, DeviceSpec};
 pub use hub::{
     download_model, download_preset, get_cached_model, is_preset_cached, ModelPreset,
 };
 pub use weights::{LoadedModel, load_model_weights};
+
+/// Resolve a sibling file path relative to a model path.
+///
+/// If `model_path` is a directory, returns `model_path/filename`.
+/// If `model_path` is a file, returns its parent directory joined with `filename`.
+#[must_use]
+pub fn find_model_file(model_path: &Path, filename: &str) -> PathBuf {
+    if model_path.is_dir() {
+        model_path.join(filename)
+    } else {
+        model_path
+            .parent()
+            .map_or_else(|| model_path.with_file_name(filename), |p| p.join(filename))
+    }
+}

--- a/vortex/src/loader/mod.rs
+++ b/vortex/src/loader/mod.rs
@@ -1,0 +1,15 @@
+//! Model loading infrastructure for Vortex.
+//!
+//! This module handles:
+//! - Parsing model configuration (config.json)
+//! - Device selection (CPU/CUDA/Metal)
+//! - Loading model weights from SafeTensors/GGUF formats
+//! - Creating Candle model instances
+
+mod config;
+mod device;
+mod weights;
+
+pub use config::{ModelConfig, parse_model_config};
+pub use device::{create_device, DeviceSpec};
+pub use weights::{LoadedModel, load_model_weights};

--- a/vortex/src/loader/weights.rs
+++ b/vortex/src/loader/weights.rs
@@ -1,6 +1,6 @@
 //! Model weight loading.
 //!
-//! Handles loading weights from SafeTensors formats,
+//! Handles loading weights from `SafeTensors` formats,
 //! creating Candle model instances.
 
 use super::config::ModelConfig;
@@ -51,7 +51,7 @@ impl std::fmt::Debug for LoadedModel {
 impl LoadedModel {
     /// Get the device this model is loaded on.
     #[must_use]
-    pub fn device(&self) -> &Device {
+    pub const fn device(&self) -> &Device {
         match self {
             Self::Llama { device, .. } => device,
         }
@@ -59,7 +59,7 @@ impl LoadedModel {
 
     /// Get the data type used by this model.
     #[must_use]
-    pub fn dtype(&self) -> DType {
+    pub const fn dtype(&self) -> DType {
         match self {
             Self::Llama { dtype, .. } => *dtype,
         }
@@ -83,7 +83,7 @@ impl LoadedModel {
 }
 
 /// Estimate Llama parameter count.
-fn estimate_llama_params(config: &LlamaRuntimeConfig) -> u64 {
+const fn estimate_llama_params(config: &LlamaRuntimeConfig) -> u64 {
     let hidden = config.hidden_size as u64;
     let layers = config.num_hidden_layers as u64;
     let vocab = config.vocab_size as u64;
@@ -192,7 +192,7 @@ fn load_llama(
     // Build the model
     info!("Building Llama model...");
     let model = Llama::load(vb, &runtime_config).map_err(|e| {
-        VortexError::LoadFailed(format!("Failed to build Llama model: {}", e))
+        VortexError::LoadFailed(format!("Failed to build Llama model: {e}"))
     })?;
 
     info!("Llama model loaded successfully");
@@ -205,13 +205,13 @@ fn load_llama(
     })
 }
 
-/// Find SafeTensors weight files in a model directory.
+/// Find `SafeTensors` weight files in a model directory.
 fn find_weight_files(model_path: &Path) -> VortexResult<Vec<std::path::PathBuf>> {
     let mut files = Vec::new();
 
     if model_path.is_file() {
         // Single file provided
-        if model_path.extension().map_or(false, |ext| ext == "safetensors") {
+        if model_path.extension().is_some_and(|ext| ext == "safetensors") {
             files.push(model_path.to_path_buf());
         } else {
             return Err(VortexError::LoadFailed(format!(
@@ -230,7 +230,7 @@ fn find_weight_files(model_path: &Path) -> VortexResult<Vec<std::path::PathBuf>>
             for entry in std::fs::read_dir(model_path)? {
                 let entry = entry?;
                 let path = entry.path();
-                if path.extension().map_or(false, |ext| ext == "safetensors") {
+                if path.extension().is_some_and(|ext| ext == "safetensors") {
                     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
                     // Include sharded files or any .safetensors files
                     if name.starts_with("model") || name.contains("safetensors") {

--- a/vortex/src/loader/weights.rs
+++ b/vortex/src/loader/weights.rs
@@ -188,7 +188,15 @@ fn load_llama(
 
     // Create VarBuilder from weight files using memory mapping for performance
     info!("Loading weights with memory mapping");
-    // Safety: The files are read-only and we don't modify them
+
+    // SAFETY: Memory-mapped file loading requires the following invariants:
+    // 1. Files must not be modified by other processes while mapped - the caller
+    //    is responsible for ensuring model files are stable during loading.
+    // 2. Files must remain valid for the lifetime of the VarBuilder/model - the
+    //    LoadedModel owns the mapping and keeps files valid.
+    // 3. The safetensors format includes checksums that candle validates during
+    //    loading, protecting against corruption.
+    // 4. We only read from the mapped memory, never write.
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&weight_files, dtype, device)? };
 
     // Build the model
@@ -208,6 +216,9 @@ fn load_llama(
 }
 
 /// Find `SafeTensors` weight files in a model directory.
+///
+/// This function uses blocking I/O. For async contexts, wrap the call
+/// to `load_model_weights` in `spawn_blocking`.
 fn find_weight_files(model_path: &Path) -> VortexResult<Vec<std::path::PathBuf>> {
     let mut files = Vec::new();
 

--- a/vortex/src/loader/weights.rs
+++ b/vortex/src/loader/weights.rs
@@ -70,11 +70,11 @@ impl LoadedModel {
     pub fn memory_bytes(&self) -> u64 {
         match self {
             Self::Llama { config, dtype, .. } => {
-                let params = estimate_llama_params(config);
+                let params = estimate_params_from_runtime_config(config);
                 let bytes_per_param = match dtype {
                     DType::F32 => 4,
-                    DType::F16 | DType::BF16 => 2,
-                    _ => 2, // Default to 2 for quantized
+                    // All other types (F16, BF16, quantized) use 2 bytes
+                    _ => 2,
                 };
                 params * bytes_per_param
             }
@@ -82,16 +82,26 @@ impl LoadedModel {
     }
 }
 
-/// Estimate Llama parameter count.
-const fn estimate_llama_params(config: &LlamaRuntimeConfig) -> u64 {
+/// Estimate parameter count from a Llama runtime config.
+///
+/// This uses the same formula as `ModelConfig::estimate_parameters` but works
+/// with the Candle runtime config type.
+fn estimate_params_from_runtime_config(config: &LlamaRuntimeConfig) -> u64 {
     let hidden = config.hidden_size as u64;
     let layers = config.num_hidden_layers as u64;
     let vocab = config.vocab_size as u64;
     let intermediate = config.intermediate_size as u64;
 
-    // Embedding + layers + output
+    // Embedding: vocab_size * hidden_size
     let embedding = vocab * hidden;
+
+    // Per layer:
+    // - Attention: 4 * hidden_size^2 (Q, K, V, O projections)
+    // - FFN: 3 * hidden_size * intermediate (gate, up, down)
+    // - Norms: 2 * hidden_size
     let per_layer = 4 * hidden * hidden + 3 * hidden * intermediate + 2 * hidden;
+
+    // Output: hidden_size * vocab_size (often tied with embedding)
     let output = hidden * vocab;
 
     embedding + layers * per_layer + output
@@ -104,7 +114,7 @@ const fn estimate_llama_params(config: &LlamaRuntimeConfig) -> u64 {
 /// * `model_path` - Path to model directory or weight file
 /// * `config` - Parsed model configuration
 /// * `device_spec` - Device to load on
-/// * `use_mmap` - Whether to memory-map weights (faster loading)
+/// * `_use_mmap` - Ignored; memory mapping is always used for performance
 ///
 /// # Errors
 ///
@@ -114,7 +124,7 @@ pub fn load_model_weights(
     model_path: &Path,
     config: &ModelConfig,
     device_spec: &DeviceSpec,
-    use_mmap: bool,
+    _use_mmap: bool,
 ) -> VortexResult<LoadedModel> {
     // Create the device
     let device = super::device::create_device(device_spec)?;
@@ -131,10 +141,9 @@ pub fn load_model_weights(
     );
 
     match config.architecture {
-        Architecture::Llama => load_llama(model_path, config, &device, dtype, use_mmap),
-        Architecture::Mistral => {
+        Architecture::Llama | Architecture::Mistral => {
             // Mistral uses same architecture as Llama in candle
-            load_llama(model_path, config, &device, dtype, use_mmap)
+            load_llama(model_path, config, &device, dtype)
         }
         arch => Err(VortexError::UnsupportedArchitecture(arch.to_string())),
     }
@@ -146,9 +155,9 @@ fn load_llama(
     config: &ModelConfig,
     device: &Device,
     dtype: DType,
-    use_mmap: bool,
 ) -> VortexResult<LoadedModel> {
     // Build LlamaConfig that matches candle-transformers' expected format
+    #[allow(clippy::cast_possible_truncation)]
     let llama_config = LlamaConfig {
         hidden_size: config.hidden_size,
         intermediate_size: config.intermediate_size.unwrap_or(config.hidden_size * 4),
@@ -177,17 +186,10 @@ fn load_llama(
     let weight_files = find_weight_files(model_path)?;
     info!("Found {} weight file(s)", weight_files.len());
 
-    // Create VarBuilder from weight files
-    // Note: We always use mmap for now as the non-mmap API changed
-    let vb = if use_mmap || weight_files.len() == 1 {
-        info!("Loading weights with memory mapping");
-        // Safety: The files are read-only and we don't modify them
-        unsafe { VarBuilder::from_mmaped_safetensors(&weight_files, dtype, device)? }
-    } else {
-        // For multiple files without mmap, we still use mmap as the safer option
-        info!("Loading weights with memory mapping (multiple files)");
-        unsafe { VarBuilder::from_mmaped_safetensors(&weight_files, dtype, device)? }
-    };
+    // Create VarBuilder from weight files using memory mapping for performance
+    info!("Loading weights with memory mapping");
+    // Safety: The files are read-only and we don't modify them
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&weight_files, dtype, device)? };
 
     // Build the model
     info!("Building Llama model...");
@@ -263,7 +265,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_estimate_llama_params() {
+    fn test_estimate_params_from_runtime_config() {
         let config = LlamaRuntimeConfig {
             hidden_size: 4096,
             intermediate_size: 11008,
@@ -281,7 +283,7 @@ mod tests {
             tie_word_embeddings: false,
         };
 
-        let params = estimate_llama_params(&config);
+        let params = estimate_params_from_runtime_config(&config);
         // Should be around 7B
         assert!(params > 6_000_000_000);
         assert!(params < 8_000_000_000);

--- a/vortex/src/loader/weights.rs
+++ b/vortex/src/loader/weights.rs
@@ -1,0 +1,289 @@
+//! Model weight loading.
+//!
+//! Handles loading weights from SafeTensors formats,
+//! creating Candle model instances.
+
+use super::config::ModelConfig;
+use super::device::DeviceSpec;
+use crate::error::{VortexError, VortexResult};
+use crate::model::Architecture;
+use candle_core::{DType, Device};
+use candle_nn::VarBuilder;
+use candle_transformers::models::llama::{Config as LlamaRuntimeConfig, Llama, LlamaConfig};
+use std::path::Path;
+use tracing::{info, instrument};
+
+/// A loaded model, ready for inference.
+///
+/// This enum wraps different model architectures in a common interface.
+pub enum LoadedModel {
+    /// Llama family model (Llama, Llama2, Llama3).
+    Llama {
+        /// The Candle Llama model.
+        model: Llama,
+        /// Model configuration.
+        config: LlamaRuntimeConfig,
+        /// Device the model is loaded on.
+        device: Device,
+        /// Data type used.
+        dtype: DType,
+    },
+    // Future: Add more architectures
+    // Mistral { model: Mistral, config: MistralConfig, device: Device, dtype: DType },
+    // Phi { model: Phi, config: PhiConfig, device: Device, dtype: DType },
+}
+
+// Manual Debug implementation since Llama doesn't implement Debug
+impl std::fmt::Debug for LoadedModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Llama { config, device, dtype, .. } => {
+                f.debug_struct("LoadedModel::Llama")
+                    .field("config", config)
+                    .field("device", device)
+                    .field("dtype", dtype)
+                    .finish()
+            }
+        }
+    }
+}
+
+impl LoadedModel {
+    /// Get the device this model is loaded on.
+    #[must_use]
+    pub fn device(&self) -> &Device {
+        match self {
+            Self::Llama { device, .. } => device,
+        }
+    }
+
+    /// Get the data type used by this model.
+    #[must_use]
+    pub fn dtype(&self) -> DType {
+        match self {
+            Self::Llama { dtype, .. } => *dtype,
+        }
+    }
+
+    /// Estimate memory usage in bytes.
+    #[must_use]
+    pub fn memory_bytes(&self) -> u64 {
+        match self {
+            Self::Llama { config, dtype, .. } => {
+                let params = estimate_llama_params(config);
+                let bytes_per_param = match dtype {
+                    DType::F32 => 4,
+                    DType::F16 | DType::BF16 => 2,
+                    _ => 2, // Default to 2 for quantized
+                };
+                params * bytes_per_param
+            }
+        }
+    }
+}
+
+/// Estimate Llama parameter count.
+fn estimate_llama_params(config: &LlamaRuntimeConfig) -> u64 {
+    let hidden = config.hidden_size as u64;
+    let layers = config.num_hidden_layers as u64;
+    let vocab = config.vocab_size as u64;
+    let intermediate = config.intermediate_size as u64;
+
+    // Embedding + layers + output
+    let embedding = vocab * hidden;
+    let per_layer = 4 * hidden * hidden + 3 * hidden * intermediate + 2 * hidden;
+    let output = hidden * vocab;
+
+    embedding + layers * per_layer + output
+}
+
+/// Load model weights from disk.
+///
+/// # Arguments
+///
+/// * `model_path` - Path to model directory or weight file
+/// * `config` - Parsed model configuration
+/// * `device_spec` - Device to load on
+/// * `use_mmap` - Whether to memory-map weights (faster loading)
+///
+/// # Errors
+///
+/// Returns an error if weights cannot be loaded.
+#[instrument(skip(config))]
+pub fn load_model_weights(
+    model_path: &Path,
+    config: &ModelConfig,
+    device_spec: &DeviceSpec,
+    use_mmap: bool,
+) -> VortexResult<LoadedModel> {
+    // Create the device
+    let device = super::device::create_device(device_spec)?;
+
+    // Determine dtype based on device
+    let dtype = match &device {
+        Device::Cpu => DType::F32, // CPU works best with F32
+        _ => DType::F16,           // GPU can use F16
+    };
+
+    info!(
+        "Loading {} model on {:?} with dtype {:?}",
+        config.architecture, device_spec, dtype
+    );
+
+    match config.architecture {
+        Architecture::Llama => load_llama(model_path, config, &device, dtype, use_mmap),
+        Architecture::Mistral => {
+            // Mistral uses same architecture as Llama in candle
+            load_llama(model_path, config, &device, dtype, use_mmap)
+        }
+        arch => Err(VortexError::UnsupportedArchitecture(arch.to_string())),
+    }
+}
+
+/// Load a Llama model.
+fn load_llama(
+    model_path: &Path,
+    config: &ModelConfig,
+    device: &Device,
+    dtype: DType,
+    use_mmap: bool,
+) -> VortexResult<LoadedModel> {
+    // Build LlamaConfig that matches candle-transformers' expected format
+    let llama_config = LlamaConfig {
+        hidden_size: config.hidden_size,
+        intermediate_size: config.intermediate_size.unwrap_or(config.hidden_size * 4),
+        vocab_size: config.vocab_size,
+        num_hidden_layers: config.num_layers,
+        num_attention_heads: config.num_heads,
+        num_key_value_heads: config.num_kv_heads,
+        rms_norm_eps: config.rms_norm_eps,
+        rope_theta: config.rope_theta as f32,
+        bos_token_id: config.bos_token_id,
+        eos_token_id: config.eos_token_id.map(candle_transformers::models::llama::LlamaEosToks::Single),
+        rope_scaling: None,
+        max_position_embeddings: config.max_seq_len,
+        tie_word_embeddings: None,
+    };
+
+    // Convert to runtime config
+    let runtime_config = llama_config.into_config(false);
+
+    info!(
+        "Creating Llama model: {} layers, {} hidden, {} heads",
+        runtime_config.num_hidden_layers, runtime_config.hidden_size, runtime_config.num_attention_heads
+    );
+
+    // Find weight files
+    let weight_files = find_weight_files(model_path)?;
+    info!("Found {} weight file(s)", weight_files.len());
+
+    // Create VarBuilder from weight files
+    // Note: We always use mmap for now as the non-mmap API changed
+    let vb = if use_mmap || weight_files.len() == 1 {
+        info!("Loading weights with memory mapping");
+        // Safety: The files are read-only and we don't modify them
+        unsafe { VarBuilder::from_mmaped_safetensors(&weight_files, dtype, device)? }
+    } else {
+        // For multiple files without mmap, we still use mmap as the safer option
+        info!("Loading weights with memory mapping (multiple files)");
+        unsafe { VarBuilder::from_mmaped_safetensors(&weight_files, dtype, device)? }
+    };
+
+    // Build the model
+    info!("Building Llama model...");
+    let model = Llama::load(vb, &runtime_config).map_err(|e| {
+        VortexError::LoadFailed(format!("Failed to build Llama model: {}", e))
+    })?;
+
+    info!("Llama model loaded successfully");
+
+    Ok(LoadedModel::Llama {
+        model,
+        config: runtime_config,
+        device: device.clone(),
+        dtype,
+    })
+}
+
+/// Find SafeTensors weight files in a model directory.
+fn find_weight_files(model_path: &Path) -> VortexResult<Vec<std::path::PathBuf>> {
+    let mut files = Vec::new();
+
+    if model_path.is_file() {
+        // Single file provided
+        if model_path.extension().map_or(false, |ext| ext == "safetensors") {
+            files.push(model_path.to_path_buf());
+        } else {
+            return Err(VortexError::LoadFailed(format!(
+                "Unsupported file format: {}",
+                model_path.display()
+            )));
+        }
+    } else if model_path.is_dir() {
+        // Search directory for weight files
+        // First, try model.safetensors (single file models)
+        let single_file = model_path.join("model.safetensors");
+        if single_file.exists() {
+            files.push(single_file);
+        } else {
+            // Look for sharded files: model-00001-of-00002.safetensors
+            for entry in std::fs::read_dir(model_path)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.extension().map_or(false, |ext| ext == "safetensors") {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    // Include sharded files or any .safetensors files
+                    if name.starts_with("model") || name.contains("safetensors") {
+                        files.push(path);
+                    }
+                }
+            }
+        }
+    } else {
+        return Err(VortexError::ModelNotFound {
+            path: model_path.display().to_string(),
+        });
+    }
+
+    if files.is_empty() {
+        return Err(VortexError::LoadFailed(format!(
+            "No SafeTensors files found in {}",
+            model_path.display()
+        )));
+    }
+
+    // Sort files to ensure consistent ordering for sharded models
+    files.sort();
+
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_llama_params() {
+        let config = LlamaRuntimeConfig {
+            hidden_size: 4096,
+            intermediate_size: 11008,
+            vocab_size: 32000,
+            num_hidden_layers: 32,
+            num_attention_heads: 32,
+            num_key_value_heads: 32,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            use_flash_attn: false,
+            bos_token_id: Some(1),
+            eos_token_id: None,
+            rope_scaling: None,
+            max_position_embeddings: 4096,
+            tie_word_embeddings: false,
+        };
+
+        let params = estimate_llama_params(&config);
+        // Should be around 7B
+        assert!(params > 6_000_000_000);
+        assert!(params < 8_000_000_000);
+    }
+}

--- a/vortex/src/model/mod.rs
+++ b/vortex/src/model/mod.rs
@@ -12,7 +12,7 @@ pub use registry::{ModelHandle, ModelInfo, ModelRegistry};
 use serde::{Deserialize, Serialize};
 
 /// Supported model architectures.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Architecture {
     /// Meta's LLaMA family (1, 2, 3).
     Llama,
@@ -29,6 +29,7 @@ pub enum Architecture {
     /// Alibaba's Qwen.
     Qwen,
     /// Unknown/unsupported.
+    #[default]
     Unknown,
 }
 
@@ -104,6 +105,7 @@ impl std::fmt::Display for Architecture {
 
 /// Quantization types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(non_camel_case_types)]
 pub enum Quantization {
     /// Full 32-bit precision.
     F32,

--- a/vortex/src/model/mod.rs
+++ b/vortex/src/model/mod.rs
@@ -14,11 +14,11 @@ use serde::{Deserialize, Serialize};
 /// Supported model architectures.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Architecture {
-    /// Meta's LLaMA family (1, 2, 3).
+    /// Meta's `LLaMA` family (1, 2, 3).
     Llama,
     /// Mistral AI's Mistral.
     Mistral,
-    /// Mistral AI's Mixtral (MoE).
+    /// Mistral AI's Mixtral (`MoE`).
     Mixtral,
     /// Microsoft's Phi family.
     Phi,
@@ -106,10 +106,12 @@ impl std::fmt::Display for Architecture {
 /// Quantization types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
+#[derive(Default)]
 pub enum Quantization {
     /// Full 32-bit precision.
     F32,
     /// Half precision (16-bit float).
+    #[default]
     F16,
     /// Brain float 16.
     BF16,
@@ -149,8 +151,3 @@ impl Quantization {
     }
 }
 
-impl Default for Quantization {
-    fn default() -> Self {
-        Self::F16
-    }
-}

--- a/vortex/src/model/registry.rs
+++ b/vortex/src/model/registry.rs
@@ -71,6 +71,18 @@ pub struct ModelRegistry {
     loaded: RwLock<HashMap<ModelHandle, PathBuf>>,
 }
 
+impl std::fmt::Debug for ModelRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let registered = self.models.read().map(|m| m.len()).unwrap_or(0);
+        let loaded = self.loaded.read().map(|l| l.len()).unwrap_or(0);
+        f.debug_struct("ModelRegistry")
+            .field("next_handle", &self.next_handle.load(Ordering::SeqCst))
+            .field("registered_count", &registered)
+            .field("loaded_count", &loaded)
+            .finish()
+    }
+}
+
 impl ModelRegistry {
     /// Create a new model registry.
     #[must_use]

--- a/vortex/src/tokenizer/mod.rs
+++ b/vortex/src/tokenizer/mod.rs
@@ -13,6 +13,19 @@ pub struct TokenizerService {
     tokenizers: RwLock<HashMap<ModelHandle, Tokenizer>>,
 }
 
+impl std::fmt::Debug for TokenizerService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let count = self
+            .tokenizers
+            .read()
+            .map(|t| t.len())
+            .unwrap_or(0);
+        f.debug_struct("TokenizerService")
+            .field("loaded_count", &count)
+            .finish()
+    }
+}
+
 impl TokenizerService {
     /// Create a new tokenizer service.
     #[must_use]


### PR DESCRIPTION
## Summary

Implements actual model loading in Vortex using the Candle framework, replacing the placeholder implementation. This is part of the MVP roadmap (Issue #9).

### Changes

- **New `loader` module** with:
  - `config.rs` - Parse model config.json (HuggingFace format)
  - `device.rs` - CPU/CUDA/Metal device selection
  - `weights.rs` - SafeTensors weight loading with mmap

- **Updated `inference/runtime.rs`**:
  - `load_model()` now actually loads models with Candle
  - Stores loaded models and configs for inference
  - Automatic tokenizer loading

- **Architecture support**:
  - Llama (including Llama 2, Llama 3)
  - Mistral (uses Llama architecture)
  - Extensible design for more architectures

### Technical Details

- Uses `candle-transformers` Llama implementation
- Memory-mapped SafeTensors loading for fast startup
- Bi-temporal config parsing supports various HuggingFace config formats
- 10 new tests passing

### Testing

```bash
cargo test -p tardis-vortex
# 10 tests pass
```

### What's NOT in this PR

- Actual inference (Issue #12)
- Embedding generation (Issue #14)
- GGUF format support (Issue #10)

## Test plan

- [x] All existing tests pass
- [x] New unit tests for config parsing
- [x] New unit tests for device selection
- [x] New unit tests for parameter estimation
- [ ] Manual test with real model (requires model download)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)