### PR TITLE
Refactor: Kill Speculative Generality in Chronos/Vortex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,7 +3178,6 @@ dependencies = [
 name = "tardis-common"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
  "criterion",
  "proptest",

--- a/chronos/src/experimental/echoes.rs
+++ b/chronos/src/experimental/echoes.rs
@@ -7,7 +7,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tardis_common::traits::{GallifreyService, VortexService};
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::Vortex;
 
 /// An echo from the past.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -25,14 +26,14 @@ pub struct Echo {
 /// The Echo Chamber service.
 #[derive(Debug)]
 pub struct EchoChamber {
-    vortex: Arc<dyn VortexService>,
-    gallifrey: Arc<dyn GallifreyService>,
+    vortex: Arc<Vortex>,
+    gallifrey: Arc<Gallifrey>,
 }
 
 impl EchoChamber {
     /// Create a new `EchoChamber`.
     #[must_use]
-    pub fn new(vortex: Arc<dyn VortexService>, gallifrey: Arc<dyn GallifreyService>) -> Self {
+    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self { vortex, gallifrey }
     }
 
@@ -89,101 +90,40 @@ impl EchoChamber {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
-    use tardis_common::domain::{Change, Entity, Message, Snapshot};
+    use tardis_common::domain::{Entity, Message};
     use tardis_common::id::{EntityId, ModelHandle, SessionId};
-    use tardis_common::llm::{InferenceParams, ModelLoadConfig};
-    use tardis_common::temporal::{BiTemporalInterval, TemporalQuery};
-    use tardis_common::traits::QueryResult;
-    use tardis_common::Result;
-
-    #[derive(Debug)]
-    struct MockVortex;
-
-    #[async_trait]
-    impl VortexService for MockVortex {
-        async fn load_model(&self, _path: &str, _config: ModelLoadConfig) -> Result<ModelHandle> {
-            Ok(ModelHandle::new(0))
-        }
-        async fn unload_model(&self, _handle: ModelHandle) -> Result<()> {
-            Ok(())
-        }
-        async fn infer(
-            &self,
-            _handle: ModelHandle,
-            _prompt: &str,
-            _params: InferenceParams,
-        ) -> Result<String> {
-            Ok("inference".to_string())
-        }
-        async fn embed(&self, _handle: ModelHandle, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![0.1, 0.2, 0.3])
-        }
-    }
-
-    #[derive(Debug)]
-    struct MockGallifrey;
-
-    #[async_trait]
-    impl GallifreyService for MockGallifrey {
-        async fn insert(&self, _entity: Entity) -> Result<EntityId> {
-            Ok(EntityId::new())
-        }
-        async fn get_history(&self, _id: EntityId) -> Result<Vec<Entity>> {
-            Ok(vec![])
-        }
-        async fn search_knowledge(&self, _embedding: &[f32], _limit: usize) -> Result<Vec<Entity>> {
-            Ok(vec![Entity {
-                id: EntityId::new(),
-                entity_type: "Fact".to_string(),
-                name: "Previous System Crash".to_string(),
-                properties: std::collections::HashMap::new(),
-                embedding: None,
-                temporal: BiTemporalInterval::now(),
-                source: None,
-            }])
-        }
-        async fn query(&self, _query: &str, _temporal: TemporalQuery) -> Result<QueryResult> {
-            Ok(QueryResult {
-                nodes: vec![],
-                execution_time_ms: 0,
-                truncated: false,
-            })
-        }
-        async fn get_recent_messages(
-            &self,
-            _session_id: SessionId,
-            _limit: usize,
-        ) -> Result<Vec<Message>> {
-            Ok(vec![])
-        }
-        async fn search_conversation(
-            &self,
-            _embedding: &[f32],
-            _limit: usize,
-        ) -> Result<Vec<Message>> {
-            Ok(vec![Message {
-                id: EntityId::new(),
-                session_id: SessionId::new(),
-                role: tardis_common::domain::Role::User,
-                content: "I remember when the system crashed".to_string(),
-                timestamp: Utc::now(),
-                embedding: None,
-                entity_refs: vec![],
-            }])
-        }
-        async fn find_snapshot(&self, _timestamp: DateTime<Utc>) -> Result<Option<Snapshot>> {
-            Ok(None)
-        }
-        async fn record_change(&self, _change: Change) -> Result<()> {
-            Ok(())
-        }
-    }
+    use tardis_common::temporal::BiTemporalInterval;
 
     #[tokio::test]
     async fn test_echoes() {
-        let vortex = Arc::new(MockVortex);
-        let gallifrey = Arc::new(MockGallifrey);
+        let vortex = Arc::new(Vortex::new().unwrap());
+        vortex.set_mock_load_model(Box::new(|_, _| Ok(ModelHandle::new(0))));
+        vortex.set_mock_embedding(Box::new(|_, _| Ok(vec![0.1, 0.2, 0.3])));
+
+        let gallifrey = Arc::new(Gallifrey::new());
+
+        // Setup Knowledge
+        gallifrey.knowledge().insert_entity(Entity {
+            id: EntityId::new(),
+            entity_type: "Fact".to_string(),
+            name: "Previous System Crash".to_string(),
+            properties: std::collections::HashMap::new(),
+            embedding: Some(vec![0.1, 0.2, 0.3]),
+            temporal: BiTemporalInterval::now(),
+            source: None,
+        }).unwrap();
+
+        // Setup Conversation
+        gallifrey.conversation().add_message(Message {
+            id: EntityId::new(),
+            session_id: SessionId::new(),
+            role: tardis_common::domain::Role::User,
+            content: "I remember when the system crashed".to_string(),
+            timestamp: Utc::now(),
+            embedding: Some(vec![0.1, 0.2, 0.3]),
+            entity_refs: vec![],
+        }).unwrap();
+
         let echo_chamber = EchoChamber::new(vortex, gallifrey);
 
         let echoes = echo_chamber.listen("system crash").await.unwrap();

--- a/chronos/src/experimental/historian.rs
+++ b/chronos/src/experimental/historian.rs
@@ -15,7 +15,9 @@ use std::sync::Arc;
 #[cfg(feature = "nova")]
 use tardis_common::id::EntityId;
 #[cfg(feature = "nova")]
-use tardis_common::traits::{GallifreyService, VortexService};
+use tardis_gallifrey::Gallifrey;
+#[cfg(feature = "nova")]
+use tardis_vortex::Vortex;
 
 #[cfg(feature = "nova")]
 /// A detected anomaly in the timeline.
@@ -61,15 +63,15 @@ struct HistorySegment {
 /// The Historian service.
 #[derive(Debug)]
 pub struct Historian {
-    vortex: Arc<dyn VortexService>,
-    gallifrey: Arc<dyn GallifreyService>,
+    vortex: Arc<Vortex>,
+    gallifrey: Arc<Gallifrey>,
 }
 
 #[cfg(feature = "nova")]
 impl Historian {
     /// Create a new `Historian`.
     #[must_use]
-    pub fn new(vortex: Arc<dyn VortexService>, gallifrey: Arc<dyn GallifreyService>) -> Self {
+    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self { vortex, gallifrey }
     }
 
@@ -156,153 +158,84 @@ impl Historian {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
-    use tardis_common::domain::{Change, Entity, Message, Snapshot};
-    use tardis_common::id::{EntityId, ModelHandle, SessionId};
-    use tardis_common::llm::{InferenceParams, ModelLoadConfig};
-    use tardis_common::temporal::{BiTemporalInterval, TemporalQuery, TimeRange};
-    use tardis_common::traits::QueryResult;
-    use tardis_common::Result;
+    use tardis_common::domain::Entity;
+    use tardis_common::id::{EntityId, ModelHandle};
+    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
 
-    #[derive(Debug)]
-    struct MockVortex;
-
-    #[async_trait]
-    impl VortexService for MockVortex {
-        async fn load_model(&self, _path: &str, _config: ModelLoadConfig) -> Result<ModelHandle> {
-            Ok(ModelHandle::new(0))
-        }
-        async fn unload_model(&self, _handle: ModelHandle) -> Result<()> {
-            Ok(())
-        }
-        async fn infer(
-            &self,
-            _handle: ModelHandle,
-            prompt: &str,
-            _params: InferenceParams,
-        ) -> Result<String> {
-            // Check if prompt contains the retcon detection
+    #[tokio::test]
+    async fn test_historian_narrative() {
+        let vortex = Arc::new(Vortex::new().unwrap());
+        vortex.set_mock_inference(Box::new(|_, prompt, _| {
             if prompt.contains("Retcon") && prompt.contains("delay_seconds") {
                 return Ok("Narrative: We realized late that the system was offline.".to_string());
             }
             Ok("Default narrative".to_string())
-        }
-        async fn embed(&self, _handle: ModelHandle, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![])
-        }
-    }
+        }));
+        vortex.set_mock_load_model(Box::new(|_, _| Ok(ModelHandle::new(0))));
 
-    #[derive(Debug)]
-    struct MockGallifrey;
+        let gallifrey = Arc::new(Gallifrey::new());
+        let id = EntityId::new();
+        setup_history(&gallifrey, id).await;
 
-    #[async_trait]
-    impl GallifreyService for MockGallifrey {
-        async fn insert(&self, _entity: Entity) -> Result<EntityId> {
-            Ok(EntityId::new())
-        }
-        async fn get_history(&self, _id: EntityId) -> Result<Vec<Entity>> {
-            let now = Utc::now();
-            let ten_mins_ago = now - chrono::Duration::seconds(600);
-            let five_mins_ago = now - chrono::Duration::seconds(300);
-
-            // Record 1: Normal (Trans=10 mins ago, Valid=10 mins ago)
-            let e1 = Entity {
-                id: EntityId::new(),
-                entity_type: "Test".to_string(),
-                name: "Test Entity".to_string(),
-                properties: std::collections::HashMap::new(),
-                embedding: None,
-                temporal: BiTemporalInterval {
-                    valid_time: TimeRange {
-                        start: ten_mins_ago,
-                        end: None,
-                    },
-                    transaction_time: TimeRange {
-                        start: ten_mins_ago,
-                        end: None,
-                    },
-                },
-                source: None,
-            };
-
-            // Record 2: Retcon (Trans=Now, Valid=5 mins ago) -> Trans > Valid by 300s
-            // Wait, Retcon definition: Recorded > Actual + 5s.
-            // Trans=Now, Valid=5 mins ago. Diff = 300s. Correct.
-            let e2 = Entity {
-                id: EntityId::new(),
-                entity_type: "Test".to_string(),
-                name: "Test Entity".to_string(),
-                properties: std::collections::HashMap::new(),
-                embedding: None,
-                temporal: BiTemporalInterval {
-                    valid_time: TimeRange {
-                        start: five_mins_ago,
-                        end: None,
-                    },
-                    transaction_time: TimeRange {
-                        start: now,
-                        end: None,
-                    },
-                },
-                source: None,
-            };
-
-            Ok(vec![e1, e2])
-        }
-        async fn search_knowledge(&self, _embedding: &[f32], _limit: usize) -> Result<Vec<Entity>> {
-            Ok(vec![])
-        }
-        async fn query(&self, _query: &str, _temporal: TemporalQuery) -> Result<QueryResult> {
-            Ok(QueryResult {
-                nodes: vec![],
-                execution_time_ms: 0,
-                truncated: false,
-            })
-        }
-        async fn get_recent_messages(&self, _id: SessionId, _limit: usize) -> Result<Vec<Message>> {
-            Ok(vec![])
-        }
-        async fn search_conversation(
-            &self,
-            _embedding: &[f32],
-            _limit: usize,
-        ) -> Result<Vec<Message>> {
-            Ok(vec![])
-        }
-        async fn find_snapshot(&self, _ts: DateTime<Utc>) -> Result<Option<Snapshot>> {
-            Ok(None)
-        }
-        async fn record_change(&self, _change: Change) -> Result<()> {
-            Ok(())
-        }
-    }
-
-    #[tokio::test]
-    async fn test_historian_narrative() {
-        let vortex = Arc::new(MockVortex);
-        let gallifrey = Arc::new(MockGallifrey);
         let historian = Historian::new(vortex, gallifrey);
 
-        let story = historian.tell_story(EntityId::new()).await.unwrap();
+        let story = historian.tell_story(id).await.unwrap();
         assert!(story.contains("Narrative"));
+    }
+
+    // Helper to setup history
+    async fn setup_history(gallifrey: &Gallifrey, id: EntityId) {
+        let now = Utc::now();
+        let ten_mins_ago = now - chrono::Duration::seconds(600);
+        let five_mins_ago = now - chrono::Duration::seconds(300);
+
+        let e1 = Entity {
+            id,
+            entity_type: "Test".to_string(),
+            name: "Test Entity".to_string(),
+            properties: std::collections::HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval {
+                valid_time: TimeRange { start: ten_mins_ago, end: None },
+                transaction_time: TimeRange { start: ten_mins_ago, end: None },
+            },
+            source: None,
+        };
+
+        let e2 = Entity {
+            id,
+            entity_type: "Test".to_string(),
+            name: "Test Entity".to_string(),
+            properties: std::collections::HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval {
+                valid_time: TimeRange { start: five_mins_ago, end: None },
+                transaction_time: TimeRange { start: now, end: None },
+            },
+            source: None,
+        };
+
+        gallifrey.knowledge().insert_entity(e1).unwrap();
+        gallifrey.knowledge().insert_entity(e2).unwrap();
     }
 
     #[tokio::test]
     async fn test_analyze_logic() {
-        let vortex = Arc::new(MockVortex);
-        let gallifrey = Arc::new(MockGallifrey);
+        let vortex = Arc::new(Vortex::new().unwrap());
+        let gallifrey = Arc::new(Gallifrey::new());
+        let id = EntityId::new();
+        setup_history(&gallifrey, id).await;
+
         let historian = Historian::new(vortex, gallifrey);
 
-        let segments = historian.analyze_history(EntityId::new()).await.unwrap();
+        let segments = historian.analyze_history(id).await.unwrap();
         assert_eq!(segments.len(), 2);
 
-        // First segment (sorted by transaction time, which was 10 mins ago)
         match segments[0].anomaly {
             TemporalAnomaly::Normal => {}
             _ => panic!("Expected Normal, got {:?}", segments[0].anomaly),
         }
 
-        // Second segment (Trans=Now, Valid=5 mins ago -> Retcon)
         match segments[1].anomaly {
             TemporalAnomaly::Retcon { delay_seconds, .. } => {
                 assert!(delay_seconds >= 299);

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -13,20 +13,20 @@ use tardis_common::domain::Entity;
 use tardis_common::id::{EntityId, ModelHandle};
 use tardis_common::llm::InferenceParams;
 use tardis_common::temporal::{BiTemporalInterval, TimeRange};
-use tardis_common::traits::VortexService;
+use tardis_vortex::Vortex;
 use tracing::{info, instrument};
 
 /// The Prophet engine.
 #[derive(Debug)]
 pub struct Prophet {
-    vortex: Arc<dyn VortexService>,
+    vortex: Arc<Vortex>,
     paper: PsychicPaper,
 }
 
 impl Prophet {
     /// Create a new Prophet.
     #[must_use]
-    pub fn new(vortex: Arc<dyn VortexService>) -> Self {
+    pub fn new(vortex: Arc<Vortex>) -> Self {
         Self {
             vortex,
             paper: PsychicPaper::new(),
@@ -66,8 +66,7 @@ impl Prophet {
                     ..Default::default()
                 },
             )
-            .await
-            .map_err(ChronosError::Common)?;
+            .await?;
 
         let parsed = self
             .paper
@@ -133,29 +132,12 @@ impl Prophet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use serde_json::json;
-    use tardis_common::llm::ModelLoadConfig;
-    use tardis_common::Result;
 
-    #[derive(Debug)]
-    struct MockVortex;
-
-    #[async_trait]
-    impl VortexService for MockVortex {
-        async fn load_model(&self, _path: &str, _config: ModelLoadConfig) -> Result<ModelHandle> {
-            Ok(ModelHandle::new(1))
-        }
-        async fn unload_model(&self, _handle: ModelHandle) -> Result<()> {
-            Ok(())
-        }
-        async fn infer(
-            &self,
-            _handle: ModelHandle,
-            _prompt: &str,
-            _params: InferenceParams,
-        ) -> Result<String> {
-            // Return a simulated prediction
+    #[tokio::test]
+    async fn test_foresee() {
+        let vortex = Arc::new(Vortex::new().unwrap());
+        vortex.set_mock_inference(Box::new(|_, _, _| {
             let response = json!([
                 {
                     "name": "High CPU Alert",
@@ -169,15 +151,8 @@ mod tests {
                 }
             ]);
             Ok(response.to_string())
-        }
-        async fn embed(&self, _handle: ModelHandle, _text: &str) -> Result<Vec<f32>> {
-            Ok(vec![])
-        }
-    }
+        }));
 
-    #[tokio::test]
-    async fn test_foresee() {
-        let vortex = Arc::new(MockVortex);
         let prophet = Prophet::new(vortex);
         let model = ModelHandle::new(1);
 

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -41,8 +41,9 @@ pub use retriever::Retriever;
 use crate::error::{ChronosError, ChronosResult};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tardis_common::traits::{GallifreyService, VortexService};
 use tardis_common::{EntityId, SessionId};
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::Vortex;
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -113,8 +114,8 @@ pub struct RagResponse {
 #[derive(Debug)]
 pub struct Chronos {
     #[allow(dead_code)]
-    vortex: Arc<dyn VortexService>,
-    gallifrey: Arc<dyn GallifreyService>,
+    vortex: Arc<Vortex>,
+    gallifrey: Arc<Gallifrey>,
     analyzer: QueryAnalyzer,
     retriever: Retriever,
     augmenter: ContextAugmenter,
@@ -123,7 +124,7 @@ pub struct Chronos {
 impl Chronos {
     /// Create a new Chronos instance.
     #[must_use]
-    pub fn new(vortex: Arc<dyn VortexService>, gallifrey: Arc<dyn GallifreyService>) -> Self {
+    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self {
             vortex,
             gallifrey: Arc::clone(&gallifrey),

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -4,19 +4,19 @@ use super::{ContextSource, ContextSourceType, RagConfig};
 use crate::error::{ChronosError, ChronosResult};
 use crate::pipeline::analyzer::AnalyzedQuery;
 use std::sync::Arc;
-use tardis_common::traits::GallifreyService;
+use tardis_gallifrey::Gallifrey;
 use tracing::info;
 
 /// Multi-source retriever.
 #[derive(Debug)]
 pub struct Retriever {
-    gallifrey: Arc<dyn GallifreyService>,
+    gallifrey: Arc<Gallifrey>,
 }
 
 impl Retriever {
     /// Create a new retriever.
     #[must_use]
-    pub fn new(gallifrey: Arc<dyn GallifreyService>) -> Self {
+    pub fn new(gallifrey: Arc<Gallifrey>) -> Self {
         Self { gallifrey }
     }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -24,9 +24,6 @@ chrono = { workspace = true }
 # Identifiers
 uuid = { workspace = true }
 
-# Async support
-async-trait = { workspace = true }
-
 [dev-dependencies]
 proptest = { workspace = true }
 criterion = { workspace = true }

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -3,12 +3,7 @@
 //! These traits define the contracts between subsystems, designed to support
 //! both direct function calls (monolithic) and potential future IPC (microkernel).
 
-use crate::domain::{Change, Entity, Message, Snapshot};
-use crate::id::{EntityId, ModelHandle, SessionId};
-use crate::llm::{InferenceParams, ModelLoadConfig};
-use crate::temporal::TemporalQuery;
-use crate::Result;
-use async_trait::async_trait;
+use crate::domain::Entity;
 use serde::{Deserialize, Serialize};
 
 /// Query results from Gallifrey.
@@ -20,60 +15,4 @@ pub struct QueryResult {
     pub execution_time_ms: u64,
     /// Whether results were truncated
     pub truncated: bool,
-}
-
-/// Interface for LLM inference service (Vortex).
-#[async_trait]
-pub trait VortexService: Send + Sync + std::fmt::Debug {
-    /// Load a model.
-    async fn load_model(&self, path: &str, config: ModelLoadConfig) -> Result<ModelHandle>;
-
-    /// Unload a model.
-    async fn unload_model(&self, handle: ModelHandle) -> Result<()>;
-
-    /// Run inference.
-    async fn infer(
-        &self,
-        handle: ModelHandle,
-        prompt: &str,
-        params: InferenceParams,
-    ) -> Result<String>;
-
-    /// Generate embeddings.
-    async fn embed(&self, handle: ModelHandle, text: &str) -> Result<Vec<f32>>;
-}
-
-/// Interface for Temporal Knowledge Graph service (Gallifrey).
-#[async_trait]
-pub trait GallifreyService: Send + Sync + std::fmt::Debug {
-    /// Insert an entity into the knowledge graph.
-    async fn insert(&self, entity: Entity) -> Result<EntityId>;
-
-    /// Get the history of an entity.
-    async fn get_history(&self, id: EntityId) -> Result<Vec<Entity>>;
-
-    /// Semantic search in knowledge graph.
-    async fn search_knowledge(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>>;
-
-    /// Execute a temporal query.
-    async fn query(&self, query: &str, temporal: TemporalQuery) -> Result<QueryResult>;
-
-    /// Get recent messages from a session.
-    async fn get_recent_messages(
-        &self,
-        session_id: SessionId,
-        limit: usize,
-    ) -> Result<Vec<Message>>;
-
-    /// Semantic search in conversation history.
-    async fn search_conversation(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>>;
-
-    /// Find a system snapshot at a specific time.
-    async fn find_snapshot(
-        &self,
-        timestamp: chrono::DateTime<chrono::Utc>,
-    ) -> Result<Option<Snapshot>>;
-
-    /// Record a system change.
-    async fn record_change(&self, change: Change) -> Result<()>;
 }

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -74,12 +74,11 @@ pub use error::{GallifreyError, GallifreyResult};
 pub use stores::{ConversationStore, KnowledgeStore, SystemStateStore};
 pub use temporal::{BiTemporalInterval, TimeRange};
 
-use async_trait::async_trait;
 use std::sync::Arc;
 use tardis_common::domain::{Change, Entity, Message, Snapshot};
 use tardis_common::id::{EntityId, SessionId};
 use tardis_common::temporal::TemporalQuery;
-use tardis_common::traits::{GallifreyService, QueryResult};
+use tardis_common::traits::QueryResult;
 
 /// The main Gallifrey database instance.
 ///
@@ -287,60 +286,6 @@ impl Gallifrey {
         self.system_state
             .record_change(change)
             .map_err(|e| tardis_common::Error::Internal(e.to_string()))
-    }
-}
-
-#[async_trait]
-impl GallifreyService for Gallifrey {
-    async fn insert(&self, entity: Entity) -> tardis_common::Result<EntityId> {
-        self.insert(entity).await
-    }
-
-    async fn get_history(&self, id: EntityId) -> tardis_common::Result<Vec<Entity>> {
-        self.get_history(id).await
-    }
-
-    async fn search_knowledge(
-        &self,
-        embedding: &[f32],
-        limit: usize,
-    ) -> tardis_common::Result<Vec<Entity>> {
-        self.search_knowledge(embedding, limit).await
-    }
-
-    async fn query(
-        &self,
-        query: &str,
-        temporal: TemporalQuery,
-    ) -> tardis_common::Result<QueryResult> {
-        self.query(query, temporal).await
-    }
-
-    async fn get_recent_messages(
-        &self,
-        session_id: SessionId,
-        limit: usize,
-    ) -> tardis_common::Result<Vec<Message>> {
-        self.get_recent_messages(session_id, limit).await
-    }
-
-    async fn search_conversation(
-        &self,
-        embedding: &[f32],
-        limit: usize,
-    ) -> tardis_common::Result<Vec<Message>> {
-        self.search_conversation(embedding, limit).await
-    }
-
-    async fn find_snapshot(
-        &self,
-        timestamp: chrono::DateTime<chrono::Utc>,
-    ) -> tardis_common::Result<Option<Snapshot>> {
-        self.find_snapshot(timestamp).await
-    }
-
-    async fn record_change(&self, change: Change) -> tardis_common::Result<()> {
-        self.record_change(change).await
     }
 }
 

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -7,14 +7,22 @@ use crate::loader::{
 };
 use crate::model::{ModelHandle, ModelInfo, ModelRegistry};
 use crate::tokenizer::TokenizerService;
-use async_trait::async_trait;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 use tardis_common::llm::{InferenceParams, ModelLoadConfig};
-use tardis_common::traits::VortexService;
 use tokio::task;
 use tracing::{info, instrument};
+
+/// Mock inference callback type.
+pub type MockInference =
+    Box<dyn Fn(ModelHandle, &str, InferenceParams) -> VortexResult<String> + Send + Sync>;
+
+/// Mock embedding callback type.
+pub type MockEmbedding = Box<dyn Fn(ModelHandle, &str) -> VortexResult<Vec<f32>> + Send + Sync>;
+
+/// Mock load model callback type.
+pub type MockLoadModel = Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
 
 /// The main Vortex inference engine.
 pub struct Vortex {
@@ -26,6 +34,12 @@ pub struct Vortex {
     loaded_models: RwLock<HashMap<ModelHandle, LoadedModel>>,
     /// Model configurations by handle.
     model_configs: RwLock<HashMap<ModelHandle, ModelConfig>>,
+    /// Optional mock inference callback for testing.
+    mock_inference: RwLock<Option<MockInference>>,
+    /// Optional mock embedding callback for testing.
+    mock_embedding: RwLock<Option<MockEmbedding>>,
+    /// Optional mock load model callback for testing.
+    mock_load_model: RwLock<Option<MockLoadModel>>,
 }
 
 impl std::fmt::Debug for Vortex {
@@ -59,6 +73,9 @@ impl Vortex {
             tokenizers: Arc::new(TokenizerService::new()),
             loaded_models: RwLock::new(HashMap::new()),
             model_configs: RwLock::new(HashMap::new()),
+            mock_inference: RwLock::new(None),
+            mock_embedding: RwLock::new(None),
+            mock_load_model: RwLock::new(None),
         })
     }
 
@@ -73,6 +90,13 @@ impl Vortex {
         path: &str,
         config: ModelLoadConfig,
     ) -> VortexResult<ModelHandle> {
+        // Check for mock first
+        if let Ok(lock) = self.mock_load_model.read() {
+            if let Some(mock) = &*lock {
+                return mock(path, config);
+            }
+        }
+
         let path_buf = std::path::PathBuf::from(path);
 
         if !path_buf.exists() {
@@ -273,6 +297,13 @@ impl Vortex {
         prompt: &str,
         params: InferenceParams,
     ) -> VortexResult<String> {
+        // Check for mock first
+        if let Ok(lock) = self.mock_inference.read() {
+            if let Some(mock) = &*lock {
+                return mock(handle, prompt, params);
+            }
+        }
+
         if !self.registry.is_valid(handle) {
             return Err(VortexError::InvalidHandle(handle.raw()));
         }
@@ -298,6 +329,13 @@ impl Vortex {
     /// Returns an error if embedding generation fails.
     #[allow(clippy::unused_async)] // Will use async when embedding is truly async
     pub async fn embed(&self, handle: ModelHandle, text: &str) -> VortexResult<Vec<f32>> {
+        // Check for mock first
+        if let Ok(lock) = self.mock_embedding.read() {
+            if let Some(mock) = &*lock {
+                return mock(handle, text);
+            }
+        }
+
         if !self.registry.is_valid(handle) {
             return Err(VortexError::InvalidHandle(handle.raw()));
         }
@@ -344,33 +382,26 @@ impl Vortex {
             .map(|models| models.contains_key(&handle))
             .unwrap_or(false)
     }
-}
 
-#[async_trait]
-impl VortexService for Vortex {
-    async fn load_model(
-        &self,
-        path: &str,
-        config: ModelLoadConfig,
-    ) -> tardis_common::Result<ModelHandle> {
-        self.load_model(path, config).await.map_err(Into::into)
+    /// Set a mock inference callback for testing.
+    pub fn set_mock_inference(&self, mock: MockInference) {
+        if let Ok(mut lock) = self.mock_inference.write() {
+            *lock = Some(mock);
+        }
     }
 
-    async fn unload_model(&self, handle: ModelHandle) -> tardis_common::Result<()> {
-        self.unload_model(handle).await.map_err(Into::into)
+    /// Set a mock embedding callback for testing.
+    pub fn set_mock_embedding(&self, mock: MockEmbedding) {
+        if let Ok(mut lock) = self.mock_embedding.write() {
+            *lock = Some(mock);
+        }
     }
 
-    async fn infer(
-        &self,
-        handle: ModelHandle,
-        prompt: &str,
-        params: InferenceParams,
-    ) -> tardis_common::Result<String> {
-        self.infer(handle, prompt, params).await.map_err(Into::into)
-    }
-
-    async fn embed(&self, handle: ModelHandle, text: &str) -> tardis_common::Result<Vec<f32>> {
-        self.embed(handle, text).await.map_err(Into::into)
+    /// Set a mock load model callback for testing.
+    pub fn set_mock_load_model(&self, mock: MockLoadModel) {
+        if let Ok(mut lock) = self.mock_load_model.write() {
+            *lock = Some(mock);
+        }
     }
 }
 


### PR DESCRIPTION
This PR removes the `VortexService` and `GallifreyService` traits, which were single-implementation abstractions adding unnecessary complexity. 
 
 **Changes:** 
 - `tardis_common`: Removed traits and `async-trait` dependency. 
 - `tardis_vortex`: Added internal mocking support to the concrete `Vortex` struct to facilitate testing without traits. 
 - `tardis_gallifrey`: Removed trait implementation. 
 - `tardis_chronos`: Refactored `Chronos`, `Retriever`, and experimental features to use concrete types. Updated tests to use the new mocking mechanism. 
 
 **Benefit:** 
 - Reduced boilerplate. 
 - Explicit dependencies. 
 - Simplified testing strategy (no more `MockVortex` structs duplicated across files).

---
*PR created automatically by Jules for task [3466516695213141691](https://jules.google.com/task/3466516695213141691) started by @madmax983*