### PR TITLE
🌟 Nova: Entropy Gauge - Measuring Temporal Stability

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -24,3 +24,8 @@
 **Concept:** A bi-temporal narrative generator that detects "Retcons" and "Prophecies" in entity history and uses LLM to tell the story.
 **Fate:** Merged (Experimental)
 **Lesson:** Bi-temporal data is confusing; turning it into a natural language story makes it accessible to humans.
+
+## Entropy Gauge
+**Concept:** A metric for "Temporal Stability" that quantifies retcons and prophecies as system entropy.
+**Fate:** Merged (Experimental)
+**Lesson:** Visualizations (Heatmap) are great, but sometimes you just need a number (0-1) to know if your timeline is broken.

--- a/gallifrey/src/experimental/entropy.rs
+++ b/gallifrey/src/experimental/entropy.rs
@@ -1,0 +1,176 @@
+use crate::stores::KnowledgeStore;
+use chrono::Duration;
+use serde::{Deserialize, Serialize};
+
+/// Metrics representing the temporal stability of the system.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemEntropy {
+    /// Total number of entity versions analyzed.
+    pub total_versions: usize,
+    /// Number of "Retcons" (facts recorded after they became valid).
+    pub retcons: usize,
+    /// Number of "Prophecies" (facts recorded before they became valid).
+    pub prophecies: usize,
+    /// Mean temporal drift in seconds (Transaction Time - Valid Time).
+    /// Positive means we are lagging (reactive).
+    /// Negative means we are predicting (proactive).
+    pub mean_drift_seconds: f64,
+    /// Entropy score (0.0 = Stable, 1.0 = Chaotic).
+    /// Calculated based on the ratio of retcons/prophecies to total versions.
+    pub entropy_score: f64,
+}
+
+/// A gauge for measuring the temporal entropy of the Knowledge Store.
+#[derive(Debug)]
+pub struct EntropyGauge {
+    /// Threshold for considering a time difference as significant drift.
+    drift_threshold: Duration,
+}
+
+impl EntropyGauge {
+    /// Create a new Entropy Gauge with a default threshold (5 seconds).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            drift_threshold: Duration::seconds(5),
+        }
+    }
+
+    /// Set a custom drift threshold.
+    #[must_use]
+    pub const fn with_threshold(mut self, threshold: Duration) -> Self {
+        self.drift_threshold = threshold;
+        self
+    }
+
+    /// Measure the entropy of the Knowledge Store.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store lock is poisoned.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn measure(&self, store: &KnowledgeStore) -> crate::error::GallifreyResult<SystemEntropy> {
+        let mut total_versions = 0;
+        let mut retcons = 0;
+        let mut prophecies = 0;
+        let mut total_drift_ms = 0i64;
+
+        store.scan_history(|history| {
+            for entity in history {
+                total_versions += 1;
+
+                let valid_start = entity.temporal.valid_time.start;
+                let transaction_start = entity.temporal.transaction_time.start;
+
+                let drift = transaction_start - valid_start;
+                total_drift_ms += drift.num_milliseconds();
+
+                if drift > self.drift_threshold {
+                    retcons += 1;
+                } else if drift < -self.drift_threshold {
+                    prophecies += 1;
+                }
+            }
+        })?;
+
+        let mean_drift_seconds = if total_versions > 0 {
+            (total_drift_ms as f64 / total_versions as f64) / 1000.0
+        } else {
+            0.0
+        };
+
+        let unstable_count = retcons + prophecies;
+        let entropy_score = if total_versions > 0 {
+            (unstable_count as f64 / total_versions as f64).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+
+        Ok(SystemEntropy {
+            total_versions,
+            retcons,
+            prophecies,
+            mean_drift_seconds,
+            entropy_score,
+        })
+    }
+}
+
+impl Default for EntropyGauge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stores::KnowledgeStore;
+    use chrono::Utc;
+    use std::collections::HashMap;
+    use tardis_common::domain::Entity;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+
+    fn create_entity(valid_start: chrono::DateTime<Utc>, trans_start: chrono::DateTime<Utc>) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            entity_type: "Test".to_string(),
+            name: "Test".to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval {
+                valid_time: TimeRange::starting_at(valid_start),
+                transaction_time: TimeRange::starting_at(trans_start),
+            },
+            source: None,
+        }
+    }
+
+    #[test]
+    fn test_entropy_calculation() {
+        let store = KnowledgeStore::new();
+        let now = Utc::now();
+        let hour = Duration::hours(1);
+
+        // 1. Stable: Valid = Transaction (roughly)
+        let stable = create_entity(now, now);
+        store.insert_entity(stable).unwrap();
+
+        // 2. Retcon: Transaction (Now) > Valid (Last Hour)
+        // We learned about it late.
+        let retcon = create_entity(now - hour, now);
+        store.insert_entity(retcon).unwrap();
+
+        // 3. Prophecy: Valid (Next Hour) > Transaction (Now)
+        // We predicted it.
+        let prophecy = create_entity(now + hour, now);
+        store.insert_entity(prophecy).unwrap();
+
+        let gauge = EntropyGauge::new();
+        let entropy = gauge.measure(&store).unwrap();
+
+        assert_eq!(entropy.total_versions, 3);
+        assert_eq!(entropy.retcons, 1, "Should identify 1 retcon");
+        assert_eq!(entropy.prophecies, 1, "Should identify 1 prophecy");
+
+        // Retcon drift: +3600s
+        // Prophecy drift: -3600s
+        // Stable drift: 0s
+        // Mean should be roughly 0
+        assert!(entropy.mean_drift_seconds.abs() < 1.0);
+
+        // Score: 2 unstable / 3 total = 0.666...
+        assert!(entropy.entropy_score > 0.6 && entropy.entropy_score < 0.7);
+    }
+
+    #[test]
+    fn test_empty_store() {
+        let store = KnowledgeStore::new();
+        let gauge = EntropyGauge::new();
+        let entropy = gauge.measure(&store).unwrap();
+
+        assert_eq!(entropy.total_versions, 0);
+        assert_eq!(entropy.entropy_score, 0.0);
+    }
+}

--- a/gallifrey/src/experimental/heatmap.rs
+++ b/gallifrey/src/experimental/heatmap.rs
@@ -163,7 +163,7 @@ impl TemporalHeatmap {
             self.valid_range.0, self.valid_range.1
         )
         .ok();
-        writeln!(&mut output, "Max Count: {}", max_val).ok();
+        writeln!(&mut output, "Max Count: {max_val}").ok();
         writeln!(&mut output, "┌{}┐", "─".repeat(self.x_bins)).ok();
 
         // Render rows (reversed Y to have time go up)

--- a/gallifrey/src/experimental/mod.rs
+++ b/gallifrey/src/experimental/mod.rs
@@ -2,6 +2,10 @@
 //!
 //! # Features
 //! - `heatmap`: Temporal heatmap generation for visualizing entity history.
+//! - `entropy`: System entropy metrics for measuring temporal stability.
 
 /// Temporal heatmap visualization.
 pub mod heatmap;
+
+/// System entropy metrics.
+pub mod entropy;


### PR DESCRIPTION
This PR introduces the "Entropy Gauge", a new experimental feature in the Gallifrey temporal database.

**The Spark:**
While the "Temporal Heatmap" visualizes data, we lacked a quantitative metric to assess the "health" or "stability" of our timeline. High discrepancies between Valid Time (when it happened) and Transaction Time (when we recorded it) indicate a system that is either lagging (Retcons) or speculating (Prophecies).

**The Feature:**
- `EntropyGauge` struct: Configurable drift threshold (default 5s).
- `SystemEntropy` struct: Metrics for total versions, retcons, prophecies, mean drift, and an overall entropy score.
- Uses `KnowledgeStore::scan_history` to efficiently process the entire graph.

**The Potential:**
This metric can be used to trigger system alerts (e.g., "Timeline Unstable") or to auto-scale ingestion resources when retcons spike.

**Risk:**
Low. Isolated in `src/experimental/` and guarded by `#[cfg(feature = "nova")]`. It is a read-only analysis tool.

---
*PR created automatically by Jules for task [14331540447201529449](https://jules.google.com/task/14331540447201529449) started by @madmax983*