### PR TITLE
🌟 Nova: Psychic Paper - Universal Data Interpreter

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -4,3 +4,8 @@
 **Concept:** A background process that analyzes idle system conversations and generates "insights" stored as knowledge.
 **Fate:** Merged (Experimental)
 **Lesson:** Turning ephemeral chat logs into permanent knowledge mimics human memory consolidation. It's a "self-improving" loop.
+
+## Psychic Paper
+**Concept:** A universal data interpreter that attempts to parse unstructured text into structured data based on intents or heuristics.
+**Fate:** Merged (Experimental)
+**Lesson:** Structured data is often hidden in unstructured text; a "best-effort" parser enables lazy UI interactions where the user doesn't need to specify formats.

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -4,3 +4,6 @@
 
 #[cfg(feature = "nova")]
 pub mod dreamer;
+
+#[cfg(feature = "nova")]
+pub mod psychic_paper;

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -1,0 +1,127 @@
+//! Psychic Paper: The Universal Data Interpreter.
+//!
+//! "It shows you exactly what you want to see."
+
+use crate::error::ChronosResult;
+use serde_json::{json, Value};
+
+/// A universal interpreter for unstructured data.
+#[derive(Debug, Default)]
+pub struct PsychicPaper;
+
+impl PsychicPaper {
+    /// Create a new instance of Psychic Paper.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Attempt to interpret the input string based on an optional intent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if interpretation fails completely.
+    pub fn read(&self, input: &str, intent: Option<&str>) -> ChronosResult<Value> {
+        let intent = intent.unwrap_or("auto");
+
+        match intent {
+            "json" => serde_json::from_str(input).map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            }),
+            "list" => {
+                let items: Vec<&str> = input
+                    .lines()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                Ok(json!(items))
+            }
+            "kv" => Ok(Self::parse_kv(input)),
+            "auto" => Ok(Self::auto_detect(input)),
+            _ => Ok(json!({
+                "type": "text",
+                "content": input
+            })),
+        }
+    }
+
+    fn parse_kv(input: &str) -> Value {
+        let mut map = serde_json::Map::new();
+        for line in input.lines() {
+            if let Some((k, v)) = line.split_once('=') {
+                map.insert(k.trim().to_string(), Value::String(v.trim().to_string()));
+            }
+        }
+        Value::Object(map)
+    }
+
+    fn auto_detect(input: &str) -> Value {
+        // 1. Try JSON
+        if let Ok(val) = serde_json::from_str::<Value>(input) {
+            return val;
+        }
+
+        // 2. Fallback
+        json!({
+            "type": "text",
+            "content": input
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_json_explicit() {
+        let paper = PsychicPaper::new();
+        let input = r#"{"name": "Rose", "species": "Human"}"#;
+        let result = paper.read(input, Some("json")).unwrap();
+
+        assert_eq!(result["name"], "Rose");
+        assert_eq!(result["species"], "Human");
+    }
+
+    #[test]
+    fn test_read_json_implicit() {
+        let paper = PsychicPaper::new();
+        let input = r#"{"name": "Rose", "species": "Human"}"#;
+        let result = paper.read(input, None).unwrap();
+
+        assert_eq!(result["name"], "Rose");
+    }
+
+    #[test]
+    fn test_read_list() {
+        let paper = PsychicPaper::new();
+        let input = "Apples\nBananas\nPears";
+        let result = paper.read(input, Some("list")).unwrap();
+
+        assert!(result.is_array());
+        assert_eq!(result[0], "Apples");
+        assert_eq!(result[1], "Bananas");
+        assert_eq!(result[2], "Pears");
+    }
+
+    #[test]
+    fn test_read_kv() {
+        let paper = PsychicPaper::new();
+        let input = "name=Doctor\nage=900";
+        let result = paper.read(input, Some("kv")).unwrap();
+
+        assert_eq!(result["name"], "Doctor");
+        assert_eq!(result["age"], "900");
+    }
+
+    #[test]
+    fn test_read_unknown_text() {
+        let paper = PsychicPaper::new();
+        let input = "Just some text.";
+        // Should default to a wrapped string or text object
+        let result = paper.read(input, None).unwrap();
+
+        assert_eq!(result["content"], "Just some text.");
+        assert_eq!(result["type"], "text");
+    }
+}


### PR DESCRIPTION
🌟 **Nova: Psychic Paper**

💡 **The Spark:** "I noticed we often get raw strings from users or logs but need structured data for RAG. Why not make a 'Psychic Paper' that sees what we want it to see?"

🚀 **The Feature:**
- Implemented `PsychicPaper` struct in `chronos`.
- Supports explicit intents: "json", "list", "kv".
- Supports "auto" mode to guess the format (JSON or fallback to text).
- Returns `serde_json::Value`.

🔮 **The Potential:**
- Can be used in the Shell for "lazy" command input.
- Can be used in RAG pipeline to structure retrieved text chunks.

⚠️ **Risk:** Low. Isolated in `src/experimental/` and behind `#[cfg(feature = "nova")]`.


---
*PR created automatically by Jules for task [3436656675364230656](https://jules.google.com/task/3436656675364230656) started by @madmax983*