### PR TITLE
Refactor analyzer to remove hidden time dependencies

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -50,7 +50,7 @@ const-literal-digits-threshold = 4
 # ============================================================================
 
 # Known MSRV - enables/disables lints based on minimum Rust version
-msrv = "1.83"
+msrv = "1.85"
 
 # Paths to consider as standard library (for path lints)
 # Adding our common crate so `common::Error` is treated like std types

--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -5,3 +5,7 @@
 **[Refactoring Logic Chains]
 **Learning:** Long `if-else if` chains for string matching are error-prone and hard to read.
 **Action:** Replace with data-driven mapping arrays (e.g., `&[(&str, Enum)]`) where possible.
+
+**[Hidden Time Dependencies]
+**Learning:** Using `Utc::now()` deep inside business logic makes functions impure and untestable without mocking.
+**Action:** Inject `now: DateTime<Utc>` as an argument to pure functions, passing the current time from the top level (e.g., controller or public API).

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -5,7 +5,7 @@
 //! This module provides robust parsing for unstructured text, designed to handle
 //! the messy output of LLMs or user input.
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 /// The intent of the interpretation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,10 +49,10 @@ impl PsychicPaper {
         // Simple heuristics
         let trimmed = text.trim();
         if trimmed.starts_with('{') || trimmed.starts_with('[') {
-             // If it looks like JSON, try JSON first
-             if let Ok(v) = self.interpret_json(text) {
-                 return Ok(v);
-             }
+            // If it looks like JSON, try JSON first
+            if let Ok(v) = self.interpret_json(text) {
+                return Ok(v);
+            }
         }
 
         // Check for Markdown code block with json
@@ -67,15 +67,15 @@ impl PsychicPaper {
         }
 
         if trimmed.contains(':') {
-             // Check if it looks like KV lines
-             // Heuristic: majority of lines have ':'
-             let lines: Vec<&str> = trimmed.lines().filter(|l| !l.trim().is_empty()).collect();
-             if !lines.is_empty() {
-                 let colon_count = lines.iter().filter(|l| l.contains(':')).count();
-                 if colon_count >= lines.len() / 2 {
-                     return self.interpret_kv(text);
-                 }
-             }
+            // Check if it looks like KV lines
+            // Heuristic: majority of lines have ':'
+            let lines: Vec<&str> = trimmed.lines().filter(|l| !l.trim().is_empty()).collect();
+            if !lines.is_empty() {
+                let colon_count = lines.iter().filter(|l| l.contains(':')).count();
+                if colon_count >= lines.len() / 2 {
+                    return self.interpret_kv(text);
+                }
+            }
         }
 
         // Fallback: just a string
@@ -129,12 +129,16 @@ impl PsychicPaper {
             .filter(|line| !line.is_empty())
             .map(|line| {
                 // Strip bullets
-                if let Some(stripped) = line.strip_prefix("- ") { return stripped.to_string(); }
-                if let Some(stripped) = line.strip_prefix("* ") { return stripped.to_string(); }
+                if let Some(stripped) = line.strip_prefix("- ") {
+                    return stripped.to_string();
+                }
+                if let Some(stripped) = line.strip_prefix("* ") {
+                    return stripped.to_string();
+                }
                 // Strip numbers "1. "
                 if let Some(idx) = line.find(". ") {
                     if idx > 0 && line[..idx].chars().all(|c| c.is_numeric()) {
-                         return line[idx+2..].to_string();
+                        return line[idx + 2..].to_string();
                     }
                 }
                 line.to_string()
@@ -142,14 +146,15 @@ impl PsychicPaper {
             .collect();
 
         if items.is_empty() {
-             // Try comma separation if single line
-             if !text.contains('\n') && text.contains(',') {
-                 let items: Vec<String> = text.split(',')
+            // Try comma separation if single line
+            if !text.contains('\n') && text.contains(',') {
+                let items: Vec<String> = text
+                    .split(',')
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
                     .collect();
-                 return Ok(json!(items));
-             }
+                return Ok(json!(items));
+            }
         }
 
         Ok(json!(items))
@@ -160,7 +165,9 @@ impl PsychicPaper {
 
         for line in text.lines() {
             let line = line.trim();
-            if line.is_empty() { continue; }
+            if line.is_empty() {
+                continue;
+            }
 
             if let Some((key, value)) = line.split_once(':') {
                 let key = key.trim().to_string();
@@ -214,7 +221,10 @@ Hope that helps."#;
         let text = "- Sonic Screwdriver\n- TARDIS Key\n- Psychic Paper";
         let paper = PsychicPaper::new();
         let result = paper.interpret(text, Intent::List).unwrap();
-        assert_eq!(result, json!(["Sonic Screwdriver", "TARDIS Key", "Psychic Paper"]));
+        assert_eq!(
+            result,
+            json!(["Sonic Screwdriver", "TARDIS Key", "Psychic Paper"])
+        );
     }
 
     #[test]
@@ -230,11 +240,14 @@ Hope that helps."#;
         let text = "Species: Time Lord\nOrigin: Gallifrey\nRegenerations: 12";
         let paper = PsychicPaper::new();
         let result = paper.interpret(text, Intent::KeyValue).unwrap();
-        assert_eq!(result, json!({
-            "Species": "Time Lord",
-            "Origin": "Gallifrey",
-            "Regenerations": 12
-        }));
+        assert_eq!(
+            result,
+            json!({
+                "Species": "Time Lord",
+                "Origin": "Gallifrey",
+                "Regenerations": 12
+            })
+        );
     }
 
     #[test]

--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -69,6 +69,16 @@ struct TemporalRule {
     ref_type: TemporalRefType,
 }
 
+impl TemporalRule {
+    fn resolve(&self, now: DateTime<Utc>) -> DateTime<Utc> {
+        match self.offset {
+            TimeOffset::Days(d) => now - Duration::days(d),
+            TimeOffset::Weeks(w) => now - Duration::weeks(w),
+            TimeOffset::None => now,
+        }
+    }
+}
+
 const TEMPORAL_RULES: &[TemporalRule] = &[
     TemporalRule {
         keyword: "yesterday",
@@ -91,6 +101,14 @@ struct IntentRule {
     required: &'static [&'static str],
     any: &'static [&'static str],
     intent: QueryIntent,
+}
+
+impl IntentRule {
+    fn matches(&self, query_lower: &str) -> bool {
+        let has_required = self.required.iter().all(|k| query_lower.contains(k));
+        let has_any = self.any.is_empty() || self.any.iter().any(|k| query_lower.contains(k));
+        has_required && has_any
+    }
 }
 
 const INTENT_RULES: &[IntentRule] = &[
@@ -136,7 +154,7 @@ impl QueryAnalyzer {
     /// Returns an error if analysis fails.
     pub fn analyze(&self, query: &str) -> ChronosResult<AnalyzedQuery> {
         let intent = self.classify_intent(query);
-        let temporal_refs = self.extract_temporal_refs(query);
+        let temporal_refs = self.extract_temporal_refs(query, Utc::now());
         let entities = self.extract_entities(query);
 
         let temporal_description = if temporal_refs.is_empty() {
@@ -160,10 +178,7 @@ impl QueryAnalyzer {
         let lower = query.to_lowercase();
 
         for rule in INTENT_RULES {
-            let has_required = rule.required.iter().all(|k| lower.contains(k));
-            let has_any = rule.any.is_empty() || rule.any.iter().any(|k| lower.contains(k));
-
-            if has_required && has_any {
+            if rule.matches(&lower) {
                 return rule.intent.clone();
             }
         }
@@ -177,18 +192,13 @@ impl QueryAnalyzer {
 
     /// Extract temporal references from a query.
     #[allow(clippy::unused_self)]
-    fn extract_temporal_refs(&self, query: &str) -> Vec<TemporalRef> {
+    fn extract_temporal_refs(&self, query: &str, now: DateTime<Utc>) -> Vec<TemporalRef> {
         let mut refs = Vec::new();
         let lower = query.to_lowercase();
-        let now = Utc::now();
 
         for rule in TEMPORAL_RULES {
             if lower.contains(rule.keyword) {
-                let resolved = match rule.offset {
-                    TimeOffset::Days(d) => now - Duration::days(d),
-                    TimeOffset::Weeks(w) => now - Duration::weeks(w),
-                    TimeOffset::None => now,
-                };
+                let resolved = rule.resolve(now);
 
                 refs.push(TemporalRef {
                     text: rule.keyword.to_string(),
@@ -286,28 +296,50 @@ mod tests {
     #[test]
     fn test_extract_temporal_refs() {
         let analyzer = QueryAnalyzer::new();
+        let now = Utc::now();
 
-        let refs = analyzer.extract_temporal_refs("What happened yesterday?");
+        let refs = analyzer.extract_temporal_refs("What happened yesterday?", now);
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].text, "yesterday");
         assert_eq!(refs[0].ref_type, TemporalRefType::Relative);
 
-        let refs = analyzer.extract_temporal_refs("Check last week logs");
+        let refs = analyzer.extract_temporal_refs("Check last week logs", now);
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].text, "last week");
 
-        let refs = analyzer.extract_temporal_refs("Do it today");
+        let refs = analyzer.extract_temporal_refs("Do it today", now);
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].text, "today");
 
-        let refs = analyzer.extract_temporal_refs("Yesterday and today");
+        let refs = analyzer.extract_temporal_refs("Yesterday and today", now);
         assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_temporal_refs_resolved() {
+        let analyzer = QueryAnalyzer::new();
+        // Use a fixed date for deterministic testing
+        // 2024-03-15 12:00:00 UTC
+        let now = DateTime::parse_from_rfc3339("2024-03-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        // "yesterday" should be 2024-03-14 12:00:00 UTC
+        let refs = analyzer.extract_temporal_refs("yesterday", now);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].resolved.to_rfc3339(), "2024-03-14T12:00:00+00:00");
+
+        // "last week" should be 2024-03-08 12:00:00 UTC
+        let refs = analyzer.extract_temporal_refs("last week", now);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].resolved.to_rfc3339(), "2024-03-08T12:00:00+00:00");
     }
 
     #[test]
     fn test_describe_temporal_context() {
         let analyzer = QueryAnalyzer::new();
-        let refs = analyzer.extract_temporal_refs("yesterday");
+        let now = Utc::now();
+        let refs = analyzer.extract_temporal_refs("yesterday", now);
         let desc = analyzer.describe_temporal_context(&refs);
         assert!(desc.contains("yesterday"));
     }

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -179,6 +179,7 @@ impl Retriever {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::pipeline::analyzer::{AnalyzedQuery, QueryIntent};

--- a/common/src/domain.rs
+++ b/common/src/domain.rs
@@ -63,7 +63,7 @@ pub struct Entity {
     ///
     /// See [`BiTemporalInterval`] for details on how history is tracked.
     pub temporal: BiTemporalInterval,
-    /// Source of this knowledge (e.g., "user", "file_import", "inference").
+    /// Source of this knowledge (e.g., "user", "`file_import`", "inference").
     pub source: Option<String>,
 }
 

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -32,7 +32,12 @@ pub trait VortexService: Send + Sync + std::fmt::Debug {
     async fn unload_model(&self, handle: ModelHandle) -> Result<()>;
 
     /// Run inference.
-    async fn infer(&self, handle: ModelHandle, prompt: &str, params: InferenceParams) -> Result<String>;
+    async fn infer(
+        &self,
+        handle: ModelHandle,
+        prompt: &str,
+        params: InferenceParams,
+    ) -> Result<String>;
 
     /// Generate embeddings.
     async fn embed(&self, handle: ModelHandle, text: &str) -> Result<Vec<f32>>;
@@ -51,13 +56,20 @@ pub trait GallifreyService: Send + Sync + std::fmt::Debug {
     async fn query(&self, query: &str, temporal: TemporalQuery) -> Result<QueryResult>;
 
     /// Get recent messages from a session.
-    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>>;
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> Result<Vec<Message>>;
 
     /// Semantic search in conversation history.
     async fn search_conversation(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>>;
 
     /// Find a system snapshot at a specific time.
-    async fn find_snapshot(&self, timestamp: chrono::DateTime<chrono::Utc>) -> Result<Option<Snapshot>>;
+    async fn find_snapshot(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<Snapshot>>;
 
     /// Record a system change.
     async fn record_change(&self, change: Change) -> Result<()>;

--- a/gallifrey/src/experimental/heatmap.rs
+++ b/gallifrey/src/experimental/heatmap.rs
@@ -151,8 +151,18 @@ impl TemporalHeatmap {
         let max_val = self.grid.iter().flatten().max().copied().unwrap_or(0);
 
         writeln!(&mut output, "Temporal Heatmap (Y: Transaction, X: Valid)").ok();
-        writeln!(&mut output, "Y-Range: {} to {}", self.transaction_range.0, self.transaction_range.1).ok();
-        writeln!(&mut output, "X-Range: {} to {}", self.valid_range.0, self.valid_range.1).ok();
+        writeln!(
+            &mut output,
+            "Y-Range: {} to {}",
+            self.transaction_range.0, self.transaction_range.1
+        )
+        .ok();
+        writeln!(
+            &mut output,
+            "X-Range: {} to {}",
+            self.valid_range.0, self.valid_range.1
+        )
+        .ok();
         writeln!(&mut output, "Max Count: {}", max_val).ok();
         writeln!(&mut output, "┌{}┐", "─".repeat(self.x_bins)).ok();
 
@@ -179,9 +189,9 @@ impl TemporalHeatmap {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
-    use tardis_common::id::EntityId;
     use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
 
     fn create_entity(
         valid_start: DateTime<Utc>,
@@ -217,7 +227,12 @@ mod tests {
         // Entity 1: Hour 0-1 valid, recorded at Hour 0-1
         let e1 = create_entity(now, Some(now + hour), now, Some(now + hour));
         // Entity 2: Hour 1-2 valid, recorded at Hour 1-2
-        let e2 = create_entity(now + hour, Some(now + hour * 2), now + hour, Some(now + hour * 2));
+        let e2 = create_entity(
+            now + hour,
+            Some(now + hour * 2),
+            now + hour,
+            Some(now + hour * 2),
+        );
 
         let history = vec![e1, e2];
         let heatmap = TemporalHeatmap::new(&history, 2, 2);

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -7,9 +7,9 @@ use crate::loader::{
 };
 use crate::model::{ModelHandle, ModelInfo, ModelRegistry};
 use crate::tokenizer::TokenizerService;
+use async_trait::async_trait;
 use std::collections::HashMap;
 use std::path::Path;
-use async_trait::async_trait;
 use std::sync::{Arc, RwLock};
 use tardis_common::llm::{InferenceParams, ModelLoadConfig};
 use tardis_common::traits::VortexService;

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -46,8 +46,8 @@ pub mod tokenizer;
 
 // Re-export main types
 pub use error::{VortexError, VortexResult};
-pub use tardis_common::llm::{InferenceParams, ModelLoadConfig};
 pub use inference::Vortex;
 pub use loader::ModelPreset;
 pub use model::{ModelHandle, ModelInfo, ModelRegistry};
+pub use tardis_common::llm::{InferenceParams, ModelLoadConfig};
 pub use tokenizer::TokenizerService;


### PR DESCRIPTION
Refactored `chronos/src/pipeline/analyzer.rs` to improve testability and readability. Specifically, I removed the hidden dependency on `Utc::now()` within `extract_temporal_refs` by injecting it as an argument. I also encapsulated rule matching logic into methods on the rule structs. I updated `.clippy.toml` to match the workspace MSRV.

---
*PR created automatically by Jules for task [6278685778358124873](https://jules.google.com/task/6278685778358124873) started by @madmax983*