### PR TITLE
🗺️ Atlas: Decouple Chronos from Concrete Services

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -12,3 +12,12 @@
 2.  Updated `GallifreyService` trait in `common` to include methods for conversation and system state.
 3.  Refactored `Chronos` to use `Arc<dyn VortexService>` and `Arc<dyn GallifreyService>`.
 **Stability:** `Chronos` is now decoupled from specific implementations, allowing for easier mocking and substitution.
+
+**[Architect] Enforce Chronos Decoupling via Traits**
+**Tangle:** `Chronos` was still coupled to concrete `Vortex` and `Gallifrey` structs despite previous plans. `Vortex` defined its own `ModelHandle`, causing type mismatches.
+**Blueprint:**
+1. Moved `ModelLoadConfig` and `InferenceParams` to `common::llm`.
+2. Defined `VortexService` and `GallifreyService` in `common::traits`.
+3. Refactored `vortex` to use `common::id::ModelHandle`.
+4. Updated `Chronos` to use `Arc<dyn Service>`.
+**Stability:** `Chronos` is now truly decoupled. `ModelHandle` is unified.

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -41,9 +41,8 @@ pub use retriever::Retriever;
 use crate::error::{ChronosError, ChronosResult};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tardis_common::traits::{GallifreyService, VortexService};
 use tardis_common::{EntityId, SessionId};
-use tardis_gallifrey::Gallifrey;
-use tardis_vortex::Vortex;
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -114,8 +113,8 @@ pub struct RagResponse {
 #[derive(Debug)]
 pub struct Chronos {
     #[allow(dead_code)]
-    vortex: Arc<Vortex>,
-    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<dyn VortexService>,
+    gallifrey: Arc<dyn GallifreyService>,
     analyzer: QueryAnalyzer,
     retriever: Retriever,
     augmenter: ContextAugmenter,
@@ -124,7 +123,7 @@ pub struct Chronos {
 impl Chronos {
     /// Create a new Chronos instance.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(vortex: Arc<dyn VortexService>, gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self {
             vortex,
             gallifrey: Arc::clone(&gallifrey),

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -4,19 +4,19 @@ use super::{ContextSource, ContextSourceType, RagConfig};
 use crate::error::{ChronosError, ChronosResult};
 use crate::pipeline::analyzer::AnalyzedQuery;
 use std::sync::Arc;
-use tardis_gallifrey::Gallifrey;
+use tardis_common::traits::GallifreyService;
 use tracing::info;
 
 /// Multi-source retriever.
 #[derive(Debug)]
 pub struct Retriever {
-    gallifrey: Arc<Gallifrey>,
+    gallifrey: Arc<dyn GallifreyService>,
 }
 
 impl Retriever {
     /// Create a new retriever.
     #[must_use]
-    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self { gallifrey }
     }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod domain;
 pub mod error;
 pub mod id;
+pub mod llm;
 pub mod temporal;
 pub mod traits;
 

--- a/common/src/llm.rs
+++ b/common/src/llm.rs
@@ -1,4 +1,7 @@
-//! Configuration types for Vortex.
+//! LLM Configuration types shared across Tardis OS.
+//!
+//! Provides configuration structs for model loading and inference,
+//! used by both Vortex (inference engine) and Chronos (RAG orchestrator).
 
 use serde::{Deserialize, Serialize};
 

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -3,7 +3,12 @@
 //! These traits define the contracts between subsystems, designed to support
 //! both direct function calls (monolithic) and potential future IPC (microkernel).
 
-use crate::domain::Entity;
+use crate::domain::{Change, Entity, Message, Snapshot};
+use crate::id::{EntityId, ModelHandle, SessionId};
+use crate::llm::{InferenceParams, ModelLoadConfig};
+use crate::temporal::TemporalQuery;
+use crate::Result;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 /// Query results from Gallifrey.
@@ -15,4 +20,45 @@ pub struct QueryResult {
     pub execution_time_ms: u64,
     /// Whether results were truncated
     pub truncated: bool,
+}
+
+/// Interface for LLM inference service (Vortex).
+#[async_trait]
+pub trait VortexService: Send + Sync + std::fmt::Debug {
+    /// Load a model.
+    async fn load_model(&self, path: &str, config: ModelLoadConfig) -> Result<ModelHandle>;
+
+    /// Unload a model.
+    async fn unload_model(&self, handle: ModelHandle) -> Result<()>;
+
+    /// Run inference.
+    async fn infer(&self, handle: ModelHandle, prompt: &str, params: InferenceParams) -> Result<String>;
+
+    /// Generate embeddings.
+    async fn embed(&self, handle: ModelHandle, text: &str) -> Result<Vec<f32>>;
+}
+
+/// Interface for Temporal Knowledge Graph service (Gallifrey).
+#[async_trait]
+pub trait GallifreyService: Send + Sync + std::fmt::Debug {
+    /// Insert an entity into the knowledge graph.
+    async fn insert(&self, entity: Entity) -> Result<EntityId>;
+
+    /// Semantic search in knowledge graph.
+    async fn search_knowledge(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>>;
+
+    /// Execute a temporal query.
+    async fn query(&self, query: &str, temporal: TemporalQuery) -> Result<QueryResult>;
+
+    /// Get recent messages from a session.
+    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>>;
+
+    /// Semantic search in conversation history.
+    async fn search_conversation(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>>;
+
+    /// Find a system snapshot at a specific time.
+    async fn find_snapshot(&self, timestamp: chrono::DateTime<chrono::Utc>) -> Result<Option<Snapshot>>;
+
+    /// Record a system change.
+    async fn record_change(&self, change: Change) -> Result<()>;
 }

--- a/gallifrey/src/error.rs
+++ b/gallifrey/src/error.rs
@@ -52,3 +52,18 @@ pub enum GallifreyError {
 
 /// Result type for Gallifrey operations.
 pub type GallifreyResult<T> = Result<T, GallifreyError>;
+
+impl From<GallifreyError> for tardis_common::Error {
+    fn from(err: GallifreyError) -> Self {
+        match err {
+            GallifreyError::QueryParseError(msg) => Self::QueryParseError(msg),
+            GallifreyError::QueryExecutionFailed(msg) => Self::QueryExecutionFailed(msg),
+            GallifreyError::EntityNotFound(msg) => Self::EntityNotFound(msg),
+            GallifreyError::InvalidTemporalReference(msg) => Self::InvalidTemporalReference(msg),
+            GallifreyError::TimeTravelFailed(msg) => Self::TimeTravelFailed { reason: msg },
+            GallifreyError::Serialization(e) => Self::Serialization(e),
+            GallifreyError::Io(e) => Self::Io(e),
+            _ => Self::Internal(err.to_string()),
+        }
+    }
+}

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -25,11 +25,12 @@ pub use error::{GallifreyError, GallifreyResult};
 pub use stores::{ConversationStore, KnowledgeStore, SystemStateStore};
 pub use temporal::{BiTemporalInterval, TimeRange};
 
+use async_trait::async_trait;
 use std::sync::Arc;
 use tardis_common::domain::{Change, Entity, Message, Snapshot};
 use tardis_common::id::{EntityId, SessionId};
 use tardis_common::temporal::TemporalQuery;
-use tardis_common::traits::QueryResult;
+use tardis_common::traits::{GallifreyService, QueryResult};
 
 /// The main Gallifrey database instance.
 #[derive(Debug)]
@@ -228,6 +229,56 @@ impl Gallifrey {
         self.system_state
             .record_change(change)
             .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+}
+
+#[async_trait]
+impl GallifreyService for Gallifrey {
+    async fn insert(&self, entity: Entity) -> tardis_common::Result<EntityId> {
+        self.insert(entity).await
+    }
+
+    async fn search_knowledge(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Entity>> {
+        self.search_knowledge(embedding, limit).await
+    }
+
+    async fn query(
+        &self,
+        query: &str,
+        temporal: TemporalQuery,
+    ) -> tardis_common::Result<QueryResult> {
+        self.query(query, temporal).await
+    }
+
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Message>> {
+        self.get_recent_messages(session_id, limit).await
+    }
+
+    async fn search_conversation(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Message>> {
+        self.search_conversation(embedding, limit).await
+    }
+
+    async fn find_snapshot(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Option<Snapshot>> {
+        self.find_snapshot(timestamp).await
+    }
+
+    async fn record_change(&self, change: Change) -> tardis_common::Result<()> {
+        self.record_change(change).await
     }
 }
 

--- a/vortex/src/error.rs
+++ b/vortex/src/error.rs
@@ -66,3 +66,21 @@ pub enum VortexError {
 
 /// Result type for Vortex operations.
 pub type VortexResult<T> = Result<T, VortexError>;
+
+impl From<VortexError> for tardis_common::Error {
+    fn from(err: VortexError) -> Self {
+        match err {
+            VortexError::ModelNotFound { path } => Self::ModelNotFound { path },
+            VortexError::LoadFailed(msg) => Self::ModelLoadFailed {
+                name: "unknown".to_string(),
+                reason: msg,
+            },
+            VortexError::InvalidHandle(id) => Self::InvalidModelHandle(id),
+            VortexError::InferenceFailed(reason) => Self::InferenceFailed { reason },
+            VortexError::TokenizationError(reason) => Self::TokenizationFailed(reason),
+            VortexError::Io(e) => Self::Io(e),
+            VortexError::Json(e) => Self::Serialization(e),
+            _ => Self::Internal(err.to_string()),
+        }
+    }
+}

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -1,6 +1,5 @@
 //! Main Vortex inference runtime.
 
-use crate::config::{InferenceParams, ModelLoadConfig};
 use crate::error::{VortexError, VortexResult};
 use crate::loader::{
     download_preset, find_model_file, load_model_weights, parse_model_config, DeviceSpec,
@@ -10,7 +9,10 @@ use crate::model::{ModelHandle, ModelInfo, ModelRegistry};
 use crate::tokenizer::TokenizerService;
 use std::collections::HashMap;
 use std::path::Path;
+use async_trait::async_trait;
 use std::sync::{Arc, RwLock};
+use tardis_common::llm::{InferenceParams, ModelLoadConfig};
+use tardis_common::traits::VortexService;
 use tokio::task;
 use tracing::{info, instrument};
 
@@ -341,6 +343,34 @@ impl Vortex {
             .read()
             .map(|models| models.contains_key(&handle))
             .unwrap_or(false)
+    }
+}
+
+#[async_trait]
+impl VortexService for Vortex {
+    async fn load_model(
+        &self,
+        path: &str,
+        config: ModelLoadConfig,
+    ) -> tardis_common::Result<ModelHandle> {
+        self.load_model(path, config).await.map_err(Into::into)
+    }
+
+    async fn unload_model(&self, handle: ModelHandle) -> tardis_common::Result<()> {
+        self.unload_model(handle).await.map_err(Into::into)
+    }
+
+    async fn infer(
+        &self,
+        handle: ModelHandle,
+        prompt: &str,
+        params: InferenceParams,
+    ) -> tardis_common::Result<String> {
+        self.infer(handle, prompt, params).await.map_err(Into::into)
+    }
+
+    async fn embed(&self, handle: ModelHandle, text: &str) -> tardis_common::Result<Vec<f32>> {
+        self.embed(handle, text).await.map_err(Into::into)
     }
 }
 

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -38,7 +38,6 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
-pub mod config;
 pub mod error;
 pub mod inference;
 pub mod loader;
@@ -46,8 +45,8 @@ pub mod model;
 pub mod tokenizer;
 
 // Re-export main types
-pub use config::{InferenceParams, ModelLoadConfig};
 pub use error::{VortexError, VortexResult};
+pub use tardis_common::llm::{InferenceParams, ModelLoadConfig};
 pub use inference::Vortex;
 pub use loader::ModelPreset;
 pub use model::{ModelHandle, ModelInfo, ModelRegistry};

--- a/vortex/src/model/mod.rs
+++ b/vortex/src/model/mod.rs
@@ -7,7 +7,8 @@
 
 mod registry;
 
-pub use registry::{ModelHandle, ModelInfo, ModelRegistry};
+pub use registry::{ModelInfo, ModelRegistry};
+pub use tardis_common::id::ModelHandle;
 
 use serde::{Deserialize, Serialize};
 

--- a/vortex/src/model/registry.rs
+++ b/vortex/src/model/registry.rs
@@ -7,30 +7,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
-
-/// A handle to a loaded model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ModelHandle(u64);
-
-impl ModelHandle {
-    /// Create a new model handle from a raw value.
-    #[must_use]
-    pub const fn new(value: u64) -> Self {
-        Self(value)
-    }
-
-    /// Get the raw handle value.
-    #[must_use]
-    pub const fn raw(&self) -> u64 {
-        self.0
-    }
-}
-
-impl std::fmt::Display for ModelHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "model:{}", self.0)
-    }
-}
+use tardis_common::id::ModelHandle;
 
 /// Information about a model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -120,7 +97,7 @@ impl ModelRegistry {
     ///
     /// Returns an error if the registry lock is poisoned.
     pub fn mark_loaded(&self, path: &PathBuf, memory_bytes: u64) -> VortexResult<ModelHandle> {
-        let handle = ModelHandle(self.next_handle.fetch_add(1, Ordering::SeqCst));
+        let handle = ModelHandle::new(self.next_handle.fetch_add(1, Ordering::SeqCst));
 
         // Update model info
         {


### PR DESCRIPTION
This PR decouples the `Chronos` RAG orchestrator from concrete implementations of `Vortex` (LLM) and `Gallifrey` (Knowledge Store).

Changes:
1.  **Common Configs**: Moved LLM configuration structs to `tardis_common::llm` to be shared.
2.  **Service Traits**: Defined `VortexService` and `GallifreyService` in `tardis_common` to abstract dependencies.
3.  **Unified Types**: Refactored `vortex` to use `tardis_common::id::ModelHandle` instead of a local definition.
4.  **Chronos Refactor**: Updated `Chronos` to hold `Arc<dyn VortexService>` and `Arc<dyn GallifreyService>`.

This ensures a cleaner architecture where `Chronos` depends on abstractions, not details (Dependency Inversion Principle). It also fixes a type mismatch issue with `ModelHandle`.

---
*PR created automatically by Jules for task [479235303949370909](https://jules.google.com/task/479235303949370909) started by @madmax983*