### PR TITLE
🌟 Nova: The Conscience (System Mood Telemetry)

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -29,3 +29,8 @@
 **Concept:** A metric to quantify the stability of the knowledge base by measuring the "drift" between Valid Time and Transaction Time (Retcons vs Prophecies).
 **Fate:** Merged (Experimental)
 **Lesson:** We can now mathematically prove if the system is "living in the moment" or constantly rewriting history.
+
+## The Conscience
+**Concept:** Emotional telemetry that synthesizes system entropy (stability) and activity levels into a high-level "Mood" (Zen, Curious, Confused, Panic) displayed in the shell.
+**Fate:** Merged (Experimental)
+**Lesson:** Giving the system an emotional state makes abstract metrics (drift, write rate) instantly relatable and humane. "The system is panicked" is clearer than "High entropy and write load".

--- a/gallifrey/src/experimental/conscience.rs
+++ b/gallifrey/src/experimental/conscience.rs
@@ -1,0 +1,191 @@
+//! The Conscience: Emotional telemetry for the knowledge store.
+//!
+//! "Does the system feel confused? Overwhelmed? Or just Zen?"
+//!
+//! This module analyzes the state of the knowledge graph (entropy, activity)
+//! to determine a high-level "Mood" for the system.
+
+use crate::error::GallifreyResult;
+use crate::experimental::entropy::{EntropyGauge, SystemEntropy};
+use crate::stores::KnowledgeStore;
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+/// The emotional state of the system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Mood {
+    /// Low entropy, low activity. All is calm.
+    Zen,
+    /// Low entropy, moderate activity. Processing normally.
+    Curious,
+    /// High entropy. Conflicting timelines (retcons/prophecies).
+    Confused,
+    /// High activity (recent writes). System is busy.
+    Overwhelmed,
+    /// High entropy AND high activity. Panic mode.
+    Panic,
+}
+
+impl Mood {
+    /// Get a human-readable description of the mood.
+    #[must_use]
+    pub const fn description(&self) -> &'static str {
+        match self {
+            Mood::Zen => "The timeline is stable. The water is still.",
+            Mood::Curious => "Active and learning. The timeline is flowing.",
+            Mood::Confused => "Reality is fluctuating. Detected retcons or prophecies.",
+            Mood::Overwhelmed => "High write volume. The ink is still wet.",
+            Mood::Panic => "CHAOS! High drift and high load.",
+        }
+    }
+}
+
+/// A snapshot of the system's conscience.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemConscience {
+    /// The current mood.
+    pub mood: Mood,
+    /// The underlying entropy metrics.
+    pub entropy: SystemEntropy,
+    /// Activity score (approximate writes per minute).
+    pub activity_score: usize,
+}
+
+/// The Conscience analyzer.
+#[derive(Debug)]
+pub struct Conscience;
+
+impl Conscience {
+    /// Assess the current mood of the system.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store cannot be scanned.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn assess(store: &KnowledgeStore) -> GallifreyResult<SystemConscience> {
+        // 1. Measure Entropy (Stability)
+        let entropy = EntropyGauge::measure_global(store)?;
+
+        // 2. Measure Activity (Recent Writes)
+        // We define "recent" as the last 5 minutes of Transaction Time.
+        let now = Utc::now();
+        let five_mins_ago = now - Duration::minutes(5);
+        let mut recent_writes = 0;
+
+        store.scan_history(|history| {
+            // Check if any version was written recently
+            if history.iter().any(|e| {
+                e.temporal.transaction_time.start >= five_mins_ago
+                    || e.temporal
+                        .transaction_time
+                        .end
+                        .is_some_and(|end| end >= five_mins_ago)
+            }) {
+                recent_writes += 1;
+            }
+        })?;
+
+        // 3. Determine Mood
+        // Heuristics:
+        // - Stability < 0.5 -> Confused
+        // - Activity > 50 (in 5 mins) -> Overwhelmed
+        // - Both -> Panic
+        // - Else -> Zen/Curious
+
+        let mood = if entropy.stability_score < 0.5 {
+            if recent_writes > 50 {
+                Mood::Panic
+            } else {
+                Mood::Confused
+            }
+        } else if recent_writes > 50 {
+            Mood::Overwhelmed
+        } else if recent_writes > 5 {
+            Mood::Curious
+        } else {
+            Mood::Zen
+        };
+
+        Ok(SystemConscience {
+            mood,
+            entropy,
+            activity_score: recent_writes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Gallifrey;
+    use tardis_common::domain::Entity;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn test_mood_zen() {
+        let gallifrey = Gallifrey::new();
+        let store = gallifrey.knowledge();
+
+        // Empty store should be Zen
+        let conscience = Conscience::assess(&store).unwrap();
+        assert_eq!(conscience.mood, Mood::Zen);
+    }
+
+    #[tokio::test]
+    async fn test_mood_curious() {
+        let gallifrey = Gallifrey::new();
+        let store = gallifrey.knowledge();
+
+        // Add a few entities (enough to be Curious, not Overwhelmed)
+        for _ in 0..10 {
+            let entity = Entity {
+                id: EntityId::new(),
+                entity_type: "Test".to_string(),
+                name: "Test".to_string(),
+                properties: HashMap::new(),
+                embedding: None,
+                temporal: BiTemporalInterval::now(),
+                source: None,
+            };
+            store.insert_entity(entity).unwrap();
+        }
+
+        let conscience = Conscience::assess(&store).unwrap();
+        assert_eq!(conscience.mood, Mood::Curious);
+    }
+
+    #[tokio::test]
+    async fn test_mood_confused() {
+        let gallifrey = Gallifrey::new();
+        let store = gallifrey.knowledge();
+        let now = Utc::now();
+        let hour = Duration::hours(1);
+
+        // Add Retcons (Valid Time < Transaction Time)
+        // We need enough drift to lower stability score below 0.5
+        // Stability = 1.0 / (1.0 + avg_drift_sec)
+        // If avg_drift_sec > 1.0, score < 0.5.
+        // So 2 seconds drift is enough.
+
+        for _ in 0..5 {
+            let entity = Entity {
+                id: EntityId::new(),
+                entity_type: "Test".to_string(),
+                name: "Retcon".to_string(),
+                properties: HashMap::new(),
+                embedding: None,
+                temporal: BiTemporalInterval {
+                    valid_time: TimeRange::starting_at(now - hour),
+                    transaction_time: TimeRange::starting_at(now),
+                },
+                source: None,
+            };
+            store.insert_entity(entity).unwrap();
+        }
+
+        let conscience = Conscience::assess(&store).unwrap();
+        assert_eq!(conscience.mood, Mood::Confused);
+    }
+}

--- a/gallifrey/src/experimental/heatmap.rs
+++ b/gallifrey/src/experimental/heatmap.rs
@@ -1,3 +1,11 @@
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::needless_range_loop,
+    clippy::uninlined_format_args
+)]
+
 use chrono::{DateTime, Utc};
 use std::fmt::Write;
 use tardis_common::domain::Entity;
@@ -30,9 +38,6 @@ impl TemporalHeatmap {
     ///
     /// Panics if `x_bins` or `y_bins` is zero.
     #[must_use]
-    #[allow(clippy::cast_precision_loss)]
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::cast_sign_loss)]
     pub fn new(history: &[Entity], x_bins: usize, y_bins: usize) -> Self {
         assert!(x_bins > 0, "x_bins must be > 0");
         assert!(y_bins > 0, "y_bins must be > 0");

--- a/gallifrey/src/experimental/mod.rs
+++ b/gallifrey/src/experimental/mod.rs
@@ -3,9 +3,13 @@
 //! # Features
 //! - `heatmap`: Temporal heatmap generation for visualizing entity history.
 //! - `entropy`: System entropy and stability metrics.
+//! - `conscience`: Emotional telemetry based on system state.
 
 /// Temporal heatmap visualization.
 pub mod heatmap;
 
 /// System entropy and stability metrics.
 pub mod entropy;
+
+/// Emotional telemetry based on system state.
+pub mod conscience;

--- a/shell/src/dashboard.rs
+++ b/shell/src/dashboard.rs
@@ -16,13 +16,20 @@ pub mod tui {
         Frame, Terminal,
     };
     use std::{io, sync::Arc, time::Duration};
-    use tardis_gallifrey::{experimental::heatmap::TemporalHeatmap, Gallifrey};
+    use tardis_gallifrey::{
+        experimental::{
+            conscience::{Conscience, Mood, SystemConscience},
+            heatmap::TemporalHeatmap,
+        },
+        Gallifrey,
+    };
 
     /// The interactive dashboard.
     #[derive(Debug)]
     pub struct Dashboard {
         _gallifrey: Arc<Gallifrey>,
         heatmap: TemporalHeatmap,
+        conscience: SystemConscience,
     }
 
     impl Dashboard {
@@ -45,7 +52,15 @@ pub mod tui {
             // 50x20 resolution for the heatmap
             let heatmap = TemporalHeatmap::new(&all_history, 50, 20);
 
-            Ok(Self { _gallifrey: gallifrey, heatmap })
+            // Assess system conscience
+            let conscience = Conscience::assess(&gallifrey.knowledge())
+                .map_err(|e| anyhow::anyhow!("Failed to assess conscience: {}", e))?;
+
+            Ok(Self {
+                _gallifrey: gallifrey,
+                heatmap,
+                conscience,
+            })
         }
 
         /// Run the dashboard loop.
@@ -133,12 +148,51 @@ pub mod tui {
             // Stats
             let total_events: usize = self.heatmap.grid.iter().flatten().sum();
 
+            let mood_color = match self.conscience.mood {
+                Mood::Zen => Color::Green,
+                Mood::Curious => Color::Cyan,
+                Mood::Confused => Color::Yellow,
+                Mood::Overwhelmed => Color::Magenta,
+                Mood::Panic => Color::Red,
+            };
+
             let stats_text = vec![
-                Line::from(Span::styled("System Status", Style::default().add_modifier(Modifier::UNDERLINED))),
+                Line::from(Span::styled(
+                    "System Status",
+                    Style::default().add_modifier(Modifier::UNDERLINED),
+                )),
+                Line::from(""),
+                Line::from(vec![
+                    Span::raw("Mood: "),
+                    Span::styled(
+                        format!("{:?}", self.conscience.mood),
+                        Style::default()
+                            .fg(mood_color)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                ]),
+                Line::from(Span::styled(
+                    self.conscience.mood.description(),
+                    Style::default().fg(Color::DarkGray),
+                )),
+                Line::from(""),
+                Line::from(format!(
+                    "Stability: {:.2}",
+                    self.conscience.entropy.stability_score
+                )),
+                Line::from(format!("Activity: {}", self.conscience.activity_score)),
                 Line::from(""),
                 Line::from(format!("Entities: {total_events}")), // Rough proxy for activity
-                Line::from(format!("Valid Time: {} to {}", self.heatmap.valid_range.0.format("%H:%M"), self.heatmap.valid_range.1.format("%H:%M"))),
-                Line::from(format!("Trans Time: {} to {}", self.heatmap.transaction_range.0.format("%H:%M"), self.heatmap.transaction_range.1.format("%H:%M"))),
+                Line::from(format!(
+                    "Valid Time: {} to {}",
+                    self.heatmap.valid_range.0.format("%H:%M"),
+                    self.heatmap.valid_range.1.format("%H:%M")
+                )),
+                Line::from(format!(
+                    "Trans Time: {} to {}",
+                    self.heatmap.transaction_range.0.format("%H:%M"),
+                    self.heatmap.transaction_range.1.format("%H:%M")
+                )),
             ];
             let stats_widget = Paragraph::new(stats_text)
                 .block(Block::default().title("Stats").borders(Borders::ALL));


### PR DESCRIPTION
**Spark:**
"Does the system feel confused? Overwhelmed? Or just Zen?"
I wanted to bridge the gap between abstract bi-temporal metrics (Entropy, Drift) and human intuition.

**The Feature:**
`Conscience` is an experimental module in `Gallifrey` that analyzes the Knowledge Store's state to determine a high-level "Mood".
- **Zen:** Low entropy, low activity. Stable.
- **Curious:** Low entropy, moderate activity. Healthy.
- **Confused:** High entropy (lots of Retcons/Prophecies). The timeline is wobbly.
- **Overwhelmed:** High write volume. The system is struggling to keep up.
- **Panic:** High entropy AND high load. Chaos.

**The Integration:**
I connected this to the `tardis-shell` Dashboard. Now, alongside the raw Heatmap, you get a color-coded "System Mood" indicator (Green for Zen, Red for Panic).

**Why it's cool:**
It turns "Average Drift: 1500ms" into "Mood: Confused". It gives the OS a personality that reflects its internal reality.


---
*PR created automatically by Jules for task [17402830563415997192](https://jules.google.com/task/17402830563415997192) started by @madmax983*