### PR TITLE
feat(gallifrey): add tests for SystemStateStore

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -13,3 +13,7 @@
 **[RAG Context Truncation]
 **Learning:** Naive token limit checks that discard entire sources when they overflow can severely limit context utilization, especially with large documents or small token budgets. Partial truncation (e.g., `chars().take()`) allows filling the remaining budget effectively.
 **Action:** When implementing token-limited buffers, always implement partial filling logic rather than binary include/exclude decisions.
+
+**[Data Enum PartialEq]
+**Learning:** `assert_eq!` requires `PartialEq`, but complex domain types (like `SnapshotTrigger`) often lack it. Instead of modifying core crates (risking global recompilation), `matches!(val, Variant)` is a robust, non-invasive alternative for testing enum variants.
+**Action:** Default to `matches!` for enum variant testing when `PartialEq` is missing to minimize cross-crate dependencies.

--- a/chronos/src/experimental/echoes.rs
+++ b/chronos/src/experimental/echoes.rs
@@ -103,26 +103,32 @@ mod tests {
         let gallifrey = Arc::new(Gallifrey::new());
 
         // Setup Knowledge
-        gallifrey.knowledge().insert_entity(Entity {
-            id: EntityId::new(),
-            entity_type: "Fact".to_string(),
-            name: "Previous System Crash".to_string(),
-            properties: std::collections::HashMap::new(),
-            embedding: Some(vec![0.1, 0.2, 0.3]),
-            temporal: BiTemporalInterval::now(),
-            source: None,
-        }).unwrap();
+        gallifrey
+            .knowledge()
+            .insert_entity(Entity {
+                id: EntityId::new(),
+                entity_type: "Fact".to_string(),
+                name: "Previous System Crash".to_string(),
+                properties: std::collections::HashMap::new(),
+                embedding: Some(vec![0.1, 0.2, 0.3]),
+                temporal: BiTemporalInterval::now(),
+                source: None,
+            })
+            .unwrap();
 
         // Setup Conversation
-        gallifrey.conversation().add_message(Message {
-            id: EntityId::new(),
-            session_id: SessionId::new(),
-            role: tardis_common::domain::Role::User,
-            content: "I remember when the system crashed".to_string(),
-            timestamp: Utc::now(),
-            embedding: Some(vec![0.1, 0.2, 0.3]),
-            entity_refs: vec![],
-        }).unwrap();
+        gallifrey
+            .conversation()
+            .add_message(Message {
+                id: EntityId::new(),
+                session_id: SessionId::new(),
+                role: tardis_common::domain::Role::User,
+                content: "I remember when the system crashed".to_string(),
+                timestamp: Utc::now(),
+                embedding: Some(vec![0.1, 0.2, 0.3]),
+                entity_refs: vec![],
+            })
+            .unwrap();
 
         let echo_chamber = EchoChamber::new(vortex, gallifrey);
 

--- a/chronos/src/experimental/historian.rs
+++ b/chronos/src/experimental/historian.rs
@@ -196,8 +196,14 @@ mod tests {
             properties: std::collections::HashMap::new(),
             embedding: None,
             temporal: BiTemporalInterval {
-                valid_time: TimeRange { start: ten_mins_ago, end: None },
-                transaction_time: TimeRange { start: ten_mins_ago, end: None },
+                valid_time: TimeRange {
+                    start: ten_mins_ago,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: ten_mins_ago,
+                    end: None,
+                },
             },
             source: None,
         };
@@ -209,8 +215,14 @@ mod tests {
             properties: std::collections::HashMap::new(),
             embedding: None,
             temporal: BiTemporalInterval {
-                valid_time: TimeRange { start: five_mins_ago, end: None },
-                transaction_time: TimeRange { start: now, end: None },
+                valid_time: TimeRange {
+                    start: five_mins_ago,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: now,
+                    end: None,
+                },
             },
             source: None,
         };

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -173,10 +173,7 @@ impl PsychicPaper {
 
         // Fallback: Try comma separation if single line and no bullets were found/stripped
         // "No bullets found" means we have exactly one item and it matches the original trimmed text.
-        if items.len() == 1
-            && items[0] == text.trim()
-            && !text.contains('\n')
-            && text.contains(',')
+        if items.len() == 1 && items[0] == text.trim() && !text.contains('\n') && text.contains(',')
         {
             let items: Vec<String> = text
                 .split(',')

--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -355,12 +355,18 @@ mod tests {
         // "yesterday" should be 2024-03-14 12:00:00 UTC
         let refs = analyzer.extract_temporal_refs("yesterday", now);
         assert_eq!(refs.len(), 1);
-        assert_eq!(refs[0].resolved().unwrap().to_rfc3339(), "2024-03-14T12:00:00+00:00");
+        assert_eq!(
+            refs[0].resolved().unwrap().to_rfc3339(),
+            "2024-03-14T12:00:00+00:00"
+        );
 
         // "last week" should be 2024-03-08 12:00:00 UTC
         let refs = analyzer.extract_temporal_refs("last week", now);
         assert_eq!(refs.len(), 1);
-        assert_eq!(refs[0].resolved().unwrap().to_rfc3339(), "2024-03-08T12:00:00+00:00");
+        assert_eq!(
+            refs[0].resolved().unwrap().to_rfc3339(),
+            "2024-03-08T12:00:00+00:00"
+        );
     }
 
     #[test]

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -239,8 +239,8 @@ impl Default for ContextAugmenter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pipeline::{ContextSource, ContextSourceType};
     use crate::pipeline::analyzer::{AnalyzedQuery, QueryIntent};
+    use crate::pipeline::{ContextSource, ContextSourceType};
 
     fn create_mock_source(content: &str) -> ContextSource {
         ContextSource {
@@ -263,7 +263,9 @@ mod tests {
 
     #[test]
     fn test_augment_truncates_large_source() {
-        let augmenter = ContextAugmenter { max_context_tokens: 10 }; // 40 chars max
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 10,
+        }; // 40 chars max
 
         // Create a source with 50 chars (should be truncated)
         // 1 token = 4 chars, so 10 tokens = 40 chars.
@@ -275,18 +277,29 @@ mod tests {
         let result = augmenter.augment("query", &[source], &analysis).unwrap();
 
         // Should contain the truncated content (40 chars)
-        assert!(result.contains(&content[..40]), "Result should contain truncated content");
+        assert!(
+            result.contains(&content[..40]),
+            "Result should contain truncated content"
+        );
         // Should NOT contain the full content
-        assert!(!result.contains(&content), "Result should not contain full content");
+        assert!(
+            !result.contains(&content),
+            "Result should not contain full content"
+        );
         // Should indicate truncation with ellipsis
         assert!(result.contains("..."), "Result should contain ellipsis");
         // Should NOT say "1 more sources truncated" because we partially included it and there are no MORE sources.
-        assert!(!result.contains("sources truncated"), "Should not report dropped sources when none were fully dropped");
+        assert!(
+            !result.contains("sources truncated"),
+            "Should not report dropped sources when none were fully dropped"
+        );
     }
 
     #[test]
     fn test_augment_multiple_sources_partial() {
-        let augmenter = ContextAugmenter { max_context_tokens: 15 }; // 60 chars max
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 15,
+        }; // 60 chars max
 
         // Source 1: 20 chars (5 tokens)
         let s1 = create_mock_source(&"a".repeat(20));
@@ -299,14 +312,25 @@ mod tests {
 
         let result = augmenter.augment("query", &[s1, s2], &analysis).unwrap();
 
-        assert!(result.contains(&"a".repeat(20)), "Should contain full first source");
-        assert!(result.contains(&"b".repeat(40)), "Should contain truncated second source");
-        assert!(!result.contains(&"b".repeat(50)), "Should not contain full second source");
+        assert!(
+            result.contains(&"a".repeat(20)),
+            "Should contain full first source"
+        );
+        assert!(
+            result.contains(&"b".repeat(40)),
+            "Should contain truncated second source"
+        );
+        assert!(
+            !result.contains(&"b".repeat(50)),
+            "Should not contain full second source"
+        );
     }
 
     #[test]
     fn test_augment_multiple_sources_dropped() {
-        let augmenter = ContextAugmenter { max_context_tokens: 10 }; // 40 chars
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 10,
+        }; // 40 chars
 
         // S1: 40 chars (10 tokens). Fits exactly.
         let s1 = create_mock_source(&"a".repeat(40));
@@ -317,25 +341,41 @@ mod tests {
 
         let result = augmenter.augment("query", &[s1, s2], &analysis).unwrap();
 
-        assert!(result.contains(&"a".repeat(40)), "Should contain first source");
-        assert!(!result.contains(&"b".repeat(10)), "Should not contain second source");
-        assert!(result.contains("1 more sources truncated"), "Should report dropped source");
+        assert!(
+            result.contains(&"a".repeat(40)),
+            "Should contain first source"
+        );
+        assert!(
+            !result.contains(&"b".repeat(10)),
+            "Should not contain second source"
+        );
+        assert!(
+            result.contains("1 more sources truncated"),
+            "Should report dropped source"
+        );
     }
 
     #[test]
     fn test_augment_empty_context() {
-        let augmenter = ContextAugmenter { max_context_tokens: 10 };
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 10,
+        };
         let analysis = create_mock_analysis();
 
         let result = augmenter.augment("query", &[], &analysis).unwrap();
 
-        assert!(!result.contains("## Retrieved Context"), "Should not have context header");
+        assert!(
+            !result.contains("## Retrieved Context"),
+            "Should not have context header"
+        );
         assert!(result.contains("## User Query"), "Should have user query");
     }
 
     #[test]
     fn test_augment_exact_limit() {
-        let augmenter = ContextAugmenter { max_context_tokens: 10 }; // 40 chars
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 10,
+        }; // 40 chars
 
         // 40 chars. Fits exactly.
         let content = "a".repeat(40);
@@ -345,6 +385,9 @@ mod tests {
         let result = augmenter.augment("query", &[source], &analysis).unwrap();
 
         assert!(result.contains(&content), "Should contain full content");
-        assert!(!result.contains("truncated"), "Should not report truncation");
+        assert!(
+            !result.contains("truncated"),
+            "Should not report truncation"
+        );
     }
 }

--- a/gallifrey/src/experimental/entropy.rs
+++ b/gallifrey/src/experimental/entropy.rs
@@ -135,10 +135,10 @@ impl EntropyGauge {
 mod tests {
     use super::*;
     use crate::Gallifrey;
-    use tardis_common::id::EntityId;
-    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
     use chrono::{Duration, Utc};
     use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
 
     #[test]
     fn test_measure_logic() {

--- a/gallifrey/src/experimental/heatmap.rs
+++ b/gallifrey/src/experimental/heatmap.rs
@@ -1,3 +1,9 @@
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::uninlined_format_args)]
+
 use chrono::{DateTime, Utc};
 use std::fmt::Write;
 use tardis_common::domain::Entity;
@@ -30,9 +36,6 @@ impl TemporalHeatmap {
     ///
     /// Panics if `x_bins` or `y_bins` is zero.
     #[must_use]
-    #[allow(clippy::cast_precision_loss)]
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::cast_sign_loss)]
     pub fn new(history: &[Entity], x_bins: usize, y_bins: usize) -> Self {
         assert!(x_bins > 0, "x_bins must be > 0");
         assert!(y_bins > 0, "y_bins must be > 0");
@@ -163,7 +166,7 @@ impl TemporalHeatmap {
             self.valid_range.0, self.valid_range.1
         )
         .ok();
-        writeln!(&mut output, "Max Count: {}", max_val).ok();
+        writeln!(&mut output, "Max Count: {max_val}").ok();
         writeln!(&mut output, "┌{}┐", "─".repeat(self.x_bins)).ok();
 
         // Render rows (reversed Y to have time go up)

--- a/gallifrey/src/stores/system_state.rs
+++ b/gallifrey/src/stores/system_state.rs
@@ -178,10 +178,205 @@ impl SystemStateStore {
 
         Ok(list)
     }
+
+    /// Inject a snapshot for testing purposes.
+    #[cfg(test)]
+    pub fn inject_snapshot(&self, snapshot: Snapshot) {
+        let mut snapshots = self.snapshots.write().unwrap();
+        let mut by_name = self.by_name.write().unwrap();
+
+        by_name.insert(snapshot.name.clone(), snapshot.id);
+        snapshots.insert(snapshot.id, snapshot);
+    }
 }
 
 impl Default for SystemStateStore {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tardis_common::domain::{ChangeType, ProcessState};
+    use tardis_common::id::SnapshotId;
+
+    fn create_dummy_state() -> SystemState {
+        SystemState {
+            processes: HashMap::from([(
+                1,
+                ProcessState {
+                    pid: 1,
+                    name: "init".to_string(),
+                    status: "running".to_string(),
+                    memory_bytes: 1024,
+                    cpu_percent: 0.1,
+                },
+            )]),
+            config: HashMap::new(),
+            files: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn should_create_and_retrieve_snapshot() {
+        let store = SystemStateStore::new();
+        let state = create_dummy_state();
+        let name = "test-snapshot";
+
+        let id = store
+            .take_snapshot(name, SnapshotTrigger::Manual, state.clone())
+            .expect("failed to take snapshot");
+
+        let retrieved = store.get_snapshot(id).expect("failed to get snapshot");
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.name, name);
+        assert!(matches!(retrieved.trigger, SnapshotTrigger::Manual));
+
+        let retrieved_by_name = store
+            .get_snapshot_by_name(name)
+            .expect("failed to get by name");
+        assert!(retrieved_by_name.is_some());
+        assert_eq!(retrieved_by_name.unwrap().id, id);
+    }
+
+    #[test]
+    fn should_find_snapshot_at_timestamp() {
+        let store = SystemStateStore::new();
+        let base_time = Utc::now();
+
+        // Helper to create snapshot at offset
+        let make_snap = |offset_secs: i64, name: &str| {
+            let id = SnapshotId::new();
+            Snapshot {
+                id,
+                name: name.to_string(),
+                timestamp: base_time + chrono::Duration::seconds(offset_secs),
+                trigger: SnapshotTrigger::Manual,
+                state: create_dummy_state(),
+                checksum: "sum".to_string(),
+            }
+        };
+
+        let s1 = make_snap(0, "s1"); // T
+        let s2 = make_snap(10, "s2"); // T+10
+        let s3 = make_snap(20, "s3"); // T+20
+
+        store.inject_snapshot(s1.clone());
+        store.inject_snapshot(s2.clone());
+        store.inject_snapshot(s3.clone());
+
+        // Exact match
+        let found = store.find_snapshot_at(s2.timestamp).unwrap().unwrap();
+        assert_eq!(found.name, "s2");
+
+        // Between s1 and s2 (T+5) -> should find s1
+        let found = store
+            .find_snapshot_at(base_time + chrono::Duration::seconds(5))
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.name, "s1");
+
+        // After s3 (T+100) -> should find s3
+        let found = store
+            .find_snapshot_at(base_time + chrono::Duration::seconds(100))
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.name, "s3");
+
+        // Before s1 (T-10) -> should find None
+        let found = store
+            .find_snapshot_at(base_time - chrono::Duration::seconds(10))
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn should_record_and_filter_changes() {
+        let store = SystemStateStore::new();
+        let base_time = Utc::now();
+
+        let c1 = Change {
+            timestamp: base_time,
+            path: "/etc/config".to_string(),
+            change_type: ChangeType::Create,
+            old_value: None,
+            new_value: None,
+        };
+
+        let c2 = Change {
+            timestamp: base_time + chrono::Duration::seconds(10),
+            path: "/var/log".to_string(),
+            change_type: ChangeType::Update,
+            old_value: None,
+            new_value: None,
+        };
+
+        store.record_change(c1.clone()).unwrap();
+        store.record_change(c2.clone()).unwrap();
+
+        // Get all
+        let all = store
+            .get_changes(
+                base_time - chrono::Duration::seconds(1),
+                base_time + chrono::Duration::seconds(20),
+            )
+            .unwrap();
+        assert_eq!(all.len(), 2);
+
+        // Get only c1
+        let range1 = store
+            .get_changes(
+                base_time - chrono::Duration::seconds(1),
+                base_time + chrono::Duration::seconds(5),
+            )
+            .unwrap();
+        assert_eq!(range1.len(), 1);
+        assert_eq!(range1[0].path, "/etc/config");
+    }
+
+    #[test]
+    fn should_list_snapshots_chronologically() {
+        let store = SystemStateStore::new();
+        let base_time = Utc::now();
+
+        let s1 = Snapshot {
+            id: SnapshotId::new(),
+            name: "early".to_string(),
+            timestamp: base_time,
+            trigger: SnapshotTrigger::Manual,
+            state: create_dummy_state(),
+            checksum: "".to_string(),
+        };
+
+        let s2 = Snapshot {
+            id: SnapshotId::new(),
+            name: "late".to_string(),
+            timestamp: base_time + chrono::Duration::seconds(10),
+            trigger: SnapshotTrigger::Manual,
+            state: create_dummy_state(),
+            checksum: "".to_string(),
+        };
+
+        // Insert in reverse order
+        store.inject_snapshot(s2.clone());
+        store.inject_snapshot(s1.clone());
+
+        let list = store.list_snapshots().unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].name, "early");
+        assert_eq!(list[1].name, "late");
+    }
+
+    #[test]
+    fn should_return_none_for_unknown_snapshot() {
+        let store = SystemStateStore::new();
+        let res = store.get_snapshot(SnapshotId::new()).unwrap();
+        assert!(res.is_none());
+
+        let res = store.get_snapshot_by_name("non-existent").unwrap();
+        assert!(res.is_none());
     }
 }

--- a/gallifrey/tests/bi_temporal_update.rs
+++ b/gallifrey/tests/bi_temporal_update.rs
@@ -2,11 +2,11 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use tardis_gallifrey::stores::{KnowledgeStore, Entity};
+use serde_json::json;
+use std::collections::HashMap;
 use tardis_common::id::EntityId;
 use tardis_common::temporal::BiTemporalInterval;
-use std::collections::HashMap;
-use serde_json::json;
+use tardis_gallifrey::stores::{Entity, KnowledgeStore};
 
 #[test]
 fn test_bi_temporal_update_logic() {
@@ -16,9 +16,7 @@ fn test_bi_temporal_update_logic() {
         id,
         entity_type: "Test".to_string(),
         name: "Test Entity".to_string(),
-        properties: HashMap::from([
-            ("version".to_string(), json!(1))
-        ]),
+        properties: HashMap::from([("version".to_string(), json!(1))]),
         embedding: None,
         temporal: BiTemporalInterval::now(),
         source: None,
@@ -48,19 +46,37 @@ fn test_bi_temporal_update_logic() {
 
     // Check V1 (Old)
     assert_eq!(v1.properties.get("version").unwrap(), &json!(1));
-    assert!(!v1.temporal.transaction_time.is_current(), "V1 transaction time should be closed");
-    assert!(v1.temporal.transaction_time.end.is_some(), "V1 should have end time");
+    assert!(
+        !v1.temporal.transaction_time.is_current(),
+        "V1 transaction time should be closed"
+    );
+    assert!(
+        v1.temporal.transaction_time.end.is_some(),
+        "V1 should have end time"
+    );
 
     // Check V2 (New)
     assert_eq!(v2.properties.get("version").unwrap(), &json!(2));
-    assert!(v2.temporal.transaction_time.is_current(), "V2 transaction time should be open");
-    assert!(v2.temporal.transaction_time.end.is_none(), "V2 should not have end time");
+    assert!(
+        v2.temporal.transaction_time.is_current(),
+        "V2 transaction time should be open"
+    );
+    assert!(
+        v2.temporal.transaction_time.end.is_none(),
+        "V2 should not have end time"
+    );
 
     // Check Valid Time
     // V2's valid time should start at 'now' (when update happened)
     // V1's valid time should be unchanged from creation.
     // V2 transaction time starts at 'now'.
 
-    assert!(v2.temporal.valid_time.start > v1.temporal.valid_time.start, "V2 valid time should be strictly greater than V1");
-    assert!(v2.temporal.transaction_time.start > v1.temporal.transaction_time.start, "V2 transaction time should be strictly greater than V1");
+    assert!(
+        v2.temporal.valid_time.start > v1.temporal.valid_time.start,
+        "V2 valid time should be strictly greater than V1"
+    );
+    assert!(
+        v2.temporal.transaction_time.start > v1.temporal.transaction_time.start,
+        "V2 transaction time should be strictly greater than V1"
+    );
 }

--- a/shell/src/dashboard.rs
+++ b/shell/src/dashboard.rs
@@ -45,7 +45,10 @@ pub mod tui {
             // 50x20 resolution for the heatmap
             let heatmap = TemporalHeatmap::new(&all_history, 50, 20);
 
-            Ok(Self { _gallifrey: gallifrey, heatmap })
+            Ok(Self {
+                _gallifrey: gallifrey,
+                heatmap,
+            })
         }
 
         /// Run the dashboard loop.
@@ -113,7 +116,9 @@ pub mod tui {
             // Title
             let title = Paragraph::new(Text::styled(
                 "🌟 Tardis Time Stream 🌟",
-                Style::default().add_modifier(Modifier::BOLD).fg(Color::Cyan),
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .fg(Color::Cyan),
             ))
             .block(Block::default().borders(Borders::ALL));
             f.render_widget(title, chunks[0]);
@@ -126,27 +131,41 @@ pub mod tui {
 
             // Heatmap
             let heatmap_str = self.heatmap.render_ascii();
-            let heatmap_widget = Paragraph::new(heatmap_str)
-                .block(Block::default().title("Bi-Temporal Activity").borders(Borders::ALL));
+            let heatmap_widget = Paragraph::new(heatmap_str).block(
+                Block::default()
+                    .title("Bi-Temporal Activity")
+                    .borders(Borders::ALL),
+            );
             f.render_widget(heatmap_widget, main_chunks[0]);
 
             // Stats
             let total_events: usize = self.heatmap.grid.iter().flatten().sum();
 
             let stats_text = vec![
-                Line::from(Span::styled("System Status", Style::default().add_modifier(Modifier::UNDERLINED))),
+                Line::from(Span::styled(
+                    "System Status",
+                    Style::default().add_modifier(Modifier::UNDERLINED),
+                )),
                 Line::from(""),
                 Line::from(format!("Entities: {total_events}")), // Rough proxy for activity
-                Line::from(format!("Valid Time: {} to {}", self.heatmap.valid_range.0.format("%H:%M"), self.heatmap.valid_range.1.format("%H:%M"))),
-                Line::from(format!("Trans Time: {} to {}", self.heatmap.transaction_range.0.format("%H:%M"), self.heatmap.transaction_range.1.format("%H:%M"))),
+                Line::from(format!(
+                    "Valid Time: {} to {}",
+                    self.heatmap.valid_range.0.format("%H:%M"),
+                    self.heatmap.valid_range.1.format("%H:%M")
+                )),
+                Line::from(format!(
+                    "Trans Time: {} to {}",
+                    self.heatmap.transaction_range.0.format("%H:%M"),
+                    self.heatmap.transaction_range.1.format("%H:%M")
+                )),
             ];
             let stats_widget = Paragraph::new(stats_text)
                 .block(Block::default().title("Stats").borders(Borders::ALL));
             f.render_widget(stats_widget, main_chunks[1]);
 
             // Footer
-            let footer = Paragraph::new("Press 'q' to exit")
-                .block(Block::default().borders(Borders::ALL));
+            let footer =
+                Paragraph::new("Press 'q' to exit").block(Block::default().borders(Borders::ALL));
             f.render_widget(footer, chunks[2]);
         }
     }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -157,7 +157,8 @@ impl Repl {
             }
             #[cfg(feature = "nova")]
             "dashboard" => {
-                match crate::dashboard::tui::Dashboard::new(std::sync::Arc::clone(&self.gallifrey)) {
+                match crate::dashboard::tui::Dashboard::new(std::sync::Arc::clone(&self.gallifrey))
+                {
                     Ok(mut dashboard) => {
                         if let Err(e) = dashboard.run() {
                             println!("Dashboard failed: {e}");

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -138,7 +138,7 @@ impl RingSlot {
                 timestamp_ns: 0,
                 level: 0, // Level::Trace
                 _pad: 0,
-                subsystem: 255, // Subsystem::Unknown
+                subsystem: 255,    // Subsystem::Unknown
                 event_type: 65535, // EventType::Unknown
                 span_id: SpanId::NONE,
                 trace_id: TraceId::NONE,
@@ -499,7 +499,12 @@ impl RingBuffer {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic, clippy::expect_used, clippy::cast_possible_truncation)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::cast_possible_truncation
+)]
 mod tests {
     use super::*;
     use proptest::prelude::*;
@@ -822,7 +827,7 @@ mod tests {
                 timestamp_ns: 12345,
                 level: 255, // Invalid Level
                 _pad: 0,
-                subsystem: 65000, // Invalid Subsystem
+                subsystem: 65000,  // Invalid Subsystem
                 event_type: 60000, // Invalid EventType
                 span_id: SpanId::NONE,
                 trace_id: TraceId::NONE,

--- a/telemetry/tests/ring_buffer_race.rs
+++ b/telemetry/tests/ring_buffer_race.rs
@@ -10,7 +10,7 @@
 use std::sync::{Arc, Barrier};
 use std::thread;
 use tardis_telemetry::kernel::RingBuffer;
-use tardis_telemetry::types::{TelemetryEntry, Level, Subsystem, EventType, SpanId, TraceId};
+use tardis_telemetry::types::{EventType, Level, SpanId, Subsystem, TelemetryEntry, TraceId};
 
 #[test]
 fn race_condition_repro() {
@@ -74,12 +74,16 @@ fn race_condition_repro() {
         let payload_vec: Vec<u8> = payload;
         // Check strict equality.
         if payload_vec != expected {
-             // CORRUPTION DETECTED
-             panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
+            // CORRUPTION DETECTED
+            panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
                  t_id, i, expected.len(), payload_vec.len(), String::from_utf8_lossy(&payload_vec.iter().take(20).cloned().collect::<Vec<u8>>()));
         }
         valid_count += 1;
     }
 
-    println!("Read {} valid entries out of {} writes", valid_count, THREADS * WRITES_PER_THREAD);
+    println!(
+        "Read {} valid entries out of {} writes",
+        valid_count,
+        THREADS * WRITES_PER_THREAD
+    );
 }

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -22,7 +22,8 @@ pub type MockInference =
 pub type MockEmbedding = Box<dyn Fn(ModelHandle, &str) -> VortexResult<Vec<f32>> + Send + Sync>;
 
 /// Mock load model callback type.
-pub type MockLoadModel = Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
+pub type MockLoadModel =
+    Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
 
 /// The main Vortex inference engine.
 pub struct Vortex {


### PR DESCRIPTION
This PR improves the test coverage for the `SystemStateStore` in the `gallifrey` crate. It introduces a new test module with several test cases to verify the core functionality of the store, including snapshot management, time travel queries, and change tracking. It also addresses some clippy warnings in the experimental heatmap module.

---
*PR created automatically by Jules for task [3941752306779552632](https://jules.google.com/task/3941752306779552632) started by @madmax983*