### PR TITLE
fix(chronos): implement partial context truncation in RAG augmenter

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -5,3 +5,7 @@
 **[Large Struct Testing]
 **Learning:** `Box::new(LargeStruct::new())` often overflows the stack because Rust constructs the value on the stack before moving it. For large structs like `RingBuffer` (1MB), using `static` with a `reset()` helper is a reliable pattern for property-based testing.
 **Action:** Use `static` buffers + reset logic instead of heap allocation for testing large `const fn` initialized structs.
+
+**[Naive Truncation in RAG Augmenter]
+**Learning:** Checking total length before formatting can lead to dropping the *entire* context source if it exceeds the limit, even if it's the only relevant source. RAG pipelines must be robust to oversized inputs by truncating content, not sources.
+**Action:** Always implement partial inclusion/truncation logic for variable-length inputs in prompt construction, rather than binary include/exclude.

--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -130,6 +130,7 @@ mod tests {
     use tardis_common::id::EntityId;
 
     #[tokio::test]
+    #[allow(clippy::unwrap_used)]
     async fn test_dream_cycle() {
         // 1. Setup Gallifrey
         let gallifrey = Arc::new(Gallifrey::new());
@@ -161,7 +162,7 @@ mod tests {
         conv_store.add_message(msg2).unwrap();
 
         // 3. Create Dreamer
-        let dreamer = Dreamer::new(gallifrey.clone(), Box::new(MockDreamCatcher::default()));
+        let dreamer = Dreamer::new(gallifrey.clone(), Box::new(MockDreamCatcher));
 
         // 4. Dream!
         let result = dreamer.dream().await;

--- a/chronos/src/experimental/echoes.rs
+++ b/chronos/src/experimental/echoes.rs
@@ -33,7 +33,7 @@ pub struct EchoChamber {
 impl EchoChamber {
     /// Create a new `EchoChamber`.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self { vortex, gallifrey }
     }
 
@@ -88,6 +88,7 @@ impl EchoChamber {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use tardis_common::domain::{Entity, Message};

--- a/chronos/src/experimental/historian.rs
+++ b/chronos/src/experimental/historian.rs
@@ -71,7 +71,7 @@ pub struct Historian {
 impl Historian {
     /// Create a new `Historian`.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self { vortex, gallifrey }
     }
 
@@ -156,6 +156,7 @@ impl Historian {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use tardis_common::domain::Entity;
@@ -175,7 +176,7 @@ mod tests {
 
         let gallifrey = Arc::new(Gallifrey::new());
         let id = EntityId::new();
-        setup_history(&gallifrey, id).await;
+        setup_history(&gallifrey, id);
 
         let historian = Historian::new(vortex, gallifrey);
 
@@ -184,7 +185,7 @@ mod tests {
     }
 
     // Helper to setup history
-    async fn setup_history(gallifrey: &Gallifrey, id: EntityId) {
+    fn setup_history(gallifrey: &Gallifrey, id: EntityId) {
         let now = Utc::now();
         let ten_mins_ago = now - chrono::Duration::seconds(600);
         let five_mins_ago = now - chrono::Duration::seconds(300);
@@ -224,7 +225,7 @@ mod tests {
         let vortex = Arc::new(Vortex::new().unwrap());
         let gallifrey = Arc::new(Gallifrey::new());
         let id = EntityId::new();
-        setup_history(&gallifrey, id).await;
+        setup_history(&gallifrey, id);
 
         let historian = Historian::new(vortex, gallifrey);
 

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -26,7 +26,7 @@ pub struct Prophet {
 impl Prophet {
     /// Create a new Prophet.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>) -> Self {
         Self {
             vortex,
             paper: PsychicPaper::new(),
@@ -130,6 +130,7 @@ impl Prophet {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 pub enum Intent {
     /// Try to infer the format using a best-effort heuristic:
     /// 1. Check for JSON start characters `{` or `[`.
-    /// 2. Check for Markdown code blocks (````json`).
+    /// 2. Check for Markdown code blocks (starting with `json`).
     /// 3. Check for list markers (`-` or `*`).
     /// 4. Check for Key-Value pairs (majority of lines have `:`).
     /// 5. Fallback to raw string.
@@ -215,6 +215,7 @@ impl PsychicPaper {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -138,22 +138,61 @@ impl ContextAugmenter {
         let mut token_estimate = 0;
 
         for (i, source) in context.iter().enumerate() {
-            // Rough token estimate (4 chars per token)
-            let source_tokens = source.content.len() / 4;
-            if token_estimate + source_tokens > self.max_context_tokens {
-                let _ = writeln!(
-                    formatted,
-                    "\n... ({} more sources truncated)",
-                    context.len() - i
-                );
-                break;
-            }
+            // Rough token estimate (4 chars per token).
+            // Use ceiling division to ensure at least 1 token for non-empty content.
+            let source_len = source.content.len();
+            let source_tokens = if source_len == 0 {
+                0
+            } else {
+                source_len.div_ceil(4)
+            };
 
             let source_type = match source.source_type {
                 ContextSourceType::Knowledge => "Knowledge",
                 ContextSourceType::Conversation => "Conversation",
                 ContextSourceType::SystemState => "System State",
             };
+
+            if token_estimate + source_tokens > self.max_context_tokens {
+                // Determine remaining budget
+                let remaining_tokens = self.max_context_tokens.saturating_sub(token_estimate);
+
+                // If we have a reasonable amount of space left (e.g., > 10 tokens), include partial content
+                let included_partial = if remaining_tokens > 10 {
+                    let allowed_chars = remaining_tokens * 4;
+                    // Safe truncation using char iterator
+                    let truncated_content: String = source
+                        .content
+                        .chars()
+                        .take(allowed_chars)
+                        .collect();
+
+                    let _ = writeln!(
+                        formatted,
+                        "### {source_type} {} (relevance: {:.2})\n{}... (truncated)\n",
+                        i + 1,
+                        source.relevance,
+                        truncated_content
+                    );
+                    true
+                } else {
+                    false
+                };
+
+                let remaining_sources = if included_partial {
+                    context.len() - (i + 1)
+                } else {
+                    context.len() - i
+                };
+
+                if remaining_sources > 0 {
+                    let _ = writeln!(
+                        formatted,
+                        "\n... ({remaining_sources} more sources truncated)"
+                    );
+                }
+                break;
+            }
 
             let _ = writeln!(
                 formatted,
@@ -204,5 +243,79 @@ impl ContextAugmenter {
 impl Default for ContextAugmenter {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::pipeline::analyzer::QueryIntent;
+
+    fn mock_analysis(intent: QueryIntent) -> AnalyzedQuery {
+        AnalyzedQuery {
+            text: "test query".to_string(),
+            intent,
+            temporal_refs: vec![],
+            temporal_description: None,
+            entities: vec![],
+        }
+    }
+
+    #[test]
+    fn should_include_partial_context_when_source_is_too_large() {
+        let augmenter = ContextAugmenter::new();
+        // max_context_tokens = 4096
+        // 4096 * 4 = 16384 chars.
+        // Let's create a source with 20000 chars.
+        let huge_content = "a".repeat(20000);
+        let context = vec![ContextSource {
+            source_type: ContextSourceType::Knowledge,
+            content: huge_content.clone(),
+            relevance: 1.0,
+            entity_id: None,
+        }];
+
+        let analysis = mock_analysis(QueryIntent::Question);
+        let result = augmenter.augment("test", &context, &analysis).unwrap();
+
+        // Currently, this will fail because the source is dropped entirely.
+        // We expect it to contain at least some of the content.
+        assert!(result.contains(&"a".repeat(100)), "Should contain partial content");
+    }
+
+    #[test]
+    fn should_respect_max_tokens_with_multiple_sources() {
+        let augmenter = ContextAugmenter::new();
+        // Create 6 sources of ~1000 tokens each.
+        // Total 6000 tokens > 4096.
+        // 0-3 take ~4012 tokens.
+        // 4 takes remaining ~84 tokens (partial).
+        // 5 is fully truncated.
+
+        let filler = "a".repeat(4000); // ~1000 tokens
+        let context: Vec<ContextSource> = (0..6).map(|i| ContextSource {
+            source_type: ContextSourceType::Knowledge,
+            content: format!("Source {i}: {filler}"),
+            relevance: 1.0,
+            entity_id: None,
+        }).collect();
+
+        let analysis = mock_analysis(QueryIntent::Question);
+        let result = augmenter.augment("test", &context, &analysis).unwrap();
+
+        assert!(result.contains("Source 0"));
+        assert!(result.contains("Source 1"));
+        assert!(result.contains("Source 2"));
+        assert!(result.contains("Source 3"));
+        // Source 4 should be partially included because we have ~84 tokens budget left
+        assert!(result.contains("Source 4"), "Should contain partial Source 4");
+        // Source 5 should be fully truncated
+        assert!(!result.contains("Source 5"), "Should not contain Source 5");
+
+        // Check for truncation messages
+        // "Source 4 ... (truncated)"
+        // "... (1 more sources truncated)" (Source 5)
+        assert!(result.contains("(truncated)"));
     }
 }

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -16,7 +16,7 @@ pub struct Retriever {
 impl Retriever {
     /// Create a new retriever.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
         Self { gallifrey }
     }
 

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -55,7 +55,7 @@ impl std::fmt::Debug for Vortex {
                 "model_configs_count",
                 &self.model_configs.read().map(|c| c.len()).unwrap_or(0),
             )
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
This PR addresses a critical flaw in the `ContextAugmenter` where a single large context source could cause the entire context to be dropped. It introduces logic to partially include such sources by truncating them to fit the remaining token budget. It also includes general code hygiene improvements across `chronos` and `vortex` to satisfy clippy and Sentry guidelines.

---
*PR created automatically by Jules for task [3538324944795506540](https://jules.google.com/task/3538324944795506540) started by @madmax983*