### PR TITLE
🗺️ Atlas: Decouple telemetry from common and std

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -48,3 +48,11 @@
 2. Refactored `chronos::pipeline::analyzer` to use `common::temporal::TemporalReference`.
 3. Updated consumers (`retriever`, `augmenter`) to use the shared type.
 **Stability:** Removed duplicate types, enforced consistency across crates.
+
+**[Architect] Decouple Telemetry from Std**
+**Tangle:** `telemetry` crate depended unconditionally on `tardis-common` (std-only) and `chrono` (std-default), preventing `kernel` usage.
+**Blueprint:**
+1. Made `tardis-common` and `chrono` optional dependencies in `telemetry`.
+2. Configured `serde` and `serde_json` for `no_std` environments.
+3. Updated `std` feature to enable these dependencies.
+**Stability:** Enables `telemetry` to be used in `kernel` (no_std) while retaining full functionality in userspace.

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -21,6 +21,10 @@ std = [
     "dep:parking_lot",
     "dep:once_cell",
     "dep:tardis-gallifrey",
+    "dep:tardis-common",
+    "dep:chrono",
+    "serde/std",
+    "serde_json/std",
 ]
 
 # OpenTelemetry export support
@@ -36,7 +40,8 @@ kernel = []
 
 [dependencies]
 # Core (always available, no_std compatible)
-tardis-common = { path = "../common" }
+# tardis-common moved to optional for no_std support
+tardis-common = { path = "../common", optional = true }
 
 # Userspace dependencies (behind "std" feature)
 tracing = { workspace = true, optional = true }
@@ -47,11 +52,14 @@ once_cell = { version = "1.19", optional = true }
 tardis-gallifrey = { path = "../gallifrey", optional = true }
 
 # Time handling
-chrono = { workspace = true }
+# chrono default features include std, so disable them
+chrono = { workspace = true, optional = true, default-features = false, features = ["serde"] }
 
 # Serialization
-serde = { workspace = true }
-serde_json = { workspace = true }
+# serde default features include std, so disable them
+serde = { workspace = true, default-features = false, features = ["derive"] }
+# serde_json default features include std, so disable them. Enable alloc for no_std usage (if any).
+serde_json = { workspace = true, default-features = false, features = ["alloc"] }
 
 # Error handling
 thiserror = { workspace = true }


### PR DESCRIPTION
Decoupled `tardis-telemetry` from `tardis-common` and `chrono` (which require `std` by default) to enable `no_std` builds for the kernel. Configured `serde` and `serde_json` to support `no_std` environments. This ensures the telemetry crate can be used in the kernel while retaining full functionality in userspace when the `std` feature is enabled.


---
*PR created automatically by Jules for task [3605617975441381440](https://jules.google.com/task/3605617975441381440) started by @madmax983*