### PR TITLE
🛡️ Sentry: Fix unreachable comma-list parsing in PsychicPaper

### DIFF
--- a/chronos/src/experimental/echoes.rs
+++ b/chronos/src/experimental/echoes.rs
@@ -33,7 +33,7 @@ pub struct EchoChamber {
 impl EchoChamber {
     /// Create a new `EchoChamber`.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self { vortex, gallifrey }
     }
 

--- a/chronos/src/experimental/historian.rs
+++ b/chronos/src/experimental/historian.rs
@@ -71,7 +71,7 @@ pub struct Historian {
 impl Historian {
     /// Create a new `Historian`.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self { vortex, gallifrey }
     }
 

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -26,7 +26,7 @@ pub struct Prophet {
 impl Prophet {
     /// Create a new Prophet.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>) -> Self {
         Self {
             vortex,
             paper: PsychicPaper::new(),

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 pub enum Intent {
     /// Try to infer the format using a best-effort heuristic:
     /// 1. Check for JSON start characters `{` or `[`.
-    /// 2. Check for Markdown code blocks (````json`).
+    /// 2. Check for Markdown code blocks (` ```json `).
     /// 3. Check for list markers (`-` or `*`).
     /// 4. Check for Key-Value pairs (majority of lines have `:`).
     /// 5. Fallback to raw string.
@@ -171,16 +171,19 @@ impl PsychicPaper {
             })
             .collect();
 
-        if items.is_empty() {
-            // Try comma separation if single line
-            if !text.contains('\n') && text.contains(',') {
-                let items: Vec<String> = text
-                    .split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect();
-                return Ok(json!(items));
-            }
+        // Fallback: Try comma separation if single line and no bullets were found/stripped
+        // "No bullets found" means we have exactly one item and it matches the original trimmed text.
+        if items.len() == 1
+            && items[0] == text.trim()
+            && !text.contains('\n')
+            && text.contains(',')
+        {
+            let items: Vec<String> = text
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            return Ok(json!(items));
         }
 
         Ok(json!(items))
@@ -298,5 +301,13 @@ Hope that helps."#;
         let paper = PsychicPaper::new();
         let result = paper.interpret(text, Intent::Auto).unwrap();
         assert_eq!(result, json!({"Enemy": "Weeping Angel", "Don't": "Blink"}));
+    }
+
+    #[test]
+    fn test_interpret_list_comma_separated() {
+        let text = "red, green, blue";
+        let paper = PsychicPaper::new();
+        let result = paper.interpret(text, Intent::List).unwrap();
+        assert_eq!(result, json!(["red", "green", "blue"]));
     }
 }

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -16,7 +16,7 @@ pub struct Retriever {
 impl Retriever {
     /// Create a new retriever.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
         Self { gallifrey }
     }
 

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -55,7 +55,7 @@ impl std::fmt::Debug for Vortex {
                 "model_configs_count",
                 &self.model_configs.read().map(|c| c.len()).unwrap_or(0),
             )
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
PsychicPaper::interpret_list had a dead code block intended to handle comma-separated lists when no bullets were found. The condition `items.is_empty()` was always false for non-empty input because `lines()` returns the input string itself if no newlines are present.

This PR:
1. Fixes the logic to check if `items` contains exactly one element matching the trimmed input, allowing the comma-separation fallback to execute.
2. Adds a regression test `test_interpret_list_comma_separated`.
3. Cleanups: Converts several `new()` constructors to `const fn` and updates `Vortex` debug implementation.

---
*PR created automatically by Jules for task [9053997918707934748](https://jules.google.com/task/9053997918707934748) started by @madmax983*