### PR TITLE
🌟 Nova: Chronos Dreamer

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -1,0 +1,6 @@
+# Nova's Idea Graveyard 🌟
+
+## Chronos Dreamer
+**Concept:** A background process that analyzes idle system conversations and generates "insights" stored as knowledge.
+**Fate:** Merged (Experimental)
+**Lesson:** Turning ephemeral chat logs into permanent knowledge mimics human memory consolidation. It's a "self-improving" loop.

--- a/chronos/Cargo.toml
+++ b/chronos/Cargo.toml
@@ -10,6 +10,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+nova = []
+
 [dependencies]
 # Internal
 tardis-common = { path = "../common" }

--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -1,0 +1,177 @@
+//! The Dreamer: A background process for consolidating memories.
+//!
+//! "We are such stuff as dreams are made on..."
+
+use crate::error::ChronosResult;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tardis_common::domain::{Entity, Message};
+use tardis_common::id::EntityId;
+use tardis_gallifrey::Gallifrey;
+use tracing::{info, instrument};
+
+/// Trait for catching dreams (LLM inference abstraction).
+#[async_trait]
+pub trait DreamCatcher: Send + Sync + std::fmt::Debug {
+    /// Interpret a sequence of messages and generate an insight.
+    async fn catch_dream(&self, messages: &[Message]) -> ChronosResult<String>;
+}
+
+/// The Dreamer engine.
+#[derive(Debug)]
+pub struct Dreamer {
+    gallifrey: Arc<Gallifrey>,
+    catcher: Box<dyn DreamCatcher>,
+}
+
+impl Dreamer {
+    /// Create a new Dreamer.
+    #[must_use]
+    pub fn new(gallifrey: Arc<Gallifrey>, catcher: Box<dyn DreamCatcher>) -> Self {
+        Self { gallifrey, catcher }
+    }
+
+    /// Perform a dream cycle: Analyze recent conversations and store insights.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if fetching messages or storing insights fails.
+    #[instrument(skip(self))]
+    pub async fn dream(&self) -> ChronosResult<Option<EntityId>> {
+        info!("Starting dream cycle...");
+
+        // 1. Get all sessions
+        let sessions = self.gallifrey.conversation().list_sessions().map_err(|e| {
+            crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+        })?;
+
+        if sessions.is_empty() {
+            info!("No sessions to dream about.");
+            return Ok(None);
+        }
+
+        // 2. Pick the most recent session
+        // (In a real system, we might pick a random one or one with high 'perplexity')
+        let mut sorted_sessions = sessions;
+        sorted_sessions.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        let target_session = &sorted_sessions[0];
+
+        info!("Dreaming about session: {}", target_session.id);
+
+        // 3. Fetch recent messages
+        let messages = self
+            .gallifrey
+            .get_recent_messages(target_session.id, 10) // Last 10 messages
+            .await
+            .map_err(crate::error::ChronosError::Common)?;
+
+        if messages.is_empty() {
+            info!("Session has no messages.");
+            return Ok(None);
+        }
+
+        // 4. Generate insight
+        let insight_text = self.catcher.catch_dream(&messages).await?;
+        info!("Dreamt insight: {}", insight_text);
+
+        // 5. Store as knowledge
+        let entity = Entity {
+            id: EntityId::new(),
+            entity_type: "Insight".to_string(),
+            name: format!("Dream: Session {}", target_session.id),
+            properties: {
+                let mut props = HashMap::new();
+                props.insert(
+                    "content".to_string(),
+                    serde_json::Value::String(insight_text),
+                );
+                props.insert(
+                    "source_session".to_string(),
+                    serde_json::Value::String(target_session.id.to_string()),
+                );
+                props
+            },
+            embedding: None, // TODO: Generate embedding for the insight
+            temporal: tardis_common::temporal::BiTemporalInterval::now(),
+            source: Some("Chronos::Dreamer".to_string()),
+        };
+
+        let id = self
+            .gallifrey
+            .insert(entity)
+            .await
+            .map_err(crate::error::ChronosError::Common)?;
+
+        info!("Stored dream insight as entity: {}", id);
+        Ok(Some(id))
+    }
+}
+
+/// A Mock `DreamCatcher` for testing.
+#[derive(Debug, Default)]
+pub struct MockDreamCatcher;
+
+#[async_trait]
+impl DreamCatcher for MockDreamCatcher {
+    async fn catch_dream(&self, messages: &[Message]) -> ChronosResult<String> {
+        Ok(format!(
+            "Insight from {} messages: User seems interested in time travel.",
+            messages.len()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tardis_common::domain::{Message, Role};
+    use tardis_common::id::EntityId;
+
+    #[tokio::test]
+    async fn test_dream_cycle() {
+        // 1. Setup Gallifrey
+        let gallifrey = Arc::new(Gallifrey::new());
+        let conv_store = gallifrey.conversation();
+
+        // 2. Create a session and add messages
+        let session_id = conv_store.create_session().unwrap();
+
+        let msg1 = Message {
+            id: EntityId::new(),
+            session_id,
+            role: Role::User,
+            content: "Tell me about the Doctor.".to_string(),
+            timestamp: chrono::Utc::now(),
+            embedding: None,
+            entity_refs: Vec::new(),
+        };
+        conv_store.add_message(msg1).unwrap();
+
+        let msg2 = Message {
+            id: EntityId::new(),
+            session_id,
+            role: Role::Assistant,
+            content: "The Doctor is a Time Lord from Gallifrey.".to_string(),
+            timestamp: chrono::Utc::now(),
+            embedding: None,
+            entity_refs: Vec::new(),
+        };
+        conv_store.add_message(msg2).unwrap();
+
+        // 3. Create Dreamer
+        let dreamer = Dreamer::new(gallifrey.clone(), Box::new(MockDreamCatcher::default()));
+
+        // 4. Dream!
+        let result = dreamer.dream().await;
+        assert!(result.is_ok());
+        let entity_id = result.unwrap();
+        assert!(entity_id.is_some());
+
+        // 5. Verify storage
+        // Since Gallifrey::query is not fully implemented/exposed for simple get,
+        // we trust the insert worked if no error returned.
+        // Real integration tests would verify the content.
+    }
+}

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -1,0 +1,6 @@
+//! Experimental features for Chronos.
+//!
+//! These features are unstable and hidden behind the `nova` feature flag.
+
+#[cfg(feature = "nova")]
+pub mod dreamer;

--- a/chronos/src/lib.rs
+++ b/chronos/src/lib.rs
@@ -19,3 +19,6 @@ pub mod pipeline;
 // Re-export main types
 pub use error::{ChronosError, ChronosResult};
 pub use pipeline::{Chronos, MemoryCategory, RagConfig, RagResponse};
+
+#[cfg(feature = "nova")]
+pub mod experimental;


### PR DESCRIPTION
🌟 **Nova: Chronos Dreamer**

💡 **The Spark:** Conversations in Tardis OS are ephemeral. I wondered if the system could "dream" about them when idle to form permanent memories, much like humans do.

🚀 **The Feature:**
- **Dreamer Module:** A background process in `chronos/src/experimental/dreamer.rs`.
- **Logic:** It fetches recent conversation sessions from `Gallifrey`, picks one, and uses a `DreamCatcher` (LLM abstraction) to generate an insight.
- **Outcome:** The insight is stored back into `Gallifrey` as a new `Knowledge` entity, linking the ephemeral chat to permanent knowledge.

🔮 **The Potential:**
- Self-improving knowledge base.
- "Serendipity Engine" that finds connections between unrelated chats.
- Foundation for "Offline Processing" of heavy tasks.

⚠️ **Risk:**
- **Low:** Entirely additive and isolated behind `#[cfg(feature = "nova")]`.
- **Performance:** Dream cycles only run when triggered (currently manual in tests, future: idle detection).

**Verification:**
- `cargo test --features nova` passes.
- `cargo clippy --features nova` passes.
- `MockDreamCatcher` validates the flow without requiring a live LLM.

---
*PR created automatically by Jules for task [16341954566109108669](https://jules.google.com/task/16341954566109108669) started by @madmax983*