### PR TITLE
⚒️ Forge: Refactor Chronos Analyzer Logic

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -17,3 +17,7 @@
 **[Experimental Module Lint Suppression]
 **Learning:** Experimental modules often require `clippy::cast_precision_loss` and similar lints due to prototyping nature.
 **Action:** When refactoring, preserve these suppressions but scope them tightly to the specific helper functions where the operations occur.
+
+**[Unused Self Receiver]
+**Learning:** Many methods take `&self` but don't use it, often suppressed with `#[allow(clippy::unused_self)]`. This indicates a procedural style masked as object-oriented.
+**Action:** Convert stateless methods to associated functions (e.g., `fn foo(...)`) or free functions, removing the need for suppression.

--- a/chronos/src/experimental/doctor.rs
+++ b/chronos/src/experimental/doctor.rs
@@ -3,12 +3,12 @@
 //! A self-diagnostic tool that correlates telemetry data (symptoms)
 //! with system state changes (causes) to prescribe fixes.
 
-use std::sync::Arc;
+use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tardis_gallifrey::Gallifrey;
 use tardis_telemetry::gallifrey::TelemetryStore;
 use tardis_telemetry::types::Level;
-use chrono::{Duration, Utc};
 
 /// Vital signs of the system.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -130,14 +130,20 @@ impl SystemDoctor {
         }
 
         if vitals.active_spans > 100 {
-            symptoms.push(format!("High concurrency: {} active spans", vitals.active_spans));
+            symptoms.push(format!(
+                "High concurrency: {} active spans",
+                vitals.active_spans
+            ));
             if status == HealthStatus::Healthy {
                 status = HealthStatus::Degraded;
             }
         }
 
         if vitals.average_latency_ms > 500 {
-            symptoms.push(format!("High latency: {}ms average", vitals.average_latency_ms));
+            symptoms.push(format!(
+                "High latency: {}ms average",
+                vitals.average_latency_ms
+            ));
             if status == HealthStatus::Healthy {
                 status = HealthStatus::Degraded;
             }
@@ -175,10 +181,10 @@ impl SystemDoctor {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use tardis_telemetry::userspace::layer::{EventData, SpanData};
-    use tardis_telemetry::types::{Subsystem, TraceId, SpanId};
-    use std::time::Instant;
     use std::collections::HashMap;
+    use std::time::Instant;
+    use tardis_telemetry::types::{SpanId, Subsystem, TraceId};
+    use tardis_telemetry::userspace::layer::{EventData, SpanData};
 
     #[tokio::test]
     async fn test_doctor_diagnosis() {
@@ -222,6 +228,9 @@ mod tests {
         let diagnosis = doctor.diagnose().await;
         assert_ne!(diagnosis.status, HealthStatus::Healthy);
         assert!(diagnosis.symptoms.iter().any(|s| s.contains("errors")));
-        assert!(diagnosis.symptoms.iter().any(|s| s.contains("High latency")));
+        assert!(diagnosis
+            .symptoms
+            .iter()
+            .any(|s| s.contains("High latency")));
     }
 }

--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -6,8 +6,8 @@ use crate::error::ChronosResult;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tardis_gallifrey::domain::{Entity, Message};
 use tardis_common::id::EntityId;
+use tardis_gallifrey::domain::{Entity, Message};
 use tardis_gallifrey::Gallifrey;
 use tracing::{info, instrument};
 
@@ -126,8 +126,8 @@ impl DreamCatcher for MockDreamCatcher {
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use tardis_gallifrey::domain::{Message, Role};
     use tardis_common::id::EntityId;
+    use tardis_gallifrey::domain::{Message, Role};
 
     #[tokio::test]
     async fn test_dream_cycle() {

--- a/chronos/src/experimental/echoes.rs
+++ b/chronos/src/experimental/echoes.rs
@@ -90,9 +90,9 @@ impl EchoChamber {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tardis_gallifrey::domain::{Entity, Message};
     use tardis_common::id::{EntityId, ModelHandle, SessionId};
     use tardis_common::temporal::BiTemporalInterval;
+    use tardis_gallifrey::domain::{Entity, Message};
 
     #[tokio::test]
     async fn test_echoes() {
@@ -103,26 +103,32 @@ mod tests {
         let gallifrey = Arc::new(Gallifrey::new());
 
         // Setup Knowledge
-        gallifrey.knowledge().insert_entity(Entity {
-            id: EntityId::new(),
-            entity_type: "Fact".to_string(),
-            name: "Previous System Crash".to_string(),
-            properties: std::collections::HashMap::new(),
-            embedding: Some(vec![0.1, 0.2, 0.3]),
-            temporal: BiTemporalInterval::now(),
-            source: None,
-        }).unwrap();
+        gallifrey
+            .knowledge()
+            .insert_entity(Entity {
+                id: EntityId::new(),
+                entity_type: "Fact".to_string(),
+                name: "Previous System Crash".to_string(),
+                properties: std::collections::HashMap::new(),
+                embedding: Some(vec![0.1, 0.2, 0.3]),
+                temporal: BiTemporalInterval::now(),
+                source: None,
+            })
+            .unwrap();
 
         // Setup Conversation
-        gallifrey.conversation().add_message(Message {
-            id: EntityId::new(),
-            session_id: SessionId::new(),
-            role: tardis_gallifrey::domain::Role::User,
-            content: "I remember when the system crashed".to_string(),
-            timestamp: Utc::now(),
-            embedding: Some(vec![0.1, 0.2, 0.3]),
-            entity_refs: vec![],
-        }).unwrap();
+        gallifrey
+            .conversation()
+            .add_message(Message {
+                id: EntityId::new(),
+                session_id: SessionId::new(),
+                role: tardis_gallifrey::domain::Role::User,
+                content: "I remember when the system crashed".to_string(),
+                timestamp: Utc::now(),
+                embedding: Some(vec![0.1, 0.2, 0.3]),
+                entity_refs: vec![],
+            })
+            .unwrap();
 
         let echo_chamber = EchoChamber::new(vortex, gallifrey);
 

--- a/chronos/src/experimental/historian.rs
+++ b/chronos/src/experimental/historian.rs
@@ -144,11 +144,7 @@ impl Historian {
 
         let story = self
             .vortex
-            .infer(
-                handle,
-                &prompt,
-                tardis_vortex::InferenceParams::default(),
-            )
+            .infer(handle, &prompt, tardis_vortex::InferenceParams::default())
             .await?;
 
         Ok(story)
@@ -158,9 +154,9 @@ impl Historian {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tardis_gallifrey::domain::Entity;
     use tardis_common::id::{EntityId, ModelHandle};
     use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+    use tardis_gallifrey::domain::Entity;
 
     #[tokio::test]
     async fn test_historian_narrative() {
@@ -196,8 +192,14 @@ mod tests {
             properties: std::collections::HashMap::new(),
             embedding: None,
             temporal: BiTemporalInterval {
-                valid_time: TimeRange { start: ten_mins_ago, end: None },
-                transaction_time: TimeRange { start: ten_mins_ago, end: None },
+                valid_time: TimeRange {
+                    start: ten_mins_ago,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: ten_mins_ago,
+                    end: None,
+                },
             },
             source: None,
         };
@@ -209,8 +211,14 @@ mod tests {
             properties: std::collections::HashMap::new(),
             embedding: None,
             temporal: BiTemporalInterval {
-                valid_time: TimeRange { start: five_mins_ago, end: None },
-                transaction_time: TimeRange { start: now, end: None },
+                valid_time: TimeRange {
+                    start: five_mins_ago,
+                    end: None,
+                },
+                transaction_time: TimeRange {
+                    start: now,
+                    end: None,
+                },
             },
             source: None,
         };

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -9,10 +9,10 @@ use crate::error::{ChronosError, ChronosResult};
 use crate::experimental::psychic_paper::{Intent, PsychicPaper};
 use std::sync::Arc;
 use std::time::Duration;
-use tardis_gallifrey::domain::Entity;
 use tardis_common::id::{EntityId, ModelHandle};
-use tardis_vortex::InferenceParams;
 use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+use tardis_gallifrey::domain::Entity;
+use tardis_vortex::InferenceParams;
 use tardis_vortex::Vortex;
 use tracing::{info, instrument};
 

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -173,10 +173,7 @@ impl PsychicPaper {
 
         // Fallback: Try comma separation if single line and no bullets were found/stripped
         // "No bullets found" means we have exactly one item and it matches the original trimmed text.
-        if items.len() == 1
-            && items[0] == text.trim()
-            && !text.contains('\n')
-            && text.contains(',')
+        if items.len() == 1 && items[0] == text.trim() && !text.contains('\n') && text.contains(',')
         {
             let items: Vec<String> = text
                 .split(',')

--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -156,14 +156,14 @@ impl QueryAnalyzer {
     pub fn analyze(&self, query: &str) -> ChronosResult<AnalyzedQuery> {
         // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
         let query_lower = query.to_lowercase();
-        let intent = self.classify_intent(&query_lower);
-        let temporal_refs = self.extract_temporal_refs(&query_lower, Utc::now());
-        let entities = self.extract_entities(query);
+        let intent = Self::classify_intent(&query_lower);
+        let temporal_refs = Self::extract_temporal_refs(&query_lower, Utc::now());
+        let entities = Self::extract_entities(query);
 
         let temporal_description = if temporal_refs.is_empty() {
             None
         } else {
-            Some(self.describe_temporal_context(&temporal_refs))
+            Some(Self::describe_temporal_context(&temporal_refs))
         };
 
         Ok(AnalyzedQuery {
@@ -176,52 +176,36 @@ impl QueryAnalyzer {
     }
 
     /// Classify the intent of a query.
-    #[allow(clippy::unused_self)]
-    fn classify_intent(&self, query_lower: &str) -> QueryIntent {
-        for rule in INTENT_RULES {
-            if rule.matches(query_lower) {
-                return rule.intent.clone();
-            }
-        }
-
-        if query_lower.ends_with('?') {
-            return QueryIntent::Question;
-        }
-
-        QueryIntent::Chat
+    fn classify_intent(query_lower: &str) -> QueryIntent {
+        INTENT_RULES
+            .iter()
+            .find(|rule| rule.matches(query_lower))
+            .map_or_else(
+                || {
+                    if query_lower.ends_with('?') {
+                        QueryIntent::Question
+                    } else {
+                        QueryIntent::Chat
+                    }
+                },
+                |rule| rule.intent.clone(),
+            )
     }
 
     /// Extract temporal references from a query.
-    #[allow(clippy::unused_self)]
-    fn extract_temporal_refs(
-        &self,
-        query_lower: &str,
-        now: DateTime<Utc>,
-    ) -> Vec<TemporalReference> {
-        let mut refs = Vec::new();
-
-        for rule in TEMPORAL_RULES {
-            if query_lower.contains(rule.keyword) {
-                let resolved = rule.resolve(now);
-
-                refs.push(TemporalReference::Relative {
-                    text: rule.keyword.to_string(),
-                    resolved,
-                });
-            }
-        }
-
-        // TODO: Add more sophisticated temporal extraction
-        // - NLP-based extraction
-        // - Absolute date parsing
-        // - Event-based references
-
-        refs
+    fn extract_temporal_refs(query_lower: &str, now: DateTime<Utc>) -> Vec<TemporalReference> {
+        TEMPORAL_RULES
+            .iter()
+            .filter(|rule| query_lower.contains(rule.keyword))
+            .map(|rule| TemporalReference::Relative {
+                text: rule.keyword.to_string(),
+                resolved: rule.resolve(now),
+            })
+            .collect()
     }
 
     /// Extract entity mentions from a query.
-    #[allow(clippy::unused_self)]
-    const fn extract_entities(&self, query: &str) -> Vec<String> {
+    const fn extract_entities(query: &str) -> Vec<String> {
         // TODO: Implement NER or pattern matching
         // For now, just return empty
         let _ = query;
@@ -229,29 +213,33 @@ impl QueryAnalyzer {
     }
 
     /// Generate human-readable description of temporal context.
-    #[allow(clippy::unused_self)]
-    fn describe_temporal_context(&self, refs: &[TemporalReference]) -> String {
+    fn describe_temporal_context(refs: &[TemporalReference]) -> String {
         if refs.is_empty() {
             return "current time".to_string();
         }
 
         refs.iter()
-            .map(|r| match r {
-                TemporalReference::Relative { text, resolved } => {
-                    format!("{} ({})", text, resolved.format("%Y-%m-%d"))
-                }
-                TemporalReference::Absolute(resolved) => resolved.format("%Y-%m-%d").to_string(),
-                TemporalReference::EventBased { event, resolved } => {
-                    if let Some(res) = resolved {
-                        format!("{} ({})", event, res.format("%Y-%m-%d"))
-                    } else {
-                        event.clone()
-                    }
-                }
-                TemporalReference::Implicit => "implicit".to_string(),
-            })
+            .map(Self::format_temporal_ref)
             .collect::<Vec<_>>()
             .join(", ")
+    }
+
+    /// Format a single temporal reference.
+    fn format_temporal_ref(r: &TemporalReference) -> String {
+        match r {
+            TemporalReference::Relative { text, resolved } => {
+                format!("{} ({})", text, resolved.format("%Y-%m-%d"))
+            }
+            TemporalReference::Absolute(resolved) => resolved.format("%Y-%m-%d").to_string(),
+            TemporalReference::EventBased { event, resolved } => {
+                if let Some(res) = resolved {
+                    format!("{} ({})", event, res.format("%Y-%m-%d"))
+                } else {
+                    event.clone()
+                }
+            }
+            TemporalReference::Implicit => "implicit".to_string(),
+        }
     }
 }
 
@@ -268,56 +256,54 @@ mod tests {
 
     #[test]
     fn test_classify_intent() {
-        let analyzer = QueryAnalyzer::new();
-
         assert_eq!(
-            analyzer.classify_intent(&"Remember that I like pizza".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"Remember that I like pizza".to_lowercase()),
             QueryIntent::Remember
         );
         assert_eq!(
-            analyzer.classify_intent(&"Please remember this conversation".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"Please remember this conversation".to_lowercase()),
             QueryIntent::Remember
         );
         assert_eq!(
-            analyzer.classify_intent(&"What did we discuss yesterday?".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"What did we discuss yesterday?".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"Recall the meeting notes".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"Recall the meeting notes".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"What was the result?".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"What was the result?".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"How has the project changed?".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"How has the project changed?".to_lowercase()),
             QueryIntent::TemporalDiff
         );
         assert_eq!(
-            analyzer.classify_intent(&"Show me the system state".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"Show me the system state".to_lowercase()),
             QueryIntent::SystemQuery
         );
         assert_eq!(
-            analyzer.classify_intent(&"Take a snapshot".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"Take a snapshot".to_lowercase()),
             QueryIntent::SystemQuery
         );
         assert_eq!(
-            analyzer.classify_intent(&"Is this a question?".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"Is this a question?".to_lowercase()),
             QueryIntent::Question
         );
         assert_eq!(
-            analyzer.classify_intent(&"Just chatting".to_lowercase()),
+            QueryAnalyzer::classify_intent(&"Just chatting".to_lowercase()),
             QueryIntent::Chat
         );
     }
 
     #[test]
     fn test_extract_temporal_refs() {
-        let analyzer = QueryAnalyzer::new();
         let now = Utc::now();
 
-        let refs = analyzer.extract_temporal_refs(&"What happened yesterday?".to_lowercase(), now);
+        let refs =
+            QueryAnalyzer::extract_temporal_refs(&"What happened yesterday?".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
 
         match &refs[0] {
@@ -325,27 +311,27 @@ mod tests {
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Check last week logs".to_lowercase(), now);
+        let refs =
+            QueryAnalyzer::extract_temporal_refs(&"Check last week logs".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "last week"),
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Do it today".to_lowercase(), now);
+        let refs = QueryAnalyzer::extract_temporal_refs(&"Do it today".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "today"),
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Yesterday and today".to_lowercase(), now);
+        let refs = QueryAnalyzer::extract_temporal_refs(&"Yesterday and today".to_lowercase(), now);
         assert_eq!(refs.len(), 2);
     }
 
     #[test]
     fn test_extract_temporal_refs_resolved() {
-        let analyzer = QueryAnalyzer::new();
         // Use a fixed date for deterministic testing
         // 2024-03-15 12:00:00 UTC
         let now = DateTime::parse_from_rfc3339("2024-03-15T12:00:00Z")
@@ -353,22 +339,27 @@ mod tests {
             .with_timezone(&Utc);
 
         // "yesterday" should be 2024-03-14 12:00:00 UTC
-        let refs = analyzer.extract_temporal_refs("yesterday", now);
+        let refs = QueryAnalyzer::extract_temporal_refs("yesterday", now);
         assert_eq!(refs.len(), 1);
-        assert_eq!(refs[0].resolved().unwrap().to_rfc3339(), "2024-03-14T12:00:00+00:00");
+        assert_eq!(
+            refs[0].resolved().unwrap().to_rfc3339(),
+            "2024-03-14T12:00:00+00:00"
+        );
 
         // "last week" should be 2024-03-08 12:00:00 UTC
-        let refs = analyzer.extract_temporal_refs("last week", now);
+        let refs = QueryAnalyzer::extract_temporal_refs("last week", now);
         assert_eq!(refs.len(), 1);
-        assert_eq!(refs[0].resolved().unwrap().to_rfc3339(), "2024-03-08T12:00:00+00:00");
+        assert_eq!(
+            refs[0].resolved().unwrap().to_rfc3339(),
+            "2024-03-08T12:00:00+00:00"
+        );
     }
 
     #[test]
     fn test_describe_temporal_context() {
-        let analyzer = QueryAnalyzer::new();
         let now = Utc::now();
-        let refs = analyzer.extract_temporal_refs("yesterday", now);
-        let desc = analyzer.describe_temporal_context(&refs);
+        let refs = QueryAnalyzer::extract_temporal_refs("yesterday", now);
+        let desc = QueryAnalyzer::describe_temporal_context(&refs);
         assert!(desc.contains("yesterday"));
     }
 }

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -155,13 +155,14 @@ impl ContextAugmenter {
 
                 // If we have space for at least some content, include it partially
                 if chars_to_take > 0 {
-                    let content: String = source.content.chars().take(chars_to_take).collect();
+                    let truncated_content: String =
+                        source.content.chars().take(chars_to_take).collect();
                     let _ = writeln!(
                         formatted,
                         "### {source_type} {} (relevance: {:.2})\n{}...\n",
                         i + 1,
                         source.relevance,
-                        content
+                        truncated_content
                     );
                 }
 
@@ -177,8 +178,7 @@ impl ContextAugmenter {
                 if sources_fully_dropped > 0 {
                     let _ = writeln!(
                         formatted,
-                        "\n... ({} more sources truncated)",
-                        sources_fully_dropped
+                        "\n... ({sources_fully_dropped} more sources truncated)"
                     );
                 }
                 break;
@@ -239,8 +239,8 @@ impl Default for ContextAugmenter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pipeline::{ContextSource, ContextSourceType};
     use crate::pipeline::analyzer::{AnalyzedQuery, QueryIntent};
+    use crate::pipeline::{ContextSource, ContextSourceType};
 
     fn create_mock_source(content: &str) -> ContextSource {
         ContextSource {
@@ -263,7 +263,9 @@ mod tests {
 
     #[test]
     fn test_augment_truncates_large_source() {
-        let augmenter = ContextAugmenter { max_context_tokens: 10 }; // 40 chars max
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 10,
+        }; // 40 chars max
 
         // Create a source with 50 chars (should be truncated)
         // 1 token = 4 chars, so 10 tokens = 40 chars.
@@ -275,18 +277,29 @@ mod tests {
         let result = augmenter.augment("query", &[source], &analysis).unwrap();
 
         // Should contain the truncated content (40 chars)
-        assert!(result.contains(&content[..40]), "Result should contain truncated content");
+        assert!(
+            result.contains(&content[..40]),
+            "Result should contain truncated content"
+        );
         // Should NOT contain the full content
-        assert!(!result.contains(&content), "Result should not contain full content");
+        assert!(
+            !result.contains(&content),
+            "Result should not contain full content"
+        );
         // Should indicate truncation with ellipsis
         assert!(result.contains("..."), "Result should contain ellipsis");
         // Should NOT say "1 more sources truncated" because we partially included it and there are no MORE sources.
-        assert!(!result.contains("sources truncated"), "Should not report dropped sources when none were fully dropped");
+        assert!(
+            !result.contains("sources truncated"),
+            "Should not report dropped sources when none were fully dropped"
+        );
     }
 
     #[test]
     fn test_augment_multiple_sources_partial() {
-        let augmenter = ContextAugmenter { max_context_tokens: 15 }; // 60 chars max
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 15,
+        }; // 60 chars max
 
         // Source 1: 20 chars (5 tokens)
         let s1 = create_mock_source(&"a".repeat(20));
@@ -299,14 +312,25 @@ mod tests {
 
         let result = augmenter.augment("query", &[s1, s2], &analysis).unwrap();
 
-        assert!(result.contains(&"a".repeat(20)), "Should contain full first source");
-        assert!(result.contains(&"b".repeat(40)), "Should contain truncated second source");
-        assert!(!result.contains(&"b".repeat(50)), "Should not contain full second source");
+        assert!(
+            result.contains(&"a".repeat(20)),
+            "Should contain full first source"
+        );
+        assert!(
+            result.contains(&"b".repeat(40)),
+            "Should contain truncated second source"
+        );
+        assert!(
+            !result.contains(&"b".repeat(50)),
+            "Should not contain full second source"
+        );
     }
 
     #[test]
     fn test_augment_multiple_sources_dropped() {
-        let augmenter = ContextAugmenter { max_context_tokens: 10 }; // 40 chars
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 10,
+        }; // 40 chars
 
         // S1: 40 chars (10 tokens). Fits exactly.
         let s1 = create_mock_source(&"a".repeat(40));
@@ -317,25 +341,41 @@ mod tests {
 
         let result = augmenter.augment("query", &[s1, s2], &analysis).unwrap();
 
-        assert!(result.contains(&"a".repeat(40)), "Should contain first source");
-        assert!(!result.contains(&"b".repeat(10)), "Should not contain second source");
-        assert!(result.contains("1 more sources truncated"), "Should report dropped source");
+        assert!(
+            result.contains(&"a".repeat(40)),
+            "Should contain first source"
+        );
+        assert!(
+            !result.contains(&"b".repeat(10)),
+            "Should not contain second source"
+        );
+        assert!(
+            result.contains("1 more sources truncated"),
+            "Should report dropped source"
+        );
     }
 
     #[test]
     fn test_augment_empty_context() {
-        let augmenter = ContextAugmenter { max_context_tokens: 10 };
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 10,
+        };
         let analysis = create_mock_analysis();
 
         let result = augmenter.augment("query", &[], &analysis).unwrap();
 
-        assert!(!result.contains("## Retrieved Context"), "Should not have context header");
+        assert!(
+            !result.contains("## Retrieved Context"),
+            "Should not have context header"
+        );
         assert!(result.contains("## User Query"), "Should have user query");
     }
 
     #[test]
     fn test_augment_exact_limit() {
-        let augmenter = ContextAugmenter { max_context_tokens: 10 }; // 40 chars
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 10,
+        }; // 40 chars
 
         // 40 chars. Fits exactly.
         let content = "a".repeat(40);
@@ -345,6 +385,9 @@ mod tests {
         let result = augmenter.augment("query", &[source], &analysis).unwrap();
 
         assert!(result.contains(&content), "Should contain full content");
-        assert!(!result.contains("truncated"), "Should not report truncation");
+        assert!(
+            !result.contains("truncated"),
+            "Should not report truncation"
+        );
     }
 }

--- a/gallifrey/src/domain.rs
+++ b/gallifrey/src/domain.rs
@@ -1,10 +1,10 @@
 //! Domain entities shared across Tardis OS.
 
-use tardis_common::id::{EntityId, SessionId, SnapshotId};
 use crate::temporal::BiTemporalInterval;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use tardis_common::id::{EntityId, SessionId, SnapshotId};
 
 // ============================================================================
 // Knowledge Graph

--- a/gallifrey/src/experimental/entropy.rs
+++ b/gallifrey/src/experimental/entropy.rs
@@ -1,7 +1,7 @@
+use crate::domain::Entity;
 use crate::error::GallifreyResult;
 use crate::stores::KnowledgeStore;
 use serde::{Deserialize, Serialize};
-use crate::domain::Entity;
 
 /// Metrics quantifying the stability of the system's knowledge.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -135,10 +135,10 @@ impl EntropyGauge {
 mod tests {
     use super::*;
     use crate::Gallifrey;
-    use tardis_common::id::EntityId;
-    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
     use chrono::{Duration, Utc};
     use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
 
     #[test]
     fn test_measure_logic() {

--- a/gallifrey/src/experimental/heatmap.rs
+++ b/gallifrey/src/experimental/heatmap.rs
@@ -71,7 +71,10 @@ impl TemporalHeatmap {
     fn determine_bounds(
         history: &[Entity],
         now: DateTime<Utc>,
-    ) -> ((DateTime<Utc>, DateTime<Utc>), (DateTime<Utc>, DateTime<Utc>)) {
+    ) -> (
+        (DateTime<Utc>, DateTime<Utc>),
+        (DateTime<Utc>, DateTime<Utc>),
+    ) {
         let (mut v_min, mut v_max, mut t_min, mut t_max) = match history.first() {
             Some(first) => (
                 first.temporal.valid_time.start,

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -75,8 +75,8 @@ pub use error::{GallifreyError, GallifreyResult};
 pub use stores::{ConversationStore, KnowledgeStore, SystemStateStore};
 pub use temporal::{BiTemporalInterval, TimeRange};
 
-use std::sync::Arc;
 use crate::domain::{Change, Entity, Message, Snapshot};
+use std::sync::Arc;
 use tardis_common::id::{EntityId, SessionId};
 use tardis_common::temporal::TemporalQuery;
 

--- a/gallifrey/src/query/mod.rs
+++ b/gallifrey/src/query/mod.rs
@@ -2,9 +2,9 @@
 //!
 //! Provides query parsing and execution for temporal graph queries.
 
+use crate::domain::Entity;
 use crate::error::GallifreyResult;
 use serde::{Deserialize, Serialize};
-use crate::domain::Entity;
 use tardis_common::temporal::TemporalQuery;
 
 /// A parsed query.

--- a/gallifrey/src/stores/conversation.rs
+++ b/gallifrey/src/stores/conversation.rs
@@ -5,11 +5,11 @@
 //! - Semantic search across history
 //! - Session summaries
 
+pub use crate::domain::{Message, Role, Session};
 use crate::error::{GallifreyError, GallifreyResult};
 use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::RwLock;
-pub use crate::domain::{Message, Role, Session};
 use tardis_common::{EntityId, SessionId};
 
 /// The conversation store.

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -5,12 +5,12 @@
 //! - Bi-temporal versioning
 //! - Source provenance tracking
 
+pub use crate::domain::{Entity, Relationship};
 use crate::error::{GallifreyError, GallifreyResult};
 use crate::temporal::BiTemporalInterval;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::RwLock;
-pub use crate::domain::{Entity, Relationship};
 use tardis_common::EntityId;
 
 /// The knowledge graph store.

--- a/gallifrey/src/stores/system_state.rs
+++ b/gallifrey/src/stores/system_state.rs
@@ -5,11 +5,11 @@
 //! - Forensic analysis
 //! - Configuration rollback
 
+pub use crate::domain::{Change, Snapshot, SnapshotTrigger, SystemState};
 use crate::error::{GallifreyError, GallifreyResult};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::RwLock;
-pub use crate::domain::{Change, Snapshot, SnapshotTrigger, SystemState};
 use tardis_common::SnapshotId;
 
 /// The system state store.

--- a/gallifrey/tests/bi_temporal_update.rs
+++ b/gallifrey/tests/bi_temporal_update.rs
@@ -2,11 +2,11 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use tardis_gallifrey::stores::{KnowledgeStore, Entity};
+use serde_json::json;
+use std::collections::HashMap;
 use tardis_common::id::EntityId;
 use tardis_common::temporal::BiTemporalInterval;
-use std::collections::HashMap;
-use serde_json::json;
+use tardis_gallifrey::stores::{Entity, KnowledgeStore};
 
 #[test]
 fn test_bi_temporal_update_logic() {
@@ -16,9 +16,7 @@ fn test_bi_temporal_update_logic() {
         id,
         entity_type: "Test".to_string(),
         name: "Test Entity".to_string(),
-        properties: HashMap::from([
-            ("version".to_string(), json!(1))
-        ]),
+        properties: HashMap::from([("version".to_string(), json!(1))]),
         embedding: None,
         temporal: BiTemporalInterval::now(),
         source: None,
@@ -48,19 +46,37 @@ fn test_bi_temporal_update_logic() {
 
     // Check V1 (Old)
     assert_eq!(v1.properties.get("version").unwrap(), &json!(1));
-    assert!(!v1.temporal.transaction_time.is_current(), "V1 transaction time should be closed");
-    assert!(v1.temporal.transaction_time.end.is_some(), "V1 should have end time");
+    assert!(
+        !v1.temporal.transaction_time.is_current(),
+        "V1 transaction time should be closed"
+    );
+    assert!(
+        v1.temporal.transaction_time.end.is_some(),
+        "V1 should have end time"
+    );
 
     // Check V2 (New)
     assert_eq!(v2.properties.get("version").unwrap(), &json!(2));
-    assert!(v2.temporal.transaction_time.is_current(), "V2 transaction time should be open");
-    assert!(v2.temporal.transaction_time.end.is_none(), "V2 should not have end time");
+    assert!(
+        v2.temporal.transaction_time.is_current(),
+        "V2 transaction time should be open"
+    );
+    assert!(
+        v2.temporal.transaction_time.end.is_none(),
+        "V2 should not have end time"
+    );
 
     // Check Valid Time
     // V2's valid time should start at 'now' (when update happened)
     // V1's valid time should be unchanged from creation.
     // V2 transaction time starts at 'now'.
 
-    assert!(v2.temporal.valid_time.start > v1.temporal.valid_time.start, "V2 valid time should be strictly greater than V1");
-    assert!(v2.temporal.transaction_time.start > v1.temporal.transaction_time.start, "V2 transaction time should be strictly greater than V1");
+    assert!(
+        v2.temporal.valid_time.start > v1.temporal.valid_time.start,
+        "V2 valid time should be strictly greater than V1"
+    );
+    assert!(
+        v2.temporal.transaction_time.start > v1.temporal.transaction_time.start,
+        "V2 transaction time should be strictly greater than V1"
+    );
 }

--- a/shell/src/dashboard.rs
+++ b/shell/src/dashboard.rs
@@ -17,12 +17,16 @@ pub mod tui {
         widgets::{Axis, Block, Borders, Chart, Dataset, GraphType, List, ListItem, Paragraph},
         Frame, Terminal,
     };
-    use std::{io, sync::{Arc, Mutex}, time::Duration};
+    use std::{
+        io,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+    #[cfg(feature = "nova")]
+    use tardis_chronos::experimental::prophecy::Prophet;
     use tardis_common::domain::Entity;
     use tardis_gallifrey::{experimental::heatmap::TemporalHeatmap, Gallifrey};
     use tardis_telemetry::{gallifrey::TelemetryStore, types::MetricValue};
-    #[cfg(feature = "nova")]
-    use tardis_chronos::experimental::prophecy::Prophet;
 
     /// Shared data for the dashboard.
     #[derive(Debug, Default)]
@@ -78,11 +82,14 @@ pub mod tui {
                         // Mock model handle for now
                         let model = tardis_common::id::ModelHandle::new(0);
                         // Predict 10 minutes into the future
-                        if let Ok(predictions) = p.foresee(
-                            "System running normally. Telemetry active.",
-                            Duration::from_secs(600),
-                            model
-                        ).await {
+                        if let Ok(predictions) = p
+                            .foresee(
+                                "System running normally. Telemetry active.",
+                                Duration::from_secs(600),
+                                model,
+                            )
+                            .await
+                        {
                             if let Ok(mut lock) = data_clone.lock() {
                                 lock.prophecies = predictions;
                                 lock.last_update = Some(Utc::now());
@@ -173,7 +180,9 @@ pub mod tui {
             // Title
             let title = Paragraph::new(Text::styled(
                 "🌟 Tardis Holodeck 🌟",
-                Style::default().add_modifier(Modifier::BOLD).fg(Color::Cyan),
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .fg(Color::Cyan),
             ))
             .block(Block::default().borders(Borders::ALL));
             f.render_widget(title, chunks[0]);
@@ -191,18 +200,26 @@ pub mod tui {
                 .split(content_chunks[0]);
 
             let heatmap_str = self.heatmap.render_ascii();
-            let heatmap_widget = Paragraph::new(heatmap_str)
-                .block(Block::default().title("Bi-Temporal History").borders(Borders::ALL));
+            let heatmap_widget = Paragraph::new(heatmap_str).block(
+                Block::default()
+                    .title("Bi-Temporal History")
+                    .borders(Borders::ALL),
+            );
             f.render_widget(heatmap_widget, heatmap_chunks[0]);
 
             let total_events: usize = self.heatmap.grid.iter().flatten().sum();
             let stats_text = vec![
-                Line::from(Span::styled("Archive Stats", Style::default().add_modifier(Modifier::UNDERLINED))),
+                Line::from(Span::styled(
+                    "Archive Stats",
+                    Style::default().add_modifier(Modifier::UNDERLINED),
+                )),
                 Line::from(""),
                 Line::from(format!("Entities: {total_events}")),
-                Line::from(format!("Valid: {} - {}",
+                Line::from(format!(
+                    "Valid: {} - {}",
                     self.heatmap.valid_range.0.format("%H:%M"),
-                    self.heatmap.valid_range.1.format("%H:%M"))),
+                    self.heatmap.valid_range.1.format("%H:%M")
+                )),
             ];
             let stats_widget = Paragraph::new(stats_text)
                 .block(Block::default().title("Archive").borders(Borders::ALL));
@@ -221,39 +238,45 @@ pub mod tui {
             let mut chart_title = "Live Telemetry (Simulated)";
 
             if let Some(telemetry) = &self.telemetry {
-                 // Try to read real metrics
-                 let now = Utc::now();
-                 let from = now - chrono::Duration::seconds(100);
+                // Try to read real metrics
+                let now = Utc::now();
+                let from = now - chrono::Duration::seconds(100);
 
-                 // Look for standard metrics. If none, fallback to simulated.
-                 // We don't have a way to know metric names without scanning.
-                 // But let's assume "cpu_usage" exists if telemetry is active.
-                 let samples = telemetry.metric_history("cpu_usage", from, now);
+                // Look for standard metrics. If none, fallback to simulated.
+                // We don't have a way to know metric names without scanning.
+                // But let's assume "cpu_usage" exists if telemetry is active.
+                let samples = telemetry.metric_history("cpu_usage", from, now);
 
-                 if !samples.is_empty() {
-                     chart_title = "Live Telemetry (cpu_usage)";
-                     let base_time = from.timestamp_millis() as f64 / 1000.0;
-                     for s in samples {
-                         let time_sec = s.timestamp_ns as f64 / 1_000_000_000.0;
-                         // Normalize time to 0-100 range relative to window
-                         let rel_time = time_sec - base_time;
-                         if rel_time >= 0.0 && rel_time <= 100.0 {
-                             let val = match s.value {
-                                 MetricValue::Counter(v) => v as f64,
-                                 MetricValue::Gauge(v) => v as f64,
-                                 MetricValue::Histogram { sum, count, .. } => if count > 0 { sum / count as f64 } else { 0.0 },
-                             };
-                             data_points.push((rel_time, val));
-                         }
-                     }
-                 }
+                if !samples.is_empty() {
+                    chart_title = "Live Telemetry (cpu_usage)";
+                    let base_time = from.timestamp_millis() as f64 / 1000.0;
+                    for s in samples {
+                        let time_sec = s.timestamp_ns as f64 / 1_000_000_000.0;
+                        // Normalize time to 0-100 range relative to window
+                        let rel_time = time_sec - base_time;
+                        if rel_time >= 0.0 && rel_time <= 100.0 {
+                            let val = match s.value {
+                                MetricValue::Counter(v) => v as f64,
+                                MetricValue::Gauge(v) => v as f64,
+                                MetricValue::Histogram { sum, count, .. } => {
+                                    if count > 0 {
+                                        sum / count as f64
+                                    } else {
+                                        0.0
+                                    }
+                                }
+                            };
+                            data_points.push((rel_time, val));
+                        }
+                    }
+                }
             }
 
             if data_points.is_empty() {
-                 // Fallback mock data
-                 for i in 0..100 {
-                     data_points.push((i as f64, (i as f64 / 10.0).sin()));
-                 }
+                // Fallback mock data
+                for i in 0..100 {
+                    data_points.push((i as f64, (i as f64 / 10.0).sin()));
+                }
             }
 
             let dataset = Dataset::default()
@@ -289,14 +312,17 @@ pub mod tui {
                 items.push(ListItem::new("Oracle Unreachable"));
             }
 
-            let list = List::new(items)
-                .block(Block::default().title("Prophecies (Next 10m)").borders(Borders::ALL));
+            let list = List::new(items).block(
+                Block::default()
+                    .title("Prophecies (Next 10m)")
+                    .borders(Borders::ALL),
+            );
 
             f.render_widget(list, bottom_chunks[1]);
 
             // Footer
-            let footer = Paragraph::new("Press 'q' to exit")
-                .block(Block::default().borders(Borders::ALL));
+            let footer =
+                Paragraph::new("Press 'q' to exit").block(Block::default().borders(Borders::ALL));
             f.render_widget(footer, chunks[2]);
         }
     }

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -6,8 +6,8 @@ use anyhow::Result;
 use std::sync::Arc;
 use tardis_chronos::Chronos;
 use tardis_gallifrey::Gallifrey;
-use tardis_vortex::Vortex;
 use tardis_telemetry::{init, TelemetryConfig};
+use tardis_vortex::Vortex;
 use tracing::info;
 
 #[cfg(feature = "nova")]
@@ -30,7 +30,6 @@ async fn main() -> Result<()> {
     // Capture the store
     // Telemetry is compiled with "std" feature in shell dependency, so store field exists
     let telemetry_store = telemetry_handle.store.clone();
-
 
     info!("Starting Tardis Shell");
 

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -138,7 +138,7 @@ impl RingSlot {
                 timestamp_ns: 0,
                 level: 0, // Level::Trace
                 _pad: 0,
-                subsystem: 255, // Subsystem::Unknown
+                subsystem: 255,    // Subsystem::Unknown
                 event_type: 65535, // EventType::Unknown
                 span_id: SpanId::NONE,
                 trace_id: TraceId::NONE,
@@ -499,7 +499,12 @@ impl RingBuffer {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic, clippy::expect_used, clippy::cast_possible_truncation)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::cast_possible_truncation
+)]
 mod tests {
     use super::*;
     use proptest::prelude::*;
@@ -822,7 +827,7 @@ mod tests {
                 timestamp_ns: 12345,
                 level: 255, // Invalid Level
                 _pad: 0,
-                subsystem: 65000, // Invalid Subsystem
+                subsystem: 65000,  // Invalid Subsystem
                 event_type: 60000, // Invalid EventType
                 span_id: SpanId::NONE,
                 trace_id: TraceId::NONE,

--- a/telemetry/tests/ring_buffer_race.rs
+++ b/telemetry/tests/ring_buffer_race.rs
@@ -10,7 +10,7 @@
 use std::sync::{Arc, Barrier};
 use std::thread;
 use tardis_telemetry::kernel::RingBuffer;
-use tardis_telemetry::types::{TelemetryEntry, Level, Subsystem, EventType, SpanId, TraceId};
+use tardis_telemetry::types::{EventType, Level, SpanId, Subsystem, TelemetryEntry, TraceId};
 
 #[test]
 fn race_condition_repro() {
@@ -74,12 +74,16 @@ fn race_condition_repro() {
         let payload_vec: Vec<u8> = payload;
         // Check strict equality.
         if payload_vec != expected {
-             // CORRUPTION DETECTED
-             panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
+            // CORRUPTION DETECTED
+            panic!("Corruption detected! Entry: t_id={}, i={}. Expected len={}, Got len={}. Payload prefix: {:?}",
                  t_id, i, expected.len(), payload_vec.len(), String::from_utf8_lossy(&payload_vec.iter().take(20).cloned().collect::<Vec<u8>>()));
         }
         valid_count += 1;
     }
 
-    println!("Read {} valid entries out of {} writes", valid_count, THREADS * WRITES_PER_THREAD);
+    println!(
+        "Read {} valid entries out of {} writes",
+        valid_count,
+        THREADS * WRITES_PER_THREAD
+    );
 }

--- a/vortex/src/inference/runtime.rs
+++ b/vortex/src/inference/runtime.rs
@@ -1,5 +1,6 @@
 //! Main Vortex inference runtime.
 
+use crate::config::{InferenceParams, ModelLoadConfig};
 use crate::error::{VortexError, VortexResult};
 use crate::loader::{
     download_preset, find_model_file, load_model_weights, parse_model_config, DeviceSpec,
@@ -10,7 +11,6 @@ use crate::tokenizer::TokenizerService;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
-use crate::config::{InferenceParams, ModelLoadConfig};
 use tokio::task;
 use tracing::{info, instrument};
 
@@ -22,7 +22,8 @@ pub type MockInference =
 pub type MockEmbedding = Box<dyn Fn(ModelHandle, &str) -> VortexResult<Vec<f32>> + Send + Sync>;
 
 /// Mock load model callback type.
-pub type MockLoadModel = Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
+pub type MockLoadModel =
+    Box<dyn Fn(&str, ModelLoadConfig) -> VortexResult<ModelHandle> + Send + Sync>;
 
 /// The main Vortex inference engine.
 pub struct Vortex {


### PR DESCRIPTION
Refactored `chronos/src/pipeline/analyzer.rs` to improve readability and idiomatic Rust usage.

🚮 Smell:
- Imperative `for` loops for simple filtering/mapping.
- `#[allow(clippy::unused_self)]` suppressed on methods that didn't access `self`.
- Deep nesting in `classify_intent`.

✨ Solution:
- Used `iter().filter().map().collect()` chains.
- Converted methods to associated functions (static methods).
- Used `map_or_else` for cleaner Option handling.

🧼 Benefit:
- Reduced cognitive load by removing state dependencies where none existed.
- More declarative code style.
- Removed lint suppressions.

🛡️ Verification:
- `cargo test -p tardis-chronos` passed.
- `cargo clippy -p tardis-chronos` passed.
- No logic changes (verified by tests).

---
*PR created automatically by Jules for task [8446050299117262230](https://jules.google.com/task/8446050299117262230) started by @madmax983*