### PR TITLE
🗺️ Atlas: Decouple Chronos from Concrete Services

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -4,3 +4,11 @@
 **Tangle:** `vortex/src/tokenizer/mod.rs` was a "Blob" (747 lines) containing Service logic, Types, and Chat Template logic. It violated Single Responsibility Principle.
 **Blueprint:** Extracted `types.rs` for data structures and `template.rs` for template logic.
 **Stability:** Reduced `mod.rs` size, improved cohesion, and enforced strict visibility (`pub(crate) mod template`).
+
+**[Architect] Decouple Chronos from Concrete Services**
+**Tangle:** `Chronos` struct depended on concrete `Arc<Vortex>` and `Arc<Gallifrey>`, creating high coupling and making testing difficult.
+**Blueprint:**
+1.  Extracted domain types (`Entity`, `Message`, `Snapshot`, etc.) from `gallifrey` to `common/src/domain.rs`.
+2.  Updated `GallifreyService` trait in `common` to include methods for conversation and system state.
+3.  Refactored `Chronos` to use `Arc<dyn VortexService>` and `Arc<dyn GallifreyService>`.
+**Stability:** `Chronos` is now decoupled from specific implementations, allowing for easier mocking and substitution.

--- a/chronos/src/error.rs
+++ b/chronos/src/error.rs
@@ -36,6 +36,10 @@ pub enum ChronosError {
     /// Gallifrey error.
     #[error("gallifrey error: {0}")]
     Gallifrey(#[from] tardis_gallifrey::GallifreyError),
+
+    /// Common error.
+    #[error("common error: {0}")]
+    Common(#[from] tardis_common::Error),
 }
 
 /// Result type for Chronos operations.

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -41,9 +41,8 @@ pub use retriever::Retriever;
 use crate::error::{ChronosError, ChronosResult};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tardis_common::traits::{GallifreyService, VortexService};
 use tardis_common::{EntityId, SessionId};
-use tardis_gallifrey::Gallifrey;
-use tardis_vortex::Vortex;
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -114,8 +113,8 @@ pub struct RagResponse {
 #[derive(Debug)]
 pub struct Chronos {
     #[allow(dead_code)]
-    vortex: Arc<Vortex>,
-    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<dyn VortexService>,
+    gallifrey: Arc<dyn GallifreyService>,
     analyzer: QueryAnalyzer,
     retriever: Retriever,
     augmenter: ContextAugmenter,
@@ -124,7 +123,7 @@ pub struct Chronos {
 impl Chronos {
     /// Create a new Chronos instance.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(vortex: Arc<dyn VortexService>, gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self {
             vortex,
             gallifrey: Arc::clone(&gallifrey),
@@ -193,7 +192,7 @@ impl Chronos {
         info!("Storing memory: {:?}", category);
 
         // Create entity in knowledge graph
-        let entity = tardis_gallifrey::stores::Entity {
+        let entity = tardis_common::domain::Entity {
             id: EntityId::new(),
             entity_type: format!("Memory:{category:?}"),
             name: content[..content.len().min(50)].to_string(),
@@ -206,15 +205,15 @@ impl Chronos {
                 props
             },
             embedding: None, // TODO: Generate embedding
-            temporal: tardis_gallifrey::BiTemporalInterval::now(),
+            temporal: tardis_common::temporal::BiTemporalInterval::now(),
             source: Some("user".to_string()),
         };
 
         let id = self
             .gallifrey
-            .knowledge()
-            .insert_entity(entity)
-            .map_err(ChronosError::Gallifrey)?;
+            .insert(entity)
+            .await
+            .map_err(ChronosError::Common)?;
 
         Ok(id)
     }
@@ -231,9 +230,9 @@ impl Chronos {
         // Search knowledge graph
         let results = self
             .gallifrey
-            .knowledge()
-            .semantic_search(&[], limit)
-            .map_err(ChronosError::Gallifrey)?;
+            .search_knowledge(&[], limit)
+            .await
+            .map_err(ChronosError::Common)?;
 
         Ok(results
             .into_iter()

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -4,19 +4,19 @@ use super::{ContextSource, ContextSourceType, RagConfig};
 use crate::error::{ChronosError, ChronosResult};
 use crate::pipeline::analyzer::AnalyzedQuery;
 use std::sync::Arc;
-use tardis_gallifrey::Gallifrey;
+use tardis_common::traits::GallifreyService;
 use tracing::info;
 
 /// Multi-source retriever.
 #[derive(Debug)]
 pub struct Retriever {
-    gallifrey: Arc<Gallifrey>,
+    gallifrey: Arc<dyn GallifreyService>,
 }
 
 impl Retriever {
     /// Create a new retriever.
     #[must_use]
-    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self { gallifrey }
     }
 
@@ -70,9 +70,9 @@ impl Retriever {
 
         let entities = self
             .gallifrey
-            .knowledge()
-            .semantic_search(&embedding, config.max_context_items)
-            .map_err(ChronosError::Gallifrey)?;
+            .search_knowledge(&embedding, config.max_context_items)
+            .await
+            .map_err(ChronosError::Common)?;
 
         Ok(entities
             .into_iter()
@@ -100,9 +100,9 @@ impl Retriever {
         if let Some(session_id) = config.session_id {
             let messages = self
                 .gallifrey
-                .conversation()
                 .get_recent_messages(session_id, 5)
-                .map_err(ChronosError::Gallifrey)?;
+                .await
+                .map_err(ChronosError::Common)?;
 
             for msg in messages {
                 sources.push(ContextSource {
@@ -118,9 +118,9 @@ impl Retriever {
         let embedding: Vec<f32> = Vec::new();
         let historical = self
             .gallifrey
-            .conversation()
-            .semantic_search(&embedding, config.max_context_items)
-            .map_err(ChronosError::Gallifrey)?;
+            .search_conversation(&embedding, config.max_context_items)
+            .await
+            .map_err(ChronosError::Common)?;
 
         for msg in historical {
             sources.push(ContextSource {
@@ -149,9 +149,9 @@ impl Retriever {
         for temporal_ref in &query.temporal_refs {
             if let Some(snapshot) = self
                 .gallifrey
-                .system_state()
-                .find_snapshot_at(temporal_ref.resolved)
-                .map_err(ChronosError::Gallifrey)?
+                .find_snapshot(temporal_ref.resolved)
+                .await
+                .map_err(ChronosError::Common)?
             {
                 sources.push(ContextSource {
                     source_type: ContextSourceType::SystemState,

--- a/common/src/domain.rs
+++ b/common/src/domain.rs
@@ -1,0 +1,198 @@
+//! Domain entities shared across Tardis OS.
+
+use crate::id::{EntityId, SessionId, SnapshotId};
+use crate::temporal::BiTemporalInterval;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ============================================================================
+// Knowledge Graph
+// ============================================================================
+
+/// A node in the knowledge graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entity {
+    /// Unique identifier.
+    pub id: EntityId,
+    /// Entity type (e.g., "Concept", "Person", "Project").
+    pub entity_type: String,
+    /// Entity name.
+    pub name: String,
+    /// Properties as key-value pairs.
+    pub properties: HashMap<String, serde_json::Value>,
+    /// Embedding vector for semantic search.
+    pub embedding: Option<Vec<f32>>,
+    /// Temporal metadata.
+    pub temporal: BiTemporalInterval,
+    /// Source of this knowledge.
+    pub source: Option<String>,
+}
+
+/// A relationship between entities.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Relationship {
+    /// Unique identifier.
+    pub id: EntityId,
+    /// Relationship type (e.g., "KNOWS", "CONTAINS", "`DEPENDS_ON`").
+    pub relationship_type: String,
+    /// Source entity ID.
+    pub source: EntityId,
+    /// Target entity ID.
+    pub target: EntityId,
+    /// Relationship properties.
+    pub properties: HashMap<String, serde_json::Value>,
+    /// Temporal metadata.
+    pub temporal: BiTemporalInterval,
+}
+
+// ============================================================================
+// Conversation
+// ============================================================================
+
+/// Role in a conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    /// User message.
+    User,
+    /// Assistant response.
+    Assistant,
+    /// System message.
+    System,
+}
+
+/// A message in a conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    /// Unique identifier.
+    pub id: EntityId,
+    /// Session this message belongs to.
+    pub session_id: SessionId,
+    /// Message role.
+    pub role: Role,
+    /// Message content.
+    pub content: String,
+    /// Timestamp.
+    pub timestamp: DateTime<Utc>,
+    /// Embedding for semantic search.
+    pub embedding: Option<Vec<f32>>,
+    /// References to knowledge graph entities.
+    pub entity_refs: Vec<EntityId>,
+}
+
+/// A conversation session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    /// Unique identifier.
+    pub id: SessionId,
+    /// Session start time.
+    pub started_at: DateTime<Utc>,
+    /// Session end time (None if active).
+    pub ended_at: Option<DateTime<Utc>>,
+    /// Session summary (generated after session ends).
+    pub summary: Option<String>,
+    /// Topics discussed.
+    pub topics: Vec<String>,
+    /// Session metadata.
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+// ============================================================================
+// System State
+// ============================================================================
+
+/// A snapshot of system state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot {
+    /// Unique identifier.
+    pub id: SnapshotId,
+    /// Snapshot name (user-provided or auto-generated).
+    pub name: String,
+    /// When the snapshot was taken.
+    pub timestamp: DateTime<Utc>,
+    /// What triggered the snapshot.
+    pub trigger: SnapshotTrigger,
+    /// Captured state.
+    pub state: SystemState,
+    /// Checksum for integrity.
+    pub checksum: String,
+}
+
+/// What triggered a snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SnapshotTrigger {
+    /// Scheduled snapshot.
+    Scheduled,
+    /// User-requested snapshot.
+    Manual,
+    /// Before a significant operation.
+    PreOperation(String),
+    /// After an error.
+    Error(String),
+}
+
+/// Captured system state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemState {
+    /// Process states.
+    pub processes: HashMap<u32, ProcessState>,
+    /// Configuration values.
+    pub config: HashMap<String, serde_json::Value>,
+    /// File system snapshot (paths and metadata).
+    pub files: HashMap<String, FileMetadata>,
+}
+
+/// Process state information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessState {
+    /// Process ID.
+    pub pid: u32,
+    /// Process name.
+    pub name: String,
+    /// Process status.
+    pub status: String,
+    /// Memory usage.
+    pub memory_bytes: u64,
+    /// CPU usage percentage.
+    pub cpu_percent: f32,
+}
+
+/// File metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileMetadata {
+    /// File path.
+    pub path: String,
+    /// File size.
+    pub size: u64,
+    /// Last modified time.
+    pub modified: DateTime<Utc>,
+    /// File hash (for content tracking).
+    pub hash: Option<String>,
+}
+
+/// A change between snapshots.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Change {
+    /// When the change occurred.
+    pub timestamp: DateTime<Utc>,
+    /// What changed.
+    pub path: String,
+    /// Type of change.
+    #[allow(clippy::struct_field_names)]
+    pub change_type: ChangeType,
+    /// Old value (if applicable).
+    pub old_value: Option<serde_json::Value>,
+    /// New value (if applicable).
+    pub new_value: Option<serde_json::Value>,
+}
+
+/// Type of change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChangeType {
+    /// Created.
+    Create,
+    /// Updated.
+    Update,
+    /// Deleted.
+    Delete,
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,6 +12,7 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
+pub mod domain;
 pub mod error;
 pub mod id;
 pub mod temporal;

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -3,9 +3,10 @@
 //! These traits define the contracts between subsystems, designed to support
 //! both direct function calls (monolithic) and potential future IPC (microkernel).
 
+use crate::domain::{Change, Entity, Message, Snapshot};
 use crate::error::Result;
 use crate::id::{EntityId, ModelHandle, SessionId};
-use crate::temporal::{BiTemporalInterval, TemporalQuery};
+use crate::temporal::TemporalQuery;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -72,7 +73,7 @@ pub struct ModelInfo {
 
 /// The Vortex LLM service interface.
 #[async_trait]
-pub trait VortexService: Send + Sync {
+pub trait VortexService: Send + Sync + std::fmt::Debug {
     /// Load a model from disk.
     async fn load_model(&self, path: &str, config: ModelLoadConfig) -> Result<ModelHandle>;
 
@@ -101,26 +102,11 @@ pub trait VortexService: Send + Sync {
 // Gallifrey (Database) Traits
 // ============================================================================
 
-/// A node in the knowledge graph.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GraphNode {
-    /// Unique identifier
-    pub id: EntityId,
-    /// Node type/label
-    pub node_type: String,
-    /// Node properties
-    pub properties: serde_json::Value,
-    /// Embedding vector (if computed)
-    pub embedding: Option<Vec<f32>>,
-    /// Temporal metadata
-    pub temporal: BiTemporalInterval,
-}
-
 /// Query results from Gallifrey.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryResult {
     /// Result nodes
-    pub nodes: Vec<GraphNode>,
+    pub nodes: Vec<Entity>,
     /// Query execution time in milliseconds
     pub execution_time_ms: u64,
     /// Whether results were truncated
@@ -129,21 +115,49 @@ pub struct QueryResult {
 
 /// The Gallifrey temporal database service interface.
 #[async_trait]
-pub trait GallifreyService: Send + Sync {
+pub trait GallifreyService: Send + Sync + std::fmt::Debug {
+    // --- Knowledge Graph ---
+
     /// Execute a query with optional temporal parameters.
     async fn query(&self, query: &str, temporal: TemporalQuery) -> Result<QueryResult>;
 
     /// Insert a node into the knowledge graph.
-    async fn insert(&self, node: GraphNode) -> Result<EntityId>;
+    async fn insert(&self, node: Entity) -> Result<EntityId>;
 
     /// Update an existing node.
     async fn update(&self, id: EntityId, properties: serde_json::Value) -> Result<()>;
 
     /// Get the history of an entity.
-    async fn get_history(&self, id: EntityId) -> Result<Vec<GraphNode>>;
+    async fn get_history(&self, id: EntityId) -> Result<Vec<Entity>>;
 
     /// Travel to a point in time and get a snapshot.
     async fn time_travel(&self, timestamp: chrono::DateTime<chrono::Utc>) -> Result<QueryResult>;
+
+    /// Semantic search for entities.
+    async fn search_knowledge(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>>;
+
+    // --- Conversation ---
+
+    /// Get recent messages from a session.
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> Result<Vec<Message>>;
+
+    /// Semantic search for messages.
+    async fn search_conversation(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>>;
+
+    // --- System State ---
+
+    /// Find a system snapshot at a specific time.
+    async fn find_snapshot(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<Snapshot>>;
+
+    /// Record a system change.
+    async fn record_change(&self, change: Change) -> Result<()>;
 }
 
 // ============================================================================

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -25,7 +25,12 @@ pub use error::{GallifreyError, GallifreyResult};
 pub use stores::{ConversationStore, KnowledgeStore, SystemStateStore};
 pub use temporal::{BiTemporalInterval, TimeRange};
 
+use async_trait::async_trait;
 use std::sync::Arc;
+use tardis_common::domain::{Change, Entity, Message, Snapshot};
+use tardis_common::id::{EntityId, SessionId};
+use tardis_common::temporal::TemporalQuery;
+use tardis_common::traits::{GallifreyService, QueryResult};
 
 /// The main Gallifrey database instance.
 #[derive(Debug)]
@@ -68,5 +73,110 @@ impl Gallifrey {
 impl Default for Gallifrey {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[async_trait]
+impl GallifreyService for Gallifrey {
+    // --- Knowledge Graph ---
+
+    async fn query(
+        &self,
+        _query: &str,
+        _temporal: TemporalQuery,
+    ) -> tardis_common::Result<QueryResult> {
+        // TODO: Implement actual query parsing and execution
+        Ok(QueryResult {
+            nodes: Vec::new(),
+            execution_time_ms: 0,
+            truncated: false,
+        })
+    }
+
+    async fn insert(&self, node: Entity) -> tardis_common::Result<EntityId> {
+        self.knowledge
+            .insert_entity(node)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    async fn update(
+        &self,
+        id: EntityId,
+        properties: serde_json::Value,
+    ) -> tardis_common::Result<()> {
+        let props: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_value(properties)
+                .map_err(|e| tardis_common::Error::Internal(e.to_string()))?;
+
+        self.knowledge
+            .update_entity(id, props)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    async fn get_history(&self, id: EntityId) -> tardis_common::Result<Vec<Entity>> {
+        self.knowledge
+            .get_entity_history(id)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    async fn time_travel(
+        &self,
+        _timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<QueryResult> {
+        // TODO: Implement time travel query
+        Ok(QueryResult {
+            nodes: Vec::new(),
+            execution_time_ms: 0,
+            truncated: false,
+        })
+    }
+
+    async fn search_knowledge(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Entity>> {
+        self.knowledge
+            .semantic_search(embedding, limit)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    // --- Conversation ---
+
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Message>> {
+        self.conversation
+            .get_recent_messages(session_id, limit)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    async fn search_conversation(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Message>> {
+        self.conversation
+            .semantic_search(embedding, limit)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    // --- System State ---
+
+    async fn find_snapshot(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Option<Snapshot>> {
+        self.system_state
+            .find_snapshot_at(timestamp)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    async fn record_change(&self, change: Change) -> tardis_common::Result<()> {
+        self.system_state
+            .record_change(change)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
     }
 }

--- a/gallifrey/src/stores/conversation.rs
+++ b/gallifrey/src/stores/conversation.rs
@@ -6,58 +6,11 @@
 //! - Session summaries
 
 use crate::error::{GallifreyError, GallifreyResult};
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::RwLock;
+pub use tardis_common::domain::{Message, Role, Session};
 use tardis_common::{EntityId, SessionId};
-
-/// Role in a conversation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Role {
-    /// User message.
-    User,
-    /// Assistant response.
-    Assistant,
-    /// System message.
-    System,
-}
-
-/// A message in a conversation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Message {
-    /// Unique identifier.
-    pub id: EntityId,
-    /// Session this message belongs to.
-    pub session_id: SessionId,
-    /// Message role.
-    pub role: Role,
-    /// Message content.
-    pub content: String,
-    /// Timestamp.
-    pub timestamp: DateTime<Utc>,
-    /// Embedding for semantic search.
-    pub embedding: Option<Vec<f32>>,
-    /// References to knowledge graph entities.
-    pub entity_refs: Vec<EntityId>,
-}
-
-/// A conversation session.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Session {
-    /// Unique identifier.
-    pub id: SessionId,
-    /// Session start time.
-    pub started_at: DateTime<Utc>,
-    /// Session end time (None if active).
-    pub ended_at: Option<DateTime<Utc>>,
-    /// Session summary (generated after session ends).
-    pub summary: Option<String>,
-    /// Topics discussed.
-    pub topics: Vec<String>,
-    /// Session metadata.
-    pub metadata: HashMap<String, serde_json::Value>,
-}
 
 /// The conversation store.
 #[derive(Debug)]

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -8,46 +8,10 @@
 use crate::error::{GallifreyError, GallifreyResult};
 use crate::temporal::BiTemporalInterval;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::RwLock;
+pub use tardis_common::domain::{Entity, Relationship};
 use tardis_common::EntityId;
-
-/// A node in the knowledge graph.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Entity {
-    /// Unique identifier.
-    pub id: EntityId,
-    /// Entity type (e.g., "Concept", "Person", "Project").
-    pub entity_type: String,
-    /// Entity name.
-    pub name: String,
-    /// Properties as key-value pairs.
-    pub properties: HashMap<String, serde_json::Value>,
-    /// Embedding vector for semantic search.
-    pub embedding: Option<Vec<f32>>,
-    /// Temporal metadata.
-    pub temporal: BiTemporalInterval,
-    /// Source of this knowledge.
-    pub source: Option<String>,
-}
-
-/// A relationship between entities.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Relationship {
-    /// Unique identifier.
-    pub id: EntityId,
-    /// Relationship type (e.g., "KNOWS", "CONTAINS", "`DEPENDS_ON`").
-    pub relationship_type: String,
-    /// Source entity ID.
-    pub source: EntityId,
-    /// Target entity ID.
-    pub target: EntityId,
-    /// Relationship properties.
-    pub properties: HashMap<String, serde_json::Value>,
-    /// Temporal metadata.
-    pub temporal: BiTemporalInterval,
-}
 
 /// The knowledge graph store.
 #[derive(Debug)]

--- a/gallifrey/src/stores/system_state.rs
+++ b/gallifrey/src/stores/system_state.rs
@@ -7,106 +7,10 @@
 
 use crate::error::{GallifreyError, GallifreyResult};
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::RwLock;
+pub use tardis_common::domain::{Change, Snapshot, SnapshotTrigger, SystemState};
 use tardis_common::SnapshotId;
-
-/// A snapshot of system state.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Snapshot {
-    /// Unique identifier.
-    pub id: SnapshotId,
-    /// Snapshot name (user-provided or auto-generated).
-    pub name: String,
-    /// When the snapshot was taken.
-    pub timestamp: DateTime<Utc>,
-    /// What triggered the snapshot.
-    pub trigger: SnapshotTrigger,
-    /// Captured state.
-    pub state: SystemState,
-    /// Checksum for integrity.
-    pub checksum: String,
-}
-
-/// What triggered a snapshot.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum SnapshotTrigger {
-    /// Scheduled snapshot.
-    Scheduled,
-    /// User-requested snapshot.
-    Manual,
-    /// Before a significant operation.
-    PreOperation(String),
-    /// After an error.
-    Error(String),
-}
-
-/// Captured system state.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SystemState {
-    /// Process states.
-    pub processes: HashMap<u32, ProcessState>,
-    /// Configuration values.
-    pub config: HashMap<String, serde_json::Value>,
-    /// File system snapshot (paths and metadata).
-    pub files: HashMap<String, FileMetadata>,
-}
-
-/// Process state information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProcessState {
-    /// Process ID.
-    pub pid: u32,
-    /// Process name.
-    pub name: String,
-    /// Process status.
-    pub status: String,
-    /// Memory usage.
-    pub memory_bytes: u64,
-    /// CPU usage percentage.
-    pub cpu_percent: f32,
-}
-
-/// File metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FileMetadata {
-    /// File path.
-    pub path: String,
-    /// File size.
-    pub size: u64,
-    /// Last modified time.
-    pub modified: DateTime<Utc>,
-    /// File hash (for content tracking).
-    pub hash: Option<String>,
-}
-
-/// A change between snapshots.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Change {
-    /// When the change occurred.
-    pub timestamp: DateTime<Utc>,
-    /// What changed.
-    pub path: String,
-    /// Type of change.
-    #[allow(clippy::struct_field_names)]
-    pub change_type: ChangeType,
-    /// Old value (if applicable).
-    pub old_value: Option<serde_json::Value>,
-    /// New value (if applicable).
-    pub new_value: Option<serde_json::Value>,
-}
-
-/// Type of change.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ChangeType {
-    /// Created.
-    Create,
-    /// Updated.
-    Update,
-    /// Deleted.
-    Delete,
-}
 
 /// The system state store.
 #[derive(Debug)]

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -29,7 +29,11 @@ async fn main() -> Result<()> {
     // Initialize subsystems
     let vortex = Arc::new(Vortex::new()?);
     let gallifrey = Arc::new(Gallifrey::new());
-    let chronos = Arc::new(Chronos::new(Arc::clone(&vortex), Arc::clone(&gallifrey)));
+
+    let vortex_service = vortex.clone() as Arc<dyn tardis_common::traits::VortexService>;
+    let gallifrey_service = gallifrey.clone() as Arc<dyn tardis_common::traits::GallifreyService>;
+
+    let chronos = Arc::new(Chronos::new(vortex_service, gallifrey_service));
 
     // Print banner
     print_banner();


### PR DESCRIPTION
This PR decouples the `Chronos` orchestration engine from concrete implementations of `Vortex` and `Gallifrey`.

Changes:
1.  **High Cohesion**: Moved shared domain types (`Entity`, `Message`, `Snapshot`) to `tardis_common::domain`. This ensures that data structures passed across boundaries are defined in the shared library.
2.  **Low Coupling**: `Chronos` now depends on `VortexService` and `GallifreyService` traits instead of concrete structs. This follows the Dependency Inversion Principle.
3.  **Facade Pattern**: `Gallifrey` struct now implements `GallifreyService`, acting as a facade for its internal stores (`KnowledgeStore`, `ConversationStore`, `SystemStateStore`).

This structural change enables easier unit testing of `Chronos` (by mocking services) and clearer architectural boundaries.

---
*PR created automatically by Jules for task [16760095563989324114](https://jules.google.com/task/16760095563989324114) started by @madmax983*