### PR TITLE
🎻 Bard: Documented distributed tracing primitives

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -9,3 +9,7 @@
 ## 2024-05-25 - The Hidden Chronos
 **Confusion:** Users exploring the `chronos` crate had no entry point (`README.md`) to understand the RAG pipeline architecture, making the orchestration logic feel like a black box.
 **Clarification:** Added `chronos/README.md` with an ASCII architecture diagram and detailed pipeline stage explanations to map the flow from query to response.
+
+## 2024-05-26 - The Randomness Requirement
+**Confusion:** `TraceId::generate()` is often assumed to be available everywhere, but it requires `std::time`, making it unavailable in `no_std` kernel builds.
+**Clarification:** Explicitly guarded `generate()` examples with `#[cfg(feature = "std")]` and explained that `from_bytes` is the `no_std` alternative.

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -214,8 +214,8 @@ impl RingBuffer {
             let payload_len = payload.len().min(MAX_PAYLOAD_SIZE);
             let payload_ptr = slot.payload.get().cast::<u8>();
             // Use volatile write to avoid data races with concurrent readers (Seqlock)
-            for i in 0..payload_len {
-                core::ptr::write_volatile(payload_ptr.add(i), payload[i]);
+            for (i, byte) in payload.iter().enumerate().take(payload_len) {
+                core::ptr::write_volatile(payload_ptr.add(i), *byte);
             }
 
             // Update payload length
@@ -341,10 +341,9 @@ impl RingBuffer {
             // Use volatile read to avoid data races with concurrent writers (Seqlock)
             unsafe {
                 let src_ptr = slot.payload.get().cast::<u8>();
-                let dst_ptr = payload.as_mut_ptr();
-                for i in 0..payload_len {
+                for (i, dst_byte) in payload.iter_mut().enumerate().take(payload_len) {
                     let byte = core::ptr::read_volatile(src_ptr.add(i));
-                    core::ptr::write(dst_ptr.add(i), byte);
+                    *dst_byte = byte;
                 }
             }
 

--- a/telemetry/src/trace.rs
+++ b/telemetry/src/trace.rs
@@ -1,6 +1,37 @@
 //! Distributed tracing primitives.
 //!
-//! Provides unique identifiers for traces and spans, compatible with W3C Trace Context.
+//! # Overview
+//!
+//! Distributed tracing allows you to track the propagation of a request across service boundaries.
+//! This module provides the core identifiers used to correlate logs and metrics:
+//!
+//! - [`TraceId`]: A 128-bit unique identifier for a whole trace (a complete request lifecycle).
+//! - [`SpanId`]: A 64-bit unique identifier for a single unit of work (a span) within a trace.
+//!
+//! # W3C Trace Context
+//!
+//! These identifiers are designed to be compatible with the [W3C Trace Context](https://www.w3.org/TR/trace-context/) specification,
+//! ensuring interoperability with tools like OpenTelemetry, Jaeger, and Zipkin.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use tardis_telemetry::trace::{TraceId, SpanId};
+//!
+//! // Create IDs from raw bytes (e.g., received from a network header)
+//! let trace_id = TraceId::from_bytes([
+//!     0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6,
+//!     0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36,
+//! ]);
+//!
+//! let span_id = SpanId::from_bytes([
+//!     0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7,
+//! ]);
+//!
+//! println!("Trace: {}", trace_id);
+//! println!("Span: {}", span_id);
+//! ```
+//!
 //! `no_std` compatible.
 
 use core::fmt;
@@ -8,16 +39,47 @@ use serde::{Deserialize, Serialize};
 
 /// 128-bit trace identifier (W3C Trace Context compatible).
 ///
-/// Uniquely identifies a distributed trace across the system.
+/// Uniquely identifies a distributed trace across the system. A trace represents
+/// a single operation (like a user request) that may traverse multiple services or threads.
+///
+/// The ID consists of a 16-byte array, typically serialized as a 32-character hexadecimal string.
+///
+/// # Examples
+///
+/// Creating a `TraceId` from a byte array:
+///
+/// ```
+/// use tardis_telemetry::trace::TraceId;
+///
+/// let bytes = [1u8; 16];
+/// let trace_id = TraceId::from_bytes(bytes);
+/// assert!(!trace_id.is_none());
+/// ```
+///
+/// Generating a random `TraceId` (requires `std` feature):
+///
+/// ```
+/// # #[cfg(feature = "std")]
+/// # {
+/// use tardis_telemetry::trace::TraceId;
+///
+/// let trace_id = TraceId::generate();
+/// println!("New trace started: {}", trace_id);
+/// # }
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(C)]
 pub struct TraceId([u8; 16]);
 
 impl TraceId {
     /// A zero/null trace ID indicating no trace context.
+    ///
+    /// This is used when a valid trace ID is not available or required.
     pub const NONE: Self = Self([0; 16]);
 
     /// Creates a new trace ID from raw bytes.
+    ///
+    /// This is `const` fn, allowing it to be used in static initializers.
     #[must_use]
     pub const fn from_bytes(bytes: [u8; 16]) -> Self {
         Self(bytes)
@@ -78,7 +140,22 @@ impl fmt::Display for TraceId {
 
 /// 64-bit span identifier.
 ///
-/// Uniquely identifies a span within a trace.
+/// Uniquely identifies a span within a trace. A span represents a logical unit of work,
+/// such as a function call, a database query, or a network request.
+///
+/// The ID consists of an 8-byte array, typically serialized as a 16-character hexadecimal string.
+///
+/// # Examples
+///
+/// Creating a `SpanId` from a byte array:
+///
+/// ```
+/// use tardis_telemetry::trace::SpanId;
+///
+/// let bytes = [0xAB; 8];
+/// let span_id = SpanId::from_bytes(bytes);
+/// assert_eq!(span_id.to_string(), "abababababababab");
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(C)]
 pub struct SpanId([u8; 8]);
@@ -88,6 +165,8 @@ impl SpanId {
     pub const NONE: Self = Self([0; 8]);
 
     /// Creates a new span ID from raw bytes.
+    ///
+    /// This is `const` fn, allowing it to be used in static initializers.
     #[must_use]
     pub const fn from_bytes(bytes: [u8; 8]) -> Self {
         Self(bytes)


### PR DESCRIPTION
Updated documentation for `TraceId` and `SpanId` in `tardis-telemetry`, adding module-level docs, usage examples, and W3C compatibility context. Also refactored `RingBuffer` to fix clippy warnings and improve code safety.

---
*PR created automatically by Jules for task [17863417197408936387](https://jules.google.com/task/17863417197408936387) started by @madmax983*