### PR TITLE
🔒 Warden: Fix RingBuffer Race Condition

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -21,3 +21,7 @@
 2026-02-23 - [RingBuffer UB & Stuck Writer]
 **Threat:** 1. `bytes` 1.11.0 Integer Overflow (DoS). 2. `RingBuffer` UB (Data Race in `copy_nonoverlapping` on shared memory). 3. `RingBuffer` Reader Livelock (infinite spin on stuck writer).
 **Defense:** 1. Updated `bytes` to 1.11.1. 2. Replaced `copy_nonoverlapping` with `volatile` read/write loops. 3. Added retry limit and skip logic to `try_read`.
+
+2026-03-01 - [RingBuffer Race Condition]
+**Threat:** MPSC usage of SPSC RingBuffer allowed multiple producers to race on slot claiming, leading to concurrent writes to `UnsafeCell` (UB) and data corruption.
+**Defense:** Implemented CAS (Compare-And-Swap) loop in `try_write` to enforce exclusive slot access, with spin-wait backoff for contention handling.

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -162,15 +162,47 @@ impl RingBuffer {
         // Check if slot is available (not being read)
         // We use the sequence number to track this
         let expected_seq = pos.wrapping_mul(2);
-        let current_seq = slot.sequence.load(Ordering::Acquire);
 
-        // If the slot is too far behind, we're overwriting unread data
-        if current_seq != expected_seq && current_seq != 0 {
-            self.dropped_count.fetch_add(1, Ordering::Relaxed);
+        // Claim the slot via CAS loop to prevent race conditions with multiple producers
+        let mut backoff = 0;
+        loop {
+            let current_seq = slot.sequence.load(Ordering::Acquire);
+
+            // If slot is busy (odd sequence), spin/wait
+            if current_seq & 1 == 1 {
+                if backoff > 1000 {
+                    // Give up to avoid deadlock if writer died or contention is extreme
+                    self.dropped_count.fetch_add(1, Ordering::Relaxed);
+                    return false;
+                }
+                backoff += 1;
+                core::hint::spin_loop();
+                continue;
+            }
+
+            // If the slot is too far behind, we're overwriting unread data
+            let overwriting = current_seq != expected_seq && current_seq != 0;
+
+            // Try to transition to writing state (expected_seq | 1)
+            // This compare_exchange ensures exclusive access for this writer
+            match slot.sequence.compare_exchange(
+                current_seq,
+                expected_seq | 1,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    if overwriting {
+                        self.dropped_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                    break;
+                }
+                Err(_) => {
+                    // CAS failed, retry
+                    core::hint::spin_loop();
+                }
+            }
         }
-
-        // Mark slot as being written (odd sequence)
-        slot.sequence.store(expected_seq | 1, Ordering::Release);
 
         // Write the entry
         // SAFETY: We have exclusive access to this slot via the sequence protocol
@@ -254,7 +286,8 @@ impl RingBuffer {
 
             if current_seq != expected_seq {
                 spins += 1;
-                if spins > 10_000 {
+                // Increased spin limit to avoid dropping packets during thread scheduling variation in tests
+                if spins > 100_000 {
                     // Writer stuck or crashed? Skip this slot.
                     // Try to advance read_pos past this bad slot.
                     if self

--- a/telemetry/tests/ring_buffer_race.rs
+++ b/telemetry/tests/ring_buffer_race.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "kernel")]
+
+//! Reproduction test for RingBuffer race condition.
+//!
+//! Spawns multiple threads to write to the `RingBuffer` concurrently
+//! and verifies data integrity.
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+use tardis_telemetry::kernel::RingBuffer;
+use tardis_telemetry::types::{TelemetryEntry, Level, Subsystem, EventType, SpanId, TraceId};
+
+#[test]
+fn race_condition_repro() {
+    // Use static to avoid stack overflow
+    static BUFFER: RingBuffer = RingBuffer::new();
+    let buffer_ref = &BUFFER;
+
+    const THREADS: usize = 8;
+    const WRITES_PER_THREAD: usize = 100_000;
+
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let mut handles = vec![];
+
+    // Producers
+    for t_id in 0..THREADS {
+        let b = barrier.clone();
+        handles.push(thread::spawn(move || {
+            b.wait(); // Synchronize start
+            for i in 0..WRITES_PER_THREAD {
+                let timestamp = (t_id * WRITES_PER_THREAD + i) as u64;
+                let entry = TelemetryEntry {
+                    timestamp_ns: timestamp,
+                    level: Level::Info,
+                    subsystem: Subsystem::Kernel,
+                    event_type: EventType::Log,
+                    span_id: SpanId::NONE,
+                    trace_id: TraceId::NONE,
+                    parent_span_id: SpanId::NONE,
+                    payload_len: 0,
+                };
+
+                // Write a larger payload to increase critical section duration
+                let mut payload_str = format!("payload-{}-{}", t_id, i);
+                while payload_str.len() < 150 {
+                    payload_str.push('.');
+                }
+                let payload = payload_str.into_bytes();
+
+                buffer_ref.try_write(&entry, &payload);
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Verify consistency
+    let mut valid_count = 0;
+
+    while let Some((entry, payload)) = buffer_ref.try_read() {
+        let t_id = entry.timestamp_ns / (WRITES_PER_THREAD as u64);
+        let i = entry.timestamp_ns % (WRITES_PER_THREAD as u64);
+
+        let mut expected_str = format!("payload-{}-{}", t_id, i);
+        while expected_str.len() < 150 {
+            expected_str.push('.');
+        }
+        let expected = expected_str.into_bytes();
+
+        let payload_vec: Vec<u8> = payload;
+        // Check strict equality.
+        if payload_vec != expected {
+             // CORRUPTION DETECTED
+             panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
+                 t_id, i, expected.len(), payload_vec.len(), String::from_utf8_lossy(&payload_vec.iter().take(20).cloned().collect::<Vec<u8>>()));
+        }
+        valid_count += 1;
+    }
+
+    println!("Read {} valid entries out of {} writes", valid_count, THREADS * WRITES_PER_THREAD);
+}


### PR DESCRIPTION
Fixed a critical MPSC race condition in `RingBuffer::try_write` by implementing a Compare-And-Swap (CAS) loop with backoff. Also increased `try_read` spin limit to prevent packet loss in userspace tests. Added reproduction test `telemetry/tests/ring_buffer_race.rs`.

---
*PR created automatically by Jules for task [3265887375587756479](https://jules.google.com/task/3265887375587756479) started by @madmax983*