### PR TITLE
🔒 Warden: Fix mixed volatile/non-volatile access in RingBuffer

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -18,3 +18,7 @@
 **2025-06-02 - KernelLogger Race Condition**
 **Threat:** A race condition in `KernelLogger::init` allowed `get()` to access `KERNEL_LOGGER` before it was fully initialized, leading to Undefined Behavior (reading partially written `static mut`).
 **Defense:** Replaced the boolean initialization flag with an `AtomicU8` state machine (`UNINIT`, `INITING`, `INITED`). Used `Release` ordering in `init` and `Acquire` ordering in `get` to enforce a happens-before relationship, ensuring `KERNEL_LOGGER` is only accessed after initialization is complete and visible.
+
+**2025-06-03 - RingBuffer Mixed Volatile Access**
+**Threat:** `RingBuffer::try_write` updated the `payload_len` field using a non-volatile write (`(*ptr).payload_len = ...`) after writing the struct header volatilely. This mixed volatile and non-volatile access to the same memory location, creating potential Undefined Behavior (data race) if a reader accessed it concurrently, as the compiler could reorder or tear the non-volatile write despite Seqlock protection.
+**Defense:** Refactored `try_write` to update the `payload_len` in the local `TelemetryEntryRaw` copy *before* the volatile write. Now uses a single `ptr::write_volatile` to write the entire header, ensuring all shared memory writes are volatile and atomic with respect to compiler optimizations.

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -281,21 +281,25 @@ impl RingBuffer {
         unsafe {
             let entry_ptr = slot.entry.get();
             // Convert to raw representation for safe storage
-            let raw_entry = TelemetryEntryRaw::from(entry.clone());
+            let mut raw_entry = TelemetryEntryRaw::from(entry.clone());
+
+            // Update payload length in local copy before writing to shared memory
+            let payload_len = payload.len().min(MAX_PAYLOAD_SIZE);
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                raw_entry.payload_len = payload_len as u16;
+            }
+
+            // Write the whole struct volatilely once
+            // This ensures all fields, including payload_len, are written using volatile access,
+            // preventing mixed volatile/non-volatile access (potential UB) to the same memory location.
             core::ptr::write_volatile(entry_ptr, raw_entry);
 
             // Write payload
-            let payload_len = payload.len().min(MAX_PAYLOAD_SIZE);
             let payload_ptr = slot.payload.get().cast::<u8>();
             // Use volatile write to avoid data races with concurrent readers (Seqlock)
             for (i, &byte) in payload.iter().enumerate().take(payload_len) {
                 core::ptr::write_volatile(payload_ptr.add(i), byte);
-            }
-
-            // Update payload length
-            #[allow(clippy::cast_possible_truncation)]
-            {
-                (*entry_ptr).payload_len = payload_len as u16;
             }
         }
 


### PR DESCRIPTION
🦠 Threat: `RingBuffer::try_write` updated the `payload_len` field using a non-volatile write after writing the struct header volatilely. This mixed volatile and non-volatile access to the same memory location, creating potential Undefined Behavior (data race) if a reader accessed it concurrently, as the compiler could reorder or tear the non-volatile write despite Seqlock protection.

🛡️ Defense: Refactored `try_write` to update the `payload_len` in the local `TelemetryEntryRaw` copy *before* the volatile write. Now uses a single `ptr::write_volatile` to write the entire header, ensuring all shared memory writes are volatile and atomic with respect to compiler optimizations.

💥 Severity: High - Potential kernel panic or data corruption in telemetry system.

🧪 Verification: Ran `cargo test -p tardis-telemetry --features kernel` and `cargo test -p tardis-telemetry --features kernel --test ring_buffer_race`.

---
*PR created automatically by Jules for task [4798064535847046977](https://jules.google.com/task/4798064535847046977) started by @madmax983*