### PR TITLE
⚡ Bolt: Hoist string allocation in QueryAnalyzer

### DIFF
--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -154,8 +154,10 @@ impl QueryAnalyzer {
     ///
     /// Returns an error if analysis fails.
     pub fn analyze(&self, query: &str) -> ChronosResult<AnalyzedQuery> {
-        let intent = self.classify_intent(query);
-        let temporal_refs = self.extract_temporal_refs(query, Utc::now());
+        // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
+        let query_lower = query.to_lowercase();
+        let intent = self.classify_intent(&query_lower);
+        let temporal_refs = self.extract_temporal_refs(&query_lower, Utc::now());
         let entities = self.extract_entities(query);
 
         let temporal_description = if temporal_refs.is_empty() {
@@ -175,16 +177,14 @@ impl QueryAnalyzer {
 
     /// Classify the intent of a query.
     #[allow(clippy::unused_self)]
-    fn classify_intent(&self, query: &str) -> QueryIntent {
-        let lower = query.to_lowercase();
-
+    fn classify_intent(&self, query_lower: &str) -> QueryIntent {
         for rule in INTENT_RULES {
-            if rule.matches(&lower) {
+            if rule.matches(query_lower) {
                 return rule.intent.clone();
             }
         }
 
-        if lower.ends_with('?') {
+        if query_lower.ends_with('?') {
             return QueryIntent::Question;
         }
 
@@ -193,12 +193,15 @@ impl QueryAnalyzer {
 
     /// Extract temporal references from a query.
     #[allow(clippy::unused_self)]
-    fn extract_temporal_refs(&self, query: &str, now: DateTime<Utc>) -> Vec<TemporalReference> {
+    fn extract_temporal_refs(
+        &self,
+        query_lower: &str,
+        now: DateTime<Utc>,
+    ) -> Vec<TemporalReference> {
         let mut refs = Vec::new();
-        let lower = query.to_lowercase();
 
         for rule in TEMPORAL_RULES {
-            if lower.contains(rule.keyword) {
+            if query_lower.contains(rule.keyword) {
                 let resolved = rule.resolve(now);
 
                 refs.push(TemporalReference::Relative {
@@ -268,42 +271,45 @@ mod tests {
         let analyzer = QueryAnalyzer::new();
 
         assert_eq!(
-            analyzer.classify_intent("Remember that I like pizza"),
+            analyzer.classify_intent(&"Remember that I like pizza".to_lowercase()),
             QueryIntent::Remember
         );
         assert_eq!(
-            analyzer.classify_intent("Please remember this conversation"),
+            analyzer.classify_intent(&"Please remember this conversation".to_lowercase()),
             QueryIntent::Remember
         );
         assert_eq!(
-            analyzer.classify_intent("What did we discuss yesterday?"),
+            analyzer.classify_intent(&"What did we discuss yesterday?".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent("Recall the meeting notes"),
+            analyzer.classify_intent(&"Recall the meeting notes".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent("What was the result?"),
+            analyzer.classify_intent(&"What was the result?".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent("How has the project changed?"),
+            analyzer.classify_intent(&"How has the project changed?".to_lowercase()),
             QueryIntent::TemporalDiff
         );
         assert_eq!(
-            analyzer.classify_intent("Show me the system state"),
+            analyzer.classify_intent(&"Show me the system state".to_lowercase()),
             QueryIntent::SystemQuery
         );
         assert_eq!(
-            analyzer.classify_intent("Take a snapshot"),
+            analyzer.classify_intent(&"Take a snapshot".to_lowercase()),
             QueryIntent::SystemQuery
         );
         assert_eq!(
-            analyzer.classify_intent("Is this a question?"),
+            analyzer.classify_intent(&"Is this a question?".to_lowercase()),
             QueryIntent::Question
         );
-        assert_eq!(analyzer.classify_intent("Just chatting"), QueryIntent::Chat);
+        assert_eq!(
+            analyzer.classify_intent(&"Just chatting".to_lowercase()),
+            QueryIntent::Chat
+        );
     }
 
     #[test]
@@ -311,7 +317,7 @@ mod tests {
         let analyzer = QueryAnalyzer::new();
         let now = Utc::now();
 
-        let refs = analyzer.extract_temporal_refs("What happened yesterday?", now);
+        let refs = analyzer.extract_temporal_refs(&"What happened yesterday?".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
 
         match &refs[0] {
@@ -319,21 +325,21 @@ mod tests {
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs("Check last week logs", now);
+        let refs = analyzer.extract_temporal_refs(&"Check last week logs".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "last week"),
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs("Do it today", now);
+        let refs = analyzer.extract_temporal_refs(&"Do it today".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "today"),
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs("Yesterday and today", now);
+        let refs = analyzer.extract_temporal_refs(&"Yesterday and today".to_lowercase(), now);
         assert_eq!(refs.len(), 2);
     }
 


### PR DESCRIPTION
This PR optimizes the `QueryAnalyzer` in `chronos` by hoisting the `to_lowercase()` string allocation out of the internal helper methods (`classify_intent`, `extract_temporal_refs`) and into the main `analyze` method. This ensures that the query string is allocated and lowercased only once per analysis request, rather than twice.

## Changes
- `chronos/src/pipeline/analyzer.rs`:
    - `analyze`: Compute `query_lower` once.
    - `classify_intent`: Accept `query_lower: &str` instead of `query: &str`.
    - `extract_temporal_refs`: Accept `query_lower: &str` instead of `query: &str`.
    - Tests updated to manually lowercase inputs for unit tests of private methods.

## Impact
- Reduces heap allocations by 1 `String` per query analysis.
- Zero functional change (refactor only).


---
*PR created automatically by Jules for task [16448075247817992412](https://jules.google.com/task/16448075247817992412) started by @madmax983*