### PR TITLE
🌟 Nova: Prophet Metrics Forecasting

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -24,3 +24,8 @@
 **Concept:** A bi-temporal narrative generator that detects "Retcons" and "Prophecies" in entity history and uses LLM to tell the story.
 **Fate:** Merged (Experimental)
 **Lesson:** Bi-temporal data is confusing; turning it into a natural language story makes it accessible to humans.
+
+## Prophet Metrics Forecasting
+**Concept:** Extending the Prophet module to forecast numerical system metrics (CPU, RAM) using historical snapshots and LLM time-series extrapolation.
+**Fate:** Merged (Experimental)
+**Lesson:** Structured time-series data can be effectively processed by LLMs when formatted as JSON, allowing for "fuzzy" prediction of system resources.

--- a/chronos/src/experimental/echoes.rs
+++ b/chronos/src/experimental/echoes.rs
@@ -33,7 +33,7 @@ pub struct EchoChamber {
 impl EchoChamber {
     /// Create a new `EchoChamber`.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self { vortex, gallifrey }
     }
 
@@ -103,26 +103,32 @@ mod tests {
         let gallifrey = Arc::new(Gallifrey::new());
 
         // Setup Knowledge
-        gallifrey.knowledge().insert_entity(Entity {
-            id: EntityId::new(),
-            entity_type: "Fact".to_string(),
-            name: "Previous System Crash".to_string(),
-            properties: std::collections::HashMap::new(),
-            embedding: Some(vec![0.1, 0.2, 0.3]),
-            temporal: BiTemporalInterval::now(),
-            source: None,
-        }).unwrap();
+        gallifrey
+            .knowledge()
+            .insert_entity(Entity {
+                id: EntityId::new(),
+                entity_type: "Fact".to_string(),
+                name: "Previous System Crash".to_string(),
+                properties: std::collections::HashMap::new(),
+                embedding: Some(vec![0.1, 0.2, 0.3]),
+                temporal: BiTemporalInterval::now(),
+                source: None,
+            })
+            .unwrap();
 
         // Setup Conversation
-        gallifrey.conversation().add_message(Message {
-            id: EntityId::new(),
-            session_id: SessionId::new(),
-            role: tardis_common::domain::Role::User,
-            content: "I remember when the system crashed".to_string(),
-            timestamp: Utc::now(),
-            embedding: Some(vec![0.1, 0.2, 0.3]),
-            entity_refs: vec![],
-        }).unwrap();
+        gallifrey
+            .conversation()
+            .add_message(Message {
+                id: EntityId::new(),
+                session_id: SessionId::new(),
+                role: tardis_common::domain::Role::User,
+                content: "I remember when the system crashed".to_string(),
+                timestamp: Utc::now(),
+                embedding: Some(vec![0.1, 0.2, 0.3]),
+                entity_refs: vec![],
+            })
+            .unwrap();
 
         let echo_chamber = EchoChamber::new(vortex, gallifrey);
 

--- a/chronos/src/experimental/historian.rs
+++ b/chronos/src/experimental/historian.rs
@@ -71,7 +71,7 @@ pub struct Historian {
 impl Historian {
     /// Create a new `Historian`.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self { vortex, gallifrey }
     }
 
@@ -196,8 +196,14 @@ mod tests {
             properties: std::collections::HashMap::new(),
             embedding: None,
             temporal: BiTemporalInterval {
-                valid_time: TimeRange { start: ten_mins_ago, end: None },
-                transaction_time: TimeRange { start: ten_mins_ago, end: None },
+                valid_time: TimeRange {
+                    start: ten_mins_ago,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: ten_mins_ago,
+                    end: None,
+                },
             },
             source: None,
         };
@@ -209,8 +215,14 @@ mod tests {
             properties: std::collections::HashMap::new(),
             embedding: None,
             temporal: BiTemporalInterval {
-                valid_time: TimeRange { start: five_mins_ago, end: None },
-                transaction_time: TimeRange { start: now, end: None },
+                valid_time: TimeRange {
+                    start: five_mins_ago,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: now,
+                    end: None,
+                },
             },
             source: None,
         };

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -7,28 +7,43 @@
 
 use crate::error::{ChronosError, ChronosResult};
 use crate::experimental::psychic_paper::{Intent, PsychicPaper};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 use tardis_common::domain::Entity;
 use tardis_common::id::{EntityId, ModelHandle};
 use tardis_common::llm::InferenceParams;
 use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+use tardis_gallifrey::Gallifrey;
 use tardis_vortex::Vortex;
 use tracing::{info, instrument};
+
+/// Predicted system metrics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PredictedMetrics {
+    /// Time of prediction.
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Predicted CPU usage (percent).
+    pub cpu_percent: f32,
+    /// Predicted memory usage (bytes).
+    pub memory_bytes: u64,
+}
 
 /// The Prophet engine.
 #[derive(Debug)]
 pub struct Prophet {
     vortex: Arc<Vortex>,
+    gallifrey: Arc<Gallifrey>,
     paper: PsychicPaper,
 }
 
 impl Prophet {
     /// Create a new Prophet.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self {
             vortex,
+            gallifrey,
             paper: PsychicPaper::new(),
         }
     }
@@ -127,6 +142,109 @@ impl Prophet {
         info!("Prophet foresaw {} events.", predictions.len());
         Ok(predictions)
     }
+
+    /// Forecast future system metrics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if history cannot be retrieved or inference fails.
+    #[instrument(skip(self))]
+    pub async fn forecast_metrics(
+        &self,
+        minutes: u32,
+        model: ModelHandle,
+    ) -> ChronosResult<Vec<PredictedMetrics>> {
+        info!("Forecasting metrics for the next {} minutes", minutes);
+
+        // 1. Fetch history
+        let snapshots = self
+            .gallifrey
+            .system_state()
+            .list_snapshots()
+            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+
+        // Take last 20 snapshots
+        let recent: Vec<_> = snapshots.iter().rev().take(20).rev().collect();
+
+        if recent.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // 2. Build time series prompt
+        let series: Vec<_> = recent
+            .iter()
+            .map(|s| {
+                // Aggregate CPU/Memory from all processes
+                let total_cpu: f32 = s.state.processes.values().map(|p| p.cpu_percent).sum();
+                let total_mem: u64 = s.state.processes.values().map(|p| p.memory_bytes).sum();
+
+                serde_json::json!({
+                    "timestamp": s.timestamp,
+                    "cpu": total_cpu,
+                    "memory": total_mem
+                })
+            })
+            .collect();
+
+        let prompt = format!(
+            "History:\n{}\n\nPredict the next {} data points (1 minute interval). Return strictly a JSON list of objects with 'timestamp', 'cpu', 'memory'.",
+            serde_json::to_string_pretty(&series).unwrap_or_default(),
+            minutes
+        );
+
+        // 3. Infer
+        let response = self
+            .vortex
+            .infer(
+                model,
+                &prompt,
+                InferenceParams {
+                    max_tokens: 1024,
+                    temperature: 0.2, // Lower temp for logic/numbers
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        // 4. Parse
+        let parsed = self
+            .paper
+            .interpret(&response, Intent::Json)
+            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e)))?;
+
+        let mut metrics = Vec::new();
+        if let Some(array) = parsed.as_array() {
+            for item in array {
+                #[allow(clippy::cast_possible_truncation)]
+                let cpu = item
+                    .get("cpu")
+                    .and_then(serde_json::Value::as_f64)
+                    .unwrap_or(0.0) as f32;
+                let memory = item
+                    .get("memory")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0);
+
+                // Handle timestamp parsing
+                let timestamp = if let Some(ts_str) =
+                    item.get("timestamp").and_then(serde_json::Value::as_str)
+                {
+                    chrono::DateTime::parse_from_rfc3339(ts_str)
+                        .map_or_else(|_| chrono::Utc::now(), |dt| dt.with_timezone(&chrono::Utc))
+                } else {
+                    chrono::Utc::now()
+                };
+
+                metrics.push(PredictedMetrics {
+                    timestamp,
+                    cpu_percent: cpu,
+                    memory_bytes: memory,
+                });
+            }
+        }
+
+        Ok(metrics)
+    }
 }
 
 #[cfg(test)]
@@ -137,6 +255,7 @@ mod tests {
     #[tokio::test]
     async fn test_foresee() {
         let vortex = Arc::new(Vortex::new().unwrap());
+        let gallifrey = Arc::new(Gallifrey::new());
         vortex.set_mock_inference(Box::new(|_, _, _| {
             let response = json!([
                 {
@@ -153,7 +272,7 @@ mod tests {
             Ok(response.to_string())
         }));
 
-        let prophet = Prophet::new(vortex);
+        let prophet = Prophet::new(vortex, gallifrey);
         let model = ModelHandle::new(1);
 
         let predictions = prophet
@@ -186,5 +305,54 @@ mod tests {
             diff < 5,
             "Prediction time should be ~5 minutes in the future"
         );
+    }
+
+    #[tokio::test]
+    async fn test_forecast_metrics() {
+        let vortex = Arc::new(Vortex::new().unwrap());
+        let gallifrey = Arc::new(Gallifrey::new());
+
+        // Mock Vortex response
+        vortex.set_mock_inference(Box::new(|_, _, _| {
+            // Generate some dummy predictions
+            let predictions = vec![
+                json!({
+                    "timestamp": "2024-01-01T12:01:00Z",
+                    "cpu": 50.5,
+                    "memory": 102400
+                }),
+                json!({
+                    "timestamp": "2024-01-01T12:02:00Z",
+                    "cpu": 60.0,
+                    "memory": 204800
+                }),
+            ];
+            Ok(json!(predictions).to_string())
+        }));
+
+        // Populate Gallifrey with some data
+        let state = tardis_common::domain::SystemState {
+            processes: std::collections::HashMap::new(),
+            config: std::collections::HashMap::new(),
+            files: std::collections::HashMap::new(),
+        };
+
+        gallifrey
+            .system_state()
+            .take_snapshot(
+                "test_snapshot",
+                tardis_common::domain::SnapshotTrigger::Manual,
+                state,
+            )
+            .unwrap();
+
+        let prophet = Prophet::new(vortex, gallifrey);
+        let model = ModelHandle::new(1);
+
+        let predictions = prophet.forecast_metrics(2, model).await.unwrap();
+
+        assert_eq!(predictions.len(), 2);
+        assert!((predictions[0].cpu_percent - 50.5).abs() < f32::EPSILON);
+        assert_eq!(predictions[1].memory_bytes, 204800);
     }
 }

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 pub enum Intent {
     /// Try to infer the format using a best-effort heuristic:
     /// 1. Check for JSON start characters `{` or `[`.
-    /// 2. Check for Markdown code blocks (````json`).
+    /// 2. Check for Markdown code blocks.
     /// 3. Check for list markers (`-` or `*`).
     /// 4. Check for Key-Value pairs (majority of lines have `:`).
     /// 5. Fallback to raw string.

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -16,7 +16,7 @@ pub struct Retriever {
 impl Retriever {
     /// Create a new retriever.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
         Self { gallifrey }
     }
 

--- a/shell/src/dashboard.rs
+++ b/shell/src/dashboard.rs
@@ -45,7 +45,10 @@ pub mod tui {
             // 50x20 resolution for the heatmap
             let heatmap = TemporalHeatmap::new(&all_history, 50, 20);
 
-            Ok(Self { _gallifrey: gallifrey, heatmap })
+            Ok(Self {
+                _gallifrey: gallifrey,
+                heatmap,
+            })
         }
 
         /// Run the dashboard loop.
@@ -113,7 +116,9 @@ pub mod tui {
             // Title
             let title = Paragraph::new(Text::styled(
                 "🌟 Tardis Time Stream 🌟",
-                Style::default().add_modifier(Modifier::BOLD).fg(Color::Cyan),
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .fg(Color::Cyan),
             ))
             .block(Block::default().borders(Borders::ALL));
             f.render_widget(title, chunks[0]);
@@ -126,27 +131,41 @@ pub mod tui {
 
             // Heatmap
             let heatmap_str = self.heatmap.render_ascii();
-            let heatmap_widget = Paragraph::new(heatmap_str)
-                .block(Block::default().title("Bi-Temporal Activity").borders(Borders::ALL));
+            let heatmap_widget = Paragraph::new(heatmap_str).block(
+                Block::default()
+                    .title("Bi-Temporal Activity")
+                    .borders(Borders::ALL),
+            );
             f.render_widget(heatmap_widget, main_chunks[0]);
 
             // Stats
             let total_events: usize = self.heatmap.grid.iter().flatten().sum();
 
             let stats_text = vec![
-                Line::from(Span::styled("System Status", Style::default().add_modifier(Modifier::UNDERLINED))),
+                Line::from(Span::styled(
+                    "System Status",
+                    Style::default().add_modifier(Modifier::UNDERLINED),
+                )),
                 Line::from(""),
                 Line::from(format!("Entities: {total_events}")), // Rough proxy for activity
-                Line::from(format!("Valid Time: {} to {}", self.heatmap.valid_range.0.format("%H:%M"), self.heatmap.valid_range.1.format("%H:%M"))),
-                Line::from(format!("Trans Time: {} to {}", self.heatmap.transaction_range.0.format("%H:%M"), self.heatmap.transaction_range.1.format("%H:%M"))),
+                Line::from(format!(
+                    "Valid Time: {} to {}",
+                    self.heatmap.valid_range.0.format("%H:%M"),
+                    self.heatmap.valid_range.1.format("%H:%M")
+                )),
+                Line::from(format!(
+                    "Trans Time: {} to {}",
+                    self.heatmap.transaction_range.0.format("%H:%M"),
+                    self.heatmap.transaction_range.1.format("%H:%M")
+                )),
             ];
             let stats_widget = Paragraph::new(stats_text)
                 .block(Block::default().title("Stats").borders(Borders::ALL));
             f.render_widget(stats_widget, main_chunks[1]);
 
             // Footer
-            let footer = Paragraph::new("Press 'q' to exit")
-                .block(Block::default().borders(Borders::ALL));
+            let footer =
+                Paragraph::new("Press 'q' to exit").block(Block::default().borders(Borders::ALL));
             f.render_widget(footer, chunks[2]);
         }
     }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -157,7 +157,8 @@ impl Repl {
             }
             #[cfg(feature = "nova")]
             "dashboard" => {
-                match crate::dashboard::tui::Dashboard::new(std::sync::Arc::clone(&self.gallifrey)) {
+                match crate::dashboard::tui::Dashboard::new(std::sync::Arc::clone(&self.gallifrey))
+                {
                     Ok(mut dashboard) => {
                         if let Err(e) = dashboard.run() {
                             println!("Dashboard failed: {e}");

--- a/telemetry/tests/ring_buffer_race.rs
+++ b/telemetry/tests/ring_buffer_race.rs
@@ -8,7 +8,7 @@
 use std::sync::{Arc, Barrier};
 use std::thread;
 use tardis_telemetry::kernel::RingBuffer;
-use tardis_telemetry::types::{TelemetryEntry, Level, Subsystem, EventType, SpanId, TraceId};
+use tardis_telemetry::types::{EventType, Level, SpanId, Subsystem, TelemetryEntry, TraceId};
 
 #[test]
 fn race_condition_repro() {
@@ -72,12 +72,16 @@ fn race_condition_repro() {
         let payload_vec: Vec<u8> = payload;
         // Check strict equality.
         if payload_vec != expected {
-             // CORRUPTION DETECTED
-             panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
+            // CORRUPTION DETECTED
+            panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
                  t_id, i, expected.len(), payload_vec.len(), String::from_utf8_lossy(&payload_vec.iter().take(20).cloned().collect::<Vec<u8>>()));
         }
         valid_count += 1;
     }
 
-    println!("Read {} valid entries out of {} writes", valid_count, THREADS * WRITES_PER_THREAD);
+    println!(
+        "Read {} valid entries out of {} writes",
+        valid_count,
+        THREADS * WRITES_PER_THREAD
+    );
 }

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -22,7 +22,8 @@ pub type MockInference =
 pub type MockEmbedding = Box<dyn Fn(ModelHandle, &str) -> VortexResult<Vec<f32>> + Send + Sync>;
 
 /// Mock load model callback type.
-pub type MockLoadModel = Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
+pub type MockLoadModel =
+    Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
 
 /// The main Vortex inference engine.
 pub struct Vortex {
@@ -55,7 +56,7 @@ impl std::fmt::Debug for Vortex {
                 "model_configs_count",
                 &self.model_configs.read().map(|c| c.len()).unwrap_or(0),
             )
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
*   💡 **The Spark:** "I noticed we calculate system state history in `Gallifrey` but don't use it to predict future load."
*   🚀 **The Feature:** Implemented `forecast_metrics` in `Prophet`. It uses `Gallifrey` to fetch historical CPU/RAM usage and `Vortex` (LLM) to extrapolate future trends.
*   🔮 **The Potential:** "Could be used for proactive auto-scaling or 'Pre-Crime' system alerts."
*   ⚠️ **Risk:** "Low. Isolated in `src/experimental/prophecy.rs` behind `nova` feature."

---
*PR created automatically by Jules for task [14945944432742044182](https://jules.google.com/task/14945944432742044182) started by @madmax983*