### PR TITLE
🔒 Warden: Hardened telemetry RingBuffer and types

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -9,3 +9,11 @@
 2024-05-24 - [Test Stability]
 **Threat:** SIGSEGV in tests due to privileged I/O instructions execution in userspace.
 **Defense:** Gated unsafe hardware I/O blocks with `#[cfg(not(test))]`.
+
+2025-02-23 - [RingBuffer Hardening]
+**Threat:** Race condition in `RingBuffer::try_read` allowing torn reads, and potential buffer overread via corrupted `payload_len`.
+**Defense:** Added Seqlock verification after read and capped `payload_len` to `MAX_PAYLOAD_SIZE`.
+
+2025-02-23 - [Telemetry Allocation Removal]
+**Threat:** Panic or deadlock in interrupt/no_std context due to allocation in `Subsystem::from_target`.
+**Defense:** Replaced allocating case conversion with zero-allocation case-insensitive search.

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -260,7 +260,8 @@ impl RingBuffer {
                 core::ptr::read_volatile(entry_ptr)
             };
 
-            let payload_len = entry.payload_len as usize;
+            // Cap payload length to prevent buffer overread/overflow if header is corrupted
+            let payload_len = (entry.payload_len as usize).min(MAX_PAYLOAD_SIZE);
             let mut payload = alloc::vec![0u8; payload_len];
 
             unsafe {
@@ -269,6 +270,16 @@ impl RingBuffer {
                     payload.as_mut_ptr(),
                     payload_len,
                 );
+            }
+
+            // Verify sequence hasn't changed (Seqlock check)
+            // If it has, the writer overwrote the slot while we were reading
+            let post_seq = slot.sequence.load(Ordering::Acquire);
+            if post_seq != expected_seq {
+                // Corruption detected, retry
+                // Note: We already incremented read_pos, so we effectively dropped this message.
+                // But returning corrupted data is worse.
+                continue;
             }
 
             return Some((entry, payload));
@@ -394,6 +405,44 @@ mod tests {
             // Or just the next valid read_pos (1).
             // Let's just assert we got something and it didn't hang.
             assert!(read_entry.timestamp_ns > 0);
+        } else {
+            panic!("Should have returned an entry");
+        }
+    }
+
+    #[test]
+    fn ring_buffer_corrupted_header_safety() {
+        // Use static to avoid stack overflow
+        static BUFFER: RingBuffer = RingBuffer::new();
+
+        // Write a valid entry
+        let entry = TelemetryEntry {
+            timestamp_ns: 1,
+            level: Level::Info,
+            subsystem: Subsystem::Kernel,
+            event_type: EventType::Log,
+            span_id: SpanId::NONE,
+            trace_id: TraceId::NONE,
+            parent_span_id: SpanId::NONE,
+            payload_len: 10,
+        };
+        BUFFER.try_write(&entry, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        // Manually corrupt the entry in the slot to have a huge payload_len
+        // This simulates a bit flip or race condition corruption
+        // SAFETY: We are in a test and accessing the slot directly
+        unsafe {
+            // Accessing private field 'slots' - allowed in child module
+            let slot = &BUFFER.slots[0];
+            // Accessing private field 'entry' - allowed in child module
+            (*slot.entry.get()).payload_len = 65535;
+        }
+
+        // Try to read. It should NOT panic or crash.
+        // It should return a payload capped at MAX_PAYLOAD_SIZE.
+        if let Some((read_entry, payload)) = BUFFER.try_read() {
+            assert_eq!(read_entry.payload_len, 65535); // The entry itself has the corrupted value
+            assert_eq!(payload.len(), MAX_PAYLOAD_SIZE); // The payload vector is capped
         } else {
             panic!("Should have returned an entry");
         }

--- a/telemetry/src/types.rs
+++ b/telemetry/src/types.rs
@@ -3,7 +3,6 @@
 //! All types in this module are `no_std` compatible and can be used
 //! in both kernel and userspace contexts.
 
-use alloc::borrow::Cow;
 use alloc::string::String;
 use core::fmt;
 use serde::{Deserialize, Serialize};
@@ -220,6 +219,24 @@ pub enum Subsystem {
     Unknown = 255,
 }
 
+/// Helper for case-insensitive substring check without allocation.
+fn contains_ignore_case(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let needle_len = needle.len();
+    if haystack.len() < needle_len {
+        return false;
+    }
+
+    haystack.as_bytes().windows(needle_len).any(|window| {
+        window
+            .iter()
+            .zip(needle.as_bytes())
+            .all(|(h, n)| h.eq_ignore_ascii_case(n))
+    })
+}
+
 impl Subsystem {
     /// Returns the subsystem as a static string.
     #[must_use]
@@ -261,17 +278,10 @@ impl Subsystem {
             ("telemetry", Subsystem::Telemetry),
         ];
 
-        // Bolt: Performance optimization to avoid allocation for common lowercase targets.
-        // Most tracing targets are module paths which are lowercase.
-        let target_cow = if target.chars().any(char::is_uppercase) {
-            Cow::Owned(target.to_lowercase())
-        } else {
-            Cow::Borrowed(target)
-        };
-        let target_lower = &*target_cow;
-
+        // Warden: Zero-allocation case-insensitive search.
+        // Critical for safety in restricted contexts (interrupts, no_std).
         for (key, subsystem) in MAPPINGS {
-            if target_lower.contains(key) {
+            if contains_ignore_case(target, key) {
                 return *subsystem;
             }
         }


### PR DESCRIPTION
**Threat:** Race condition in `RingBuffer::try_read` allowed reading torn writes (mixed old/new data) if the writer lapped the reader. Also, a corrupted entry header could cause a buffer overread during payload copy.
**Defense:** Implemented Seqlock verification (re-checking sequence number after read) and strictly clamped `payload_len` to `MAX_PAYLOAD_SIZE`.

**Threat:** Allocation in `Subsystem::from_target` could cause panics or deadlocks in interrupt/no_std contexts (kernel/telemetry critical paths).
**Defense:** Replaced allocating `to_lowercase()` with a zero-allocation case-insensitive search helper.

**Verification:** Added `ring_buffer_corrupted_header_safety` test and verified existing `subsystem_from_target` tests pass without allocation.

---
*PR created automatically by Jules for task [18405563772836834204](https://jules.google.com/task/18405563772836834204) started by @madmax983*