### PR TITLE
🛡️ Sentry: Fix token counting bypass in RAG context augmenter

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -10,6 +10,10 @@
 **Learning:** Naive token limit checks that discard entire sources when they overflow can severely limit context utilization, especially with large documents or small token budgets. Partial truncation (e.g., ) allows filling the remaining budget effectively.
 **Action:** When implementing token-limited buffers, always implement partial filling logic rather than binary include/exclude decisions.
 
+**[Zero-Cost Resource Bug]
+**Learning:** Integer division `len / 4` rounds down to 0 for small values (0-3), allowing an infinite number of small items to bypass resource limits. This is a common "salami slicing" vulnerability in rate limiting or quota systems.
+**Action:** Use ceiling division `(len + divisor - 1) / divisor` or `max(1, cost)` to ensure minimum cost for non-empty items. Test with "many small items" to verify accumulation.
+
 **[RAG Context Truncation]
 **Learning:** Naive token limit checks that discard entire sources when they overflow can severely limit context utilization, especially with large documents or small token budgets. Partial truncation (e.g., `chars().take()`) allows filling the remaining budget effectively.
 **Action:** When implementing token-limited buffers, always implement partial filling logic rather than binary include/exclude decisions.

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -146,7 +146,8 @@ impl ContextAugmenter {
             };
 
             // Rough token estimate (4 chars per token)
-            let source_tokens = source.content.len() / 4;
+            // Ceiling division to ensure non-empty sources cost at least 1 token
+            let source_tokens = (source.content.len() + 3) / 4;
 
             if token_estimate + source_tokens > self.max_context_tokens {
                 // Calculate remaining budget
@@ -346,5 +347,48 @@ mod tests {
 
         assert!(result.contains(&content), "Should contain full content");
         assert!(!result.contains("truncated"), "Should not report truncation");
+    }
+
+    #[test]
+    fn test_augment_many_small_sources() {
+        let augmenter = ContextAugmenter { max_context_tokens: 5 };
+
+        // Create 20 sources of 3 chars each ("s00", "s01", etc.)
+        // Current logic: 3/4 = 0 tokens. All 20 fit.
+        // Correct logic: (3+3)/4 = 1 token. Only 5 fit.
+        let sources: Vec<ContextSource> = (0..20)
+            .map(|i| ContextSource {
+                source_type: ContextSourceType::Knowledge,
+                content: format!("s{:02}", i),
+                relevance: 1.0,
+                entity_id: None,
+            })
+            .collect();
+
+        let analysis = create_mock_analysis();
+
+        let result = augmenter.augment("query", &sources, &analysis).unwrap();
+
+        // Check if truncation happened correctly
+        // With limit=5, we expect 5 sources to be included (indices 0..5)
+        for i in 0..5 {
+            assert!(
+                result.contains(&format!("s{:02}", i)),
+                "Should contain source {}",
+                i
+            );
+        }
+
+        // The 6th source (index 5) should be excluded
+        assert!(
+            !result.contains("s05"),
+            "Should not contain source 5 (limit exceeded)"
+        );
+
+        // Should report dropped sources
+        assert!(
+            result.contains("15 more sources truncated"),
+            "Should report 15 dropped sources"
+        );
     }
 }


### PR DESCRIPTION
🛡️ Sentry: Token Counting Bypass Fix
    
    🎯 Target: `ContextAugmenter::format_context` in `chronos/src/pipeline/augmenter.rs`.
    💣 Risk: Small sources (< 4 chars) were counted as 0 tokens, allowing infinite context expansion and potential OOM/DOS.
    🧪 Strategy: Added `test_augment_many_small_sources` which attempts to add 20 small sources with a limit of 5 tokens.
    🔬 Verification: `cargo test -p tardis-chronos --lib pipeline::augmenter::tests::test_augment_many_small_sources`
    
    This PR also updates `.jules/sentry.md` with the learning about integer division pitfalls.

---
*PR created automatically by Jules for task [10217296619498569949](https://jules.google.com/task/10217296619498569949) started by @madmax983*