### PR TITLE
🔒 Warden: Fix UB in RingBuffer enum reads

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -10,3 +10,7 @@
 
 **Threat:** `unsafe` port I/O in `serial.rs`.
 **Defense:** Added safety comments explaining that port I/O is restricted to kernel features and guarded by initialization checks.
+
+**2025-06-01 - RingBuffer Enum Safety**
+**Threat:** `RingBuffer` used `ptr::read_volatile` to read `TelemetryEntry` structs containing Rust enums (`Level`, `Subsystem`, `EventType`) directly from potentially corrupted shared memory. Reading an invalid discriminant (e.g., `5` for `Level`) is immediate Undefined Behavior.
+**Defense:** Introduced `TelemetryEntryRaw` with integer fields to mirror the memory layout. Modified `RingBuffer` to read raw integers first, then safely convert them to valid enum variants (mapping invalid values to `Info`/`Unknown`), eliminating the UB risk.

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -45,6 +45,70 @@ const RING_BUFFER_MASK: usize = RING_BUFFER_SIZE - 1;
 /// Maximum payload size per entry.
 pub const MAX_PAYLOAD_SIZE: usize = 192;
 
+/// Raw telemetry entry for safe storage in ring buffer.
+///
+/// This struct mirrors `TelemetryEntry` but uses primitive types for enums
+/// to prevent Undefined Behavior when reading potentially corrupted memory.
+///
+/// # Layout
+///
+/// Must match `TelemetryEntry` layout exactly:
+/// - `timestamp_ns`: u64 (offset 0)
+/// - `level`: u8 (offset 8)
+/// - `padding`: u8 (offset 9)
+/// - `subsystem`: u16 (offset 10)
+/// - `event_type`: u16 (offset 12)
+/// - `span_id`: [u8; 8] (offset 14)
+/// - `trace_id`: [u8; 16] (offset 22)
+/// - `parent_span_id`: [u8; 8] (offset 38)
+/// - `payload_len`: u16 (offset 46)
+///
+/// Total size: 48 bytes.
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct TelemetryEntryRaw {
+    timestamp_ns: u64,
+    level: u8,
+    _pad: u8, // Explicit padding to match compiler layout for align(2) of subsystem
+    subsystem: u16,
+    event_type: u16,
+    span_id: SpanId,
+    trace_id: TraceId,
+    parent_span_id: SpanId,
+    payload_len: u16,
+}
+
+impl From<TelemetryEntry> for TelemetryEntryRaw {
+    fn from(entry: TelemetryEntry) -> Self {
+        Self {
+            timestamp_ns: entry.timestamp_ns,
+            level: entry.level as u8,
+            _pad: 0,
+            subsystem: entry.subsystem as u16,
+            event_type: entry.event_type as u16,
+            span_id: entry.span_id,
+            trace_id: entry.trace_id,
+            parent_span_id: entry.parent_span_id,
+            payload_len: entry.payload_len,
+        }
+    }
+}
+
+impl From<TelemetryEntryRaw> for TelemetryEntry {
+    fn from(raw: TelemetryEntryRaw) -> Self {
+        Self {
+            timestamp_ns: raw.timestamp_ns,
+            level: Level::from(raw.level),
+            subsystem: Subsystem::from(raw.subsystem),
+            event_type: EventType::from(raw.event_type),
+            span_id: raw.span_id,
+            trace_id: raw.trace_id,
+            parent_span_id: raw.parent_span_id,
+            payload_len: raw.payload_len,
+        }
+    }
+}
+
 /// Entry slot in the ring buffer.
 ///
 /// Each slot is cache-line aligned to prevent false sharing between
@@ -58,7 +122,7 @@ pub struct RingSlot {
     sequence: AtomicUsize,
 
     /// Telemetry entry header.
-    entry: UnsafeCell<TelemetryEntry>,
+    entry: UnsafeCell<TelemetryEntryRaw>,
 
     /// Inline payload storage.
     payload: UnsafeCell<[u8; MAX_PAYLOAD_SIZE]>,
@@ -69,11 +133,13 @@ impl RingSlot {
     const fn new() -> Self {
         Self {
             sequence: AtomicUsize::new(0),
-            entry: UnsafeCell::new(TelemetryEntry {
+            // Use raw entry for storage to ensure memory safety
+            entry: UnsafeCell::new(TelemetryEntryRaw {
                 timestamp_ns: 0,
-                level: Level::Trace,
-                subsystem: Subsystem::Unknown,
-                event_type: EventType::Unknown,
+                level: 0, // Level::Trace
+                _pad: 0,
+                subsystem: 255, // Subsystem::Unknown
+                event_type: 65535, // EventType::Unknown
                 span_id: SpanId::NONE,
                 trace_id: TraceId::NONE,
                 parent_span_id: SpanId::NONE,
@@ -214,7 +280,9 @@ impl RingBuffer {
         // without atomic overhead for the bulk data.
         unsafe {
             let entry_ptr = slot.entry.get();
-            core::ptr::write_volatile(entry_ptr, entry.clone());
+            // Convert to raw representation for safe storage
+            let raw_entry = TelemetryEntryRaw::from(entry.clone());
+            core::ptr::write_volatile(entry_ptr, raw_entry);
 
             // Write payload
             let payload_len = payload.len().min(MAX_PAYLOAD_SIZE);
@@ -343,7 +411,10 @@ impl RingBuffer {
             // Volatile access tells the compiler to treat this as external I/O memory.
             let entry = unsafe {
                 let entry_ptr = slot.entry.get();
-                core::ptr::read_volatile(entry_ptr)
+                // Read as raw bytes/integers to avoid UB from invalid enum variants
+                let raw_entry = core::ptr::read_volatile(entry_ptr);
+                // Convert to safe TelemetryEntry (maps invalid values to defaults)
+                TelemetryEntry::from(raw_entry)
             };
 
             // Cap payload length to prevent buffer overread/overflow if header is corrupted
@@ -733,6 +804,51 @@ mod tests {
             } else {
                 panic!("Buffer should not be empty");
             }
+        }
+    }
+
+    #[test]
+    fn ring_buffer_invalid_enum_safety() {
+        // Use static to avoid stack overflow
+        static BUFFER: RingBuffer = RingBuffer::new();
+
+        // 1. Manually write invalid enum values to a slot
+        unsafe {
+            let slot = &BUFFER.slots[0];
+            let entry_ptr = slot.entry.get(); // *mut TelemetryEntryRaw
+
+            // Construct a raw entry with invalid values
+            let invalid_raw = TelemetryEntryRaw {
+                timestamp_ns: 12345,
+                level: 255, // Invalid Level
+                _pad: 0,
+                subsystem: 65000, // Invalid Subsystem
+                event_type: 60000, // Invalid EventType
+                span_id: SpanId::NONE,
+                trace_id: TraceId::NONE,
+                parent_span_id: SpanId::NONE,
+                payload_len: 0,
+            };
+
+            core::ptr::write_volatile(entry_ptr, invalid_raw);
+
+            // Mark slot as ready to read (seq 2)
+            slot.sequence.store(2, Ordering::Release);
+
+            // Ensure write_pos allows reading (write_pos = 1)
+            BUFFER.write_pos.store(1, Ordering::Relaxed);
+        }
+
+        // 2. Try to read using safe API
+        // This should NOT panic or crash.
+        // It should return a valid TelemetryEntry with mapped safe values.
+        if let Some((read_entry, _)) = BUFFER.try_read() {
+            assert_eq!(read_entry.timestamp_ns, 12345);
+            assert_eq!(read_entry.level, Level::Info); // Mapped from 255
+            assert_eq!(read_entry.subsystem, Subsystem::Unknown); // Mapped from 65000
+            assert_eq!(read_entry.event_type, EventType::Unknown); // Mapped from 60000
+        } else {
+            panic!("Should have returned an entry");
         }
     }
 }

--- a/telemetry/src/log.rs
+++ b/telemetry/src/log.rs
@@ -38,6 +38,19 @@ impl Level {
     }
 }
 
+impl From<u8> for Level {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Self::Trace,
+            1 => Self::Debug,
+            3 => Self::Warn,
+            4 => Self::Error,
+            // Map invalid levels (and 2/Info) to Info to avoid noise but prevent UB
+            _ => Self::Info,
+        }
+    }
+}
+
 impl fmt::Display for Level {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())

--- a/telemetry/src/meta.rs
+++ b/telemetry/src/meta.rs
@@ -139,6 +139,25 @@ impl fmt::Display for Subsystem {
     }
 }
 
+impl From<u16> for Subsystem {
+    fn from(value: u16) -> Self {
+        match value {
+            0 => Self::Kernel,
+            1 => Self::Memory,
+            2 => Self::Scheduler,
+            3 => Self::Interrupt,
+            4 => Self::Syscall,
+            5 => Self::Boot,
+            100 => Self::Vortex,
+            101 => Self::Gallifrey,
+            102 => Self::Chronos,
+            103 => Self::Shell,
+            104 => Self::Telemetry,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 /// Event type within a subsystem.
 ///
 /// Provides fine-grained categorization of telemetry events.
@@ -265,6 +284,44 @@ impl EventType {
 impl fmt::Display for EventType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+impl From<u16> for EventType {
+    fn from(value: u16) -> Self {
+        match value {
+            0 => Self::SpanStart,
+            1 => Self::SpanEnd,
+            2 => Self::Log,
+            3 => Self::Metric,
+            100 => Self::Boot,
+            101 => Self::Panic,
+            102 => Self::SyscallEntry,
+            103 => Self::SyscallExit,
+            104 => Self::PageFault,
+            105 => Self::InterruptReceived,
+            106 => Self::ContextSwitch,
+            200 => Self::ModelLoad,
+            201 => Self::ModelUnload,
+            202 => Self::InferenceStart,
+            203 => Self::InferenceEnd,
+            204 => Self::TokenGenerated,
+            205 => Self::EmbeddingComputed,
+            300 => Self::QueryStart,
+            301 => Self::QueryEnd,
+            302 => Self::EntityInsert,
+            303 => Self::EntityUpdate,
+            304 => Self::TimeTravel,
+            305 => Self::SnapshotTaken,
+            400 => Self::RagQuery,
+            401 => Self::Retrieval,
+            402 => Self::Augmentation,
+            403 => Self::Consolidation,
+            500 => Self::UserInput,
+            501 => Self::IntentClassified,
+            502 => Self::ResponseGenerated,
+            _ => Self::Unknown,
+        }
     }
 }
 


### PR DESCRIPTION
Hardened the `RingBuffer` implementation against Undefined Behavior caused by reading invalid enum discriminants from shared memory. Introduced `TelemetryEntryRaw` to safely read primitive types before converting to strong enum types with validation/fallback logic.

---
*PR created automatically by Jules for task [17355346295355078323](https://jules.google.com/task/17355346295355078323) started by @madmax983*