### PR TITLE
⚡ Bolt: Avoid allocation in context truncation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 **Cow in Public Structs
 **Learning:** Replacing `String` with `Cow<'static, str>` in a public struct is a breaking API change because it breaks existing struct literal initialization (e.g., `Struct { field: string_val }` fails type inference/conversion).
 **Action:** Avoid changing field types in public structs unless a major version bump is planned. Use internal storage optimizations or new types instead.
+
+**String Allocation during Truncation
+**Learning:** `str::chars().take(n).collect::<String>()` allocates a new `String` which is immediately discarded if used only for display/formatting.
+**Action:** Use `str::char_indices().nth(n)` to find the split point and use a string slice `&str[..idx]` to avoid allocation.

--- a/chronos/src/experimental/doctor.rs
+++ b/chronos/src/experimental/doctor.rs
@@ -65,7 +65,7 @@ pub struct SystemDoctor {
 impl SystemDoctor {
     /// Create a new System Doctor.
     #[must_use]
-    pub fn new(telemetry: Arc<TelemetryStore>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(telemetry: Arc<TelemetryStore>, gallifrey: Arc<Gallifrey>) -> Self {
         Self {
             telemetry,
             gallifrey,
@@ -97,10 +97,10 @@ impl SystemDoctor {
         let (total_latency, count) = completed_spans
             .iter()
             .filter_map(|s| s.data.duration_ns())
-            .fold((0, 0), |(sum, count), dur| (sum + dur, count + 1));
+            .fold((0, 0u64), |(sum, count), dur| (sum + dur, count + 1));
 
         let average_latency_ms = if count > 0 {
-            (total_latency / count as u64) / 1_000_000
+            (total_latency / count) / 1_000_000
         } else {
             0
         };
@@ -152,21 +152,17 @@ impl SystemDoctor {
         // Correlate with system changes (simple heuristic for now)
         // In a real version, we'd ask Gallifrey for recent "SystemState" changes
         // and ask Vortex to find causality.
-        let root_causes = if status != HealthStatus::Healthy {
+        let root_causes = if status == HealthStatus::Healthy {
+            Vec::new()
+        } else {
             // Mock causality
             vec!["Possible recent configuration change or high load".to_string()]
-        } else {
-            Vec::new()
         };
 
-        let prescription = if status != HealthStatus::Healthy {
-            Some(Prescription {
-                description: "Check recent system state changes and error logs.".to_string(),
-                auto_fix_command: None,
-            })
-        } else {
-            None
-        };
+        let prescription = (status != HealthStatus::Healthy).then(|| Prescription {
+            description: "Check recent system state changes and error logs.".to_string(),
+            auto_fix_command: None,
+        });
 
         Diagnosis {
             status,

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -156,7 +156,7 @@ impl ContextAugmenter {
 
             // Rough token estimate (4 chars per token)
             // Ceiling division to ensure non-empty sources cost at least 1 token
-            let source_tokens = (source.content.len() + 3) / 4;
+            let source_tokens = source.content.len().div_ceil(4);
 
             if token_estimate + source_tokens > self.max_context_tokens {
                 // Calculate remaining budget
@@ -165,13 +165,21 @@ impl ContextAugmenter {
 
                 // If we have space for at least some content, include it partially
                 if chars_to_take > 0 {
-                    let content: String = source.content.chars().take(chars_to_take).collect();
+                    // Bolt optimization: slice string instead of allocating new one
+                    let end_index = source
+                        .content
+                        .char_indices()
+                        .map(|(i, _)| i)
+                        .nth(chars_to_take)
+                        .unwrap_or(source.content.len());
+
+                    let truncated_content = &source.content[..end_index];
                     let _ = writeln!(
                         buffer,
                         "### {source_type} {} (relevance: {:.2})\n{}...\n",
                         i + 1,
                         source.relevance,
-                        content
+                        truncated_content
                     );
                 }
 
@@ -187,8 +195,7 @@ impl ContextAugmenter {
                 if sources_fully_dropped > 0 {
                     let _ = writeln!(
                         buffer,
-                        "\n... ({} more sources truncated)",
-                        sources_fully_dropped
+                        "\n... ({sources_fully_dropped} more sources truncated)"
                     );
                 }
                 break;


### PR DESCRIPTION
Implemented a performance optimization in `chronos/src/pipeline/augmenter.rs` identified by Bolt.

**What:**
Refactored the context truncation logic to avoid allocating an intermediate `String`.

**Why:**
The previous implementation used `chars().take(n).collect::<String>()` which allocates a new string on the heap only to write it to a buffer and drop it. This is inefficient, especially for large context chunks.

**Impact:**
Removes 1 heap allocation per truncated source per query. While small individually, this reduces memory fragmentation and CPU cycles in the RAG pipeline.

**Verification:**
- Ran `cargo test -p tardis-chronos` (all pass).
- Ran `cargo clippy -p tardis-chronos` (all clean).
- Verified logic handles UTF-8 boundaries correctly using `char_indices`.

Also opportunistically fixed clippy warnings in `chronos/src/experimental/doctor.rs` to ensure a clean build.

---
*PR created automatically by Jules for task [12471925825156114843](https://jules.google.com/task/12471925825156114843) started by @madmax983*