### PR TITLE
Clarify Bi-Temporal Updates and Mock Inference Documentation

### DIFF
--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -142,6 +142,12 @@ impl Chronos {
     /// 3. **Augmentation**: The context is formatted into a prompt for the LLM.
     /// 4. **Inference**: The LLM generates a response based on the augmented prompt.
     ///
+    /// # ⚠️ Mock Implementation
+    ///
+    /// Currently, the inference step is **mocked**. It will return a static string
+    /// indicating what *would* have been sent to the LLM, along with the retrieved context items.
+    /// This is temporary while the `vortex` crate is being integrated.
+    ///
     /// # Errors
     ///
     /// Returns an error if any stage of the pipeline fails, such as:

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -169,15 +169,20 @@ impl KnowledgeStore {
 
     /// Update an entity (creates new version).
     ///
-    /// This operation is **non-destructive** (bi-temporal). It:
-    /// 1. Finds the current version of the entity.
-    /// 2. Marks it as superseded by closing its **Transaction Time** end date to `now`.
-    ///    - This preserves the record that "we *used* to believe X was true until now".
-    /// 3. Creates a new version with the updates.
-    ///    - **Transaction Time** starts `now` (we are recording this change now).
-    ///    - **Valid Time** is reset to `now` (the new fact is true from now on).
+    /// This operation is **non-destructive** (bi-temporal). It implements the "Update" pattern:
+    /// 1. **Supersede Old Version**: The current version is marked as "historical" by closing its
+    ///    **Transaction Time** at `now`. Its **Valid Time** remains unchanged (it *was* true).
+    /// 2. **Create New Version**: A copy is created with the updated properties.
+    ///    - **Transaction Time**: Starts `now` (we believe this new version as of now).
+    ///    - **Valid Time**: Starts `now` (this new state is effective from now on).
     ///
-    /// The result is a complete audit trail of every change and correction.
+    /// The result is a chain of versions where:
+    /// - `Version 1`: Valid [T0, ∞), Known [T0, T1)
+    /// - `Version 2`: Valid [T1, ∞), Known [T1, ∞)
+    ///
+    /// Use this for state changes (e.g., status changed from "Active" to "Inactive").
+    /// For correcting mistakes in the past (e.g., "it was actually Inactive since yesterday"),
+    /// you would need a "Correction" operation (not yet exposed via this helper).
     ///
     /// # Examples
     ///
@@ -190,22 +195,29 @@ impl KnowledgeStore {
     ///
     /// let store = KnowledgeStore::new();
     /// let id = EntityId::new();
-    /// let entity = Entity {
-    ///     id,
-    ///     entity_type: "Person".to_string(),
-    ///     name: "Rose".to_string(),
-    ///     properties: HashMap::new(),
-    ///     embedding: None,
-    ///     temporal: BiTemporalInterval::now(),
-    ///     source: None,
-    /// };
-    /// store.insert_entity(entity).unwrap();
+    /// # let entity = Entity {
+    /// #     id,
+    /// #     entity_type: "Person".to_string(),
+    /// #     name: "Rose".to_string(),
+    /// #     properties: HashMap::new(),
+    /// #     embedding: None,
+    /// #     temporal: BiTemporalInterval::now(),
+    /// #     source: None,
+    /// # };
+    /// # store.insert_entity(entity).unwrap();
     ///
-    /// // Update a property
+    /// // 1. Original state: "Rose" (Version 1)
+    ///
+    /// // 2. Update status to "Bad Wolf"
     /// let mut updates = HashMap::new();
     /// updates.insert("status".to_string(), json!("Bad Wolf"));
+    /// store.update_entity(id, updates).unwrap();
     ///
-    /// assert!(store.update_entity(id, updates).is_ok());
+    /// // 3. Verify history
+    /// let history = store.get_entity_history(id).unwrap();
+    /// assert_eq!(history.len(), 2);
+    /// assert!(!history[0].temporal.transaction_time.is_current()); // Old version superseded
+    /// assert!(history[1].temporal.transaction_time.is_current());  // New version active
     /// ```
     ///
     /// # Errors
@@ -233,7 +245,6 @@ impl KnowledgeStore {
 
         // Create new version with updates
         let mut new_version = current.clone();
-        new_version.temporal = current.temporal.supersede();
         for (key, value) in updates {
             new_version.properties.insert(key, value);
         }

--- a/gallifrey/tests/bi_temporal_update.rs
+++ b/gallifrey/tests/bi_temporal_update.rs
@@ -1,0 +1,66 @@
+//! Bi-temporal update regression tests.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use tardis_gallifrey::stores::{KnowledgeStore, Entity};
+use tardis_common::id::EntityId;
+use tardis_common::temporal::BiTemporalInterval;
+use std::collections::HashMap;
+use serde_json::json;
+
+#[test]
+fn test_bi_temporal_update_logic() {
+    let store = KnowledgeStore::new();
+    let id = EntityId::new();
+    let entity = Entity {
+        id,
+        entity_type: "Test".to_string(),
+        name: "Test Entity".to_string(),
+        properties: HashMap::from([
+            ("version".to_string(), json!(1))
+        ]),
+        embedding: None,
+        temporal: BiTemporalInterval::now(),
+        source: None,
+    };
+
+    // 1. Insert original entity
+    store.insert_entity(entity.clone()).expect("Insert failed");
+
+    // 2. Wait a tiny bit to ensure timestamps differ (though not strictly necessary with superseding)
+    std::thread::sleep(std::time::Duration::from_millis(1));
+
+    // 3. Update entity
+    let mut updates = HashMap::new();
+    updates.insert("version".to_string(), json!(2));
+    store.update_entity(id, updates).expect("Update failed");
+
+    // 4. Inspect history directly (using get_entity_history which returns all versions)
+    let history = store.get_entity_history(id).expect("Get history failed");
+
+    // We expect 2 versions:
+    // - Version 1: Transaction Time closed (superseded)
+    // - Version 2: Transaction Time open (current)
+    assert_eq!(history.len(), 2, "Should have 2 versions");
+
+    let v1 = &history[0];
+    let v2 = &history[1];
+
+    // Check V1 (Old)
+    assert_eq!(v1.properties.get("version").unwrap(), &json!(1));
+    assert!(!v1.temporal.transaction_time.is_current(), "V1 transaction time should be closed");
+    assert!(v1.temporal.transaction_time.end.is_some(), "V1 should have end time");
+
+    // Check V2 (New)
+    assert_eq!(v2.properties.get("version").unwrap(), &json!(2));
+    assert!(v2.temporal.transaction_time.is_current(), "V2 transaction time should be open");
+    assert!(v2.temporal.transaction_time.end.is_none(), "V2 should not have end time");
+
+    // Check Valid Time
+    // V2's valid time should start at 'now' (when update happened)
+    // V1's valid time should be unchanged from creation.
+    // V2 transaction time starts at 'now'.
+
+    assert!(v2.temporal.valid_time.start > v1.temporal.valid_time.start, "V2 valid time should be strictly greater than V1");
+    assert!(v2.temporal.transaction_time.start > v1.temporal.transaction_time.start, "V2 transaction time should be strictly greater than V1");
+}


### PR DESCRIPTION
*   **Gallifrey**: Fixed redundant logic in `KnowledgeStore::update_entity` and improved documentation to explain the bi-temporal update pattern (Supersede vs Update).
*   **Chronos**: Documented the current mock implementation of the inference stage in `Chronos::query` to manage user expectations.
*   **Tests**: Added robust regression test `gallifrey/tests/bi_temporal_update.rs` to verify timestamp handling during updates.

---
*PR created automatically by Jules for task [136115045871264578](https://jules.google.com/task/136115045871264578) started by @madmax983*