### PR TITLE
🌟 Nova: Entropy Gauge for Timeline Stability

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -24,3 +24,8 @@
 **Concept:** A bi-temporal narrative generator that detects "Retcons" and "Prophecies" in entity history and uses LLM to tell the story.
 **Fate:** Merged (Experimental)
 **Lesson:** Bi-temporal data is confusing; turning it into a natural language story makes it accessible to humans.
+
+## Entropy Gauge
+**Concept:** A system stability monitor that measures "drift" between Valid Time and Transaction Time to quantify "Retcons" (rewriting history) and "Prophecies" (predicting future).
+**Fate:** Merged (Experimental)
+**Lesson:** Quantifying "Time Travel" gives us a metric for system integrity. A high-entropy timeline suggests the system is either hallucinating or correcting itself too often.

--- a/chronos/src/experimental/echoes.rs
+++ b/chronos/src/experimental/echoes.rs
@@ -103,26 +103,32 @@ mod tests {
         let gallifrey = Arc::new(Gallifrey::new());
 
         // Setup Knowledge
-        gallifrey.knowledge().insert_entity(Entity {
-            id: EntityId::new(),
-            entity_type: "Fact".to_string(),
-            name: "Previous System Crash".to_string(),
-            properties: std::collections::HashMap::new(),
-            embedding: Some(vec![0.1, 0.2, 0.3]),
-            temporal: BiTemporalInterval::now(),
-            source: None,
-        }).unwrap();
+        gallifrey
+            .knowledge()
+            .insert_entity(Entity {
+                id: EntityId::new(),
+                entity_type: "Fact".to_string(),
+                name: "Previous System Crash".to_string(),
+                properties: std::collections::HashMap::new(),
+                embedding: Some(vec![0.1, 0.2, 0.3]),
+                temporal: BiTemporalInterval::now(),
+                source: None,
+            })
+            .unwrap();
 
         // Setup Conversation
-        gallifrey.conversation().add_message(Message {
-            id: EntityId::new(),
-            session_id: SessionId::new(),
-            role: tardis_common::domain::Role::User,
-            content: "I remember when the system crashed".to_string(),
-            timestamp: Utc::now(),
-            embedding: Some(vec![0.1, 0.2, 0.3]),
-            entity_refs: vec![],
-        }).unwrap();
+        gallifrey
+            .conversation()
+            .add_message(Message {
+                id: EntityId::new(),
+                session_id: SessionId::new(),
+                role: tardis_common::domain::Role::User,
+                content: "I remember when the system crashed".to_string(),
+                timestamp: Utc::now(),
+                embedding: Some(vec![0.1, 0.2, 0.3]),
+                entity_refs: vec![],
+            })
+            .unwrap();
 
         let echo_chamber = EchoChamber::new(vortex, gallifrey);
 

--- a/chronos/src/experimental/historian.rs
+++ b/chronos/src/experimental/historian.rs
@@ -196,8 +196,14 @@ mod tests {
             properties: std::collections::HashMap::new(),
             embedding: None,
             temporal: BiTemporalInterval {
-                valid_time: TimeRange { start: ten_mins_ago, end: None },
-                transaction_time: TimeRange { start: ten_mins_ago, end: None },
+                valid_time: TimeRange {
+                    start: ten_mins_ago,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: ten_mins_ago,
+                    end: None,
+                },
             },
             source: None,
         };
@@ -209,8 +215,14 @@ mod tests {
             properties: std::collections::HashMap::new(),
             embedding: None,
             temporal: BiTemporalInterval {
-                valid_time: TimeRange { start: five_mins_ago, end: None },
-                transaction_time: TimeRange { start: now, end: None },
+                valid_time: TimeRange {
+                    start: five_mins_ago,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: now,
+                    end: None,
+                },
             },
             source: None,
         };

--- a/gallifrey/src/experimental/entropy.rs
+++ b/gallifrey/src/experimental/entropy.rs
@@ -1,0 +1,193 @@
+use serde::{Deserialize, Serialize};
+use tardis_common::domain::Entity;
+
+/// Metrics describing the stability of the timeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemEntropy {
+    /// Number of events where Valid Time < Transaction Time (History rewriting).
+    pub retcon_count: usize,
+    /// Number of events where Valid Time > Transaction Time (Future prediction).
+    pub prophecy_count: usize,
+    /// Average drift (Valid - Transaction) in milliseconds.
+    pub average_drift_ms: f64,
+    /// Variance of the drift (measure of chaos).
+    pub drift_variance: f64,
+    /// A normalized score (0.0 to 1.0) where 1.0 is perfectly stable.
+    pub stability_score: f64,
+}
+
+/// A gauge to measure system entropy from entity history.
+#[derive(Debug)]
+pub struct EntropyGauge {
+    /// Threshold in milliseconds to consider a drift significant (not just latency).
+    pub drift_threshold_ms: i64,
+}
+
+impl Default for EntropyGauge {
+    fn default() -> Self {
+        Self {
+            drift_threshold_ms: 5000, // 5 seconds default
+        }
+    }
+}
+
+impl EntropyGauge {
+    /// Create a new `EntropyGauge` with a specific threshold.
+    #[must_use]
+    pub const fn new(drift_threshold_ms: i64) -> Self {
+        Self { drift_threshold_ms }
+    }
+
+    /// Measure the entropy of a given history of entities.
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn measure(&self, history: &[Entity]) -> SystemEntropy {
+        if history.is_empty() {
+            return SystemEntropy {
+                retcon_count: 0,
+                prophecy_count: 0,
+                average_drift_ms: 0.0,
+                drift_variance: 0.0,
+                stability_score: 1.0,
+            };
+        }
+
+        let mut retcons = 0;
+        let mut prophecies = 0;
+        let mut total_drift = 0.0;
+        let mut drifts = Vec::with_capacity(history.len());
+
+        for entity in history {
+            let valid_start = entity.temporal.valid_time.start;
+            let trans_start = entity.temporal.transaction_time.start;
+
+            let drift = (valid_start - trans_start).num_milliseconds() as f64;
+            drifts.push(drift);
+            total_drift += drift;
+
+            if drift < -(self.drift_threshold_ms as f64) {
+                retcons += 1;
+            } else if drift > self.drift_threshold_ms as f64 {
+                prophecies += 1;
+            }
+        }
+
+        let avg_drift = total_drift / history.len() as f64;
+
+        // Calculate variance
+        let mut sum_sq_diff = 0.0;
+        for drift in &drifts {
+            sum_sq_diff += (drift - avg_drift).powi(2);
+        }
+        let variance = sum_sq_diff / history.len() as f64;
+
+        // Calculate stability score
+        // Use a sigmoid-like decay based on variance and abnormal event ratio
+        let abnormal_ratio = (retcons + prophecies) as f64 / history.len() as f64;
+
+        // Dampen variance impact.
+        // We use a simplified decay function: 1 / (1 + sqrt(variance / constant))
+        // The constant 1,000,000 implies that a std deviation of 1000ms (1s) reduces score significantly.
+        let variance_penalty = 1.0 / (1.0 + (variance / 1_000_000.0).sqrt());
+        let event_penalty = 1.0 - abnormal_ratio;
+
+        let stability = variance_penalty * event_penalty;
+
+        SystemEntropy {
+            retcon_count: retcons,
+            prophecy_count: prophecies,
+            average_drift_ms: avg_drift,
+            drift_variance: variance,
+            stability_score: stability.clamp(0.0, 1.0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+    use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+
+    fn create_entity(drift: Duration) -> Entity {
+        let now = Utc::now();
+        // valid_time = now + drift
+        // transaction_time = now
+        // drift = valid - transaction
+        Entity {
+            id: EntityId::new(),
+            entity_type: "Test".to_string(),
+            name: "Test".to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval {
+                valid_time: TimeRange {
+                    start: now + drift,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: now,
+                    end: None,
+                },
+            },
+            source: None,
+        }
+    }
+
+    #[test]
+    fn test_perfect_stability() {
+        let history = vec![
+            create_entity(Duration::zero()),
+            create_entity(Duration::zero()),
+            create_entity(Duration::zero()),
+        ];
+
+        let gauge = EntropyGauge::default();
+        let entropy = gauge.measure(&history);
+
+        assert_eq!(entropy.retcon_count, 0);
+        assert_eq!(entropy.prophecy_count, 0);
+        assert!(entropy.drift_variance.abs() < 1e-6);
+        assert!((entropy.stability_score - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_high_retcon_count() {
+        let history = vec![
+            create_entity(Duration::seconds(-10)), // Retcon
+            create_entity(Duration::seconds(-20)), // Retcon
+            create_entity(Duration::zero()),       // Normal
+        ];
+
+        let gauge = EntropyGauge::default();
+        let entropy = gauge.measure(&history);
+
+        assert_eq!(entropy.retcon_count, 2);
+        assert_eq!(entropy.prophecy_count, 0);
+        assert!(entropy.stability_score < 0.5); // Should be low
+    }
+
+    #[test]
+    fn test_prophecy_count() {
+        let history = vec![
+            create_entity(Duration::seconds(10)), // Prophecy
+            create_entity(Duration::zero()),
+        ];
+
+        let gauge = EntropyGauge::default();
+        let entropy = gauge.measure(&history);
+
+        assert_eq!(entropy.prophecy_count, 1);
+        assert_eq!(entropy.retcon_count, 0);
+    }
+
+    #[test]
+    fn test_empty_history() {
+        let history = vec![];
+        let gauge = EntropyGauge::default();
+        let entropy = gauge.measure(&history);
+        assert_eq!(entropy.stability_score, 1.0);
+    }
+}

--- a/gallifrey/src/experimental/heatmap.rs
+++ b/gallifrey/src/experimental/heatmap.rs
@@ -124,9 +124,9 @@ impl TemporalHeatmap {
             let y_start = y_start_idx.clamp(0, y_bins - 1);
             let y_end = y_end_idx.clamp(1, y_bins);
 
-            for y in y_start..y_end {
-                for x in x_start..x_end {
-                    grid[y][x] += 1;
+            for row in grid.iter_mut().take(y_end).skip(y_start) {
+                for cell in row.iter_mut().take(x_end).skip(x_start) {
+                    *cell += 1;
                 }
             }
         }
@@ -163,7 +163,7 @@ impl TemporalHeatmap {
             self.valid_range.0, self.valid_range.1
         )
         .ok();
-        writeln!(&mut output, "Max Count: {}", max_val).ok();
+        writeln!(&mut output, "Max Count: {max_val}").ok();
         writeln!(&mut output, "┌{}┐", "─".repeat(self.x_bins)).ok();
 
         // Render rows (reversed Y to have time go up)
@@ -173,8 +173,11 @@ impl TemporalHeatmap {
                 let symbol_idx = if max_val == 0 {
                     0
                 } else {
+                    #[allow(clippy::cast_precision_loss)]
                     let normalized = (count as f64 / max_val as f64) * (symbols.len() - 1) as f64;
-                    normalized.round() as usize
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let idx = normalized.round() as usize;
+                    idx
                 };
                 write!(&mut output, "{}", symbols[symbol_idx]).ok();
             }

--- a/gallifrey/src/experimental/mod.rs
+++ b/gallifrey/src/experimental/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! # Features
 //! - `heatmap`: Temporal heatmap generation for visualizing entity history.
+//! - `entropy`: System entropy calculation for timeline stability.
 
+/// System entropy calculation.
+pub mod entropy;
 /// Temporal heatmap visualization.
 pub mod heatmap;

--- a/shell/src/dashboard.rs
+++ b/shell/src/dashboard.rs
@@ -45,7 +45,10 @@ pub mod tui {
             // 50x20 resolution for the heatmap
             let heatmap = TemporalHeatmap::new(&all_history, 50, 20);
 
-            Ok(Self { _gallifrey: gallifrey, heatmap })
+            Ok(Self {
+                _gallifrey: gallifrey,
+                heatmap,
+            })
         }
 
         /// Run the dashboard loop.
@@ -113,7 +116,9 @@ pub mod tui {
             // Title
             let title = Paragraph::new(Text::styled(
                 "🌟 Tardis Time Stream 🌟",
-                Style::default().add_modifier(Modifier::BOLD).fg(Color::Cyan),
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .fg(Color::Cyan),
             ))
             .block(Block::default().borders(Borders::ALL));
             f.render_widget(title, chunks[0]);
@@ -126,27 +131,41 @@ pub mod tui {
 
             // Heatmap
             let heatmap_str = self.heatmap.render_ascii();
-            let heatmap_widget = Paragraph::new(heatmap_str)
-                .block(Block::default().title("Bi-Temporal Activity").borders(Borders::ALL));
+            let heatmap_widget = Paragraph::new(heatmap_str).block(
+                Block::default()
+                    .title("Bi-Temporal Activity")
+                    .borders(Borders::ALL),
+            );
             f.render_widget(heatmap_widget, main_chunks[0]);
 
             // Stats
             let total_events: usize = self.heatmap.grid.iter().flatten().sum();
 
             let stats_text = vec![
-                Line::from(Span::styled("System Status", Style::default().add_modifier(Modifier::UNDERLINED))),
+                Line::from(Span::styled(
+                    "System Status",
+                    Style::default().add_modifier(Modifier::UNDERLINED),
+                )),
                 Line::from(""),
                 Line::from(format!("Entities: {total_events}")), // Rough proxy for activity
-                Line::from(format!("Valid Time: {} to {}", self.heatmap.valid_range.0.format("%H:%M"), self.heatmap.valid_range.1.format("%H:%M"))),
-                Line::from(format!("Trans Time: {} to {}", self.heatmap.transaction_range.0.format("%H:%M"), self.heatmap.transaction_range.1.format("%H:%M"))),
+                Line::from(format!(
+                    "Valid Time: {} to {}",
+                    self.heatmap.valid_range.0.format("%H:%M"),
+                    self.heatmap.valid_range.1.format("%H:%M")
+                )),
+                Line::from(format!(
+                    "Trans Time: {} to {}",
+                    self.heatmap.transaction_range.0.format("%H:%M"),
+                    self.heatmap.transaction_range.1.format("%H:%M")
+                )),
             ];
             let stats_widget = Paragraph::new(stats_text)
                 .block(Block::default().title("Stats").borders(Borders::ALL));
             f.render_widget(stats_widget, main_chunks[1]);
 
             // Footer
-            let footer = Paragraph::new("Press 'q' to exit")
-                .block(Block::default().borders(Borders::ALL));
+            let footer =
+                Paragraph::new("Press 'q' to exit").block(Block::default().borders(Borders::ALL));
             f.render_widget(footer, chunks[2]);
         }
     }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -157,7 +157,8 @@ impl Repl {
             }
             #[cfg(feature = "nova")]
             "dashboard" => {
-                match crate::dashboard::tui::Dashboard::new(std::sync::Arc::clone(&self.gallifrey)) {
+                match crate::dashboard::tui::Dashboard::new(std::sync::Arc::clone(&self.gallifrey))
+                {
                     Ok(mut dashboard) => {
                         if let Err(e) = dashboard.run() {
                             println!("Dashboard failed: {e}");

--- a/telemetry/tests/ring_buffer_race.rs
+++ b/telemetry/tests/ring_buffer_race.rs
@@ -8,7 +8,7 @@
 use std::sync::{Arc, Barrier};
 use std::thread;
 use tardis_telemetry::kernel::RingBuffer;
-use tardis_telemetry::types::{TelemetryEntry, Level, Subsystem, EventType, SpanId, TraceId};
+use tardis_telemetry::types::{EventType, Level, SpanId, Subsystem, TelemetryEntry, TraceId};
 
 #[test]
 fn race_condition_repro() {
@@ -72,12 +72,16 @@ fn race_condition_repro() {
         let payload_vec: Vec<u8> = payload;
         // Check strict equality.
         if payload_vec != expected {
-             // CORRUPTION DETECTED
-             panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
+            // CORRUPTION DETECTED
+            panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
                  t_id, i, expected.len(), payload_vec.len(), String::from_utf8_lossy(&payload_vec.iter().take(20).cloned().collect::<Vec<u8>>()));
         }
         valid_count += 1;
     }
 
-    println!("Read {} valid entries out of {} writes", valid_count, THREADS * WRITES_PER_THREAD);
+    println!(
+        "Read {} valid entries out of {} writes",
+        valid_count,
+        THREADS * WRITES_PER_THREAD
+    );
 }

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -22,7 +22,8 @@ pub type MockInference =
 pub type MockEmbedding = Box<dyn Fn(ModelHandle, &str) -> VortexResult<Vec<f32>> + Send + Sync>;
 
 /// Mock load model callback type.
-pub type MockLoadModel = Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
+pub type MockLoadModel =
+    Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
 
 /// The main Vortex inference engine.
 pub struct Vortex {


### PR DESCRIPTION
💡 **The Spark:** "If we have time travel (bi-temporal data), we need to measure how 'unstable' the timeline is. Are we constantly rewriting history?"
🚀 **The Feature:** Implemented `EntropyGauge` and `SystemEntropy`. It scans entity history and calculates the drift between Valid Time and Transaction Time.
🔮 **The Potential:** Can be used to trigger "Timeline Integrity Checks" or warn the user when the system is hallucinating (high Prophecy count) or gaslighting (high Retcon count).
⚠️ **Risk:** Low. Isolated in `src/experimental/entropy.rs`.

---
*PR created automatically by Jules for task [14398990814464689664](https://jules.google.com/task/14398990814464689664) started by @madmax983*