### PR TITLE
Simplify stateless abstractions (Razor)

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -1,4 +1,4 @@
 ## [Reduction]
-**Bloat:** Speculative Generality and "One-Time Traits" (`VortexService`, `GallifreyService`, `ChronosService`).
-**Cut:** Replaced traits with concrete Structs (`Vortex`, `Gallifrey`). Removed unused `ChronosService`.
-**Saved:** 3 traits, 300+ lines of code, unnecessary casting, and cognitive load of following indirection.
+**Bloat:** Stateless structs (`QueryAnalyzer`, `CommandHandler`, `Router`) acting as namespaces for pure functions.
+**Cut:** Converted to modules with free functions.
+**Saved:** Removed 3 structs, 3 `new()` methods, 3 fields in consumer structs, and simplified call sites. Reduced cognitive load by making execution path explicit (functions are stateless).

--- a/chronos/benches/pipeline_benchmarks.rs
+++ b/chronos/benches/pipeline_benchmarks.rs
@@ -3,28 +3,24 @@
 #![allow(clippy::unwrap_used)]
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
-use tardis_chronos::pipeline::{ContextAugmenter, QueryAnalyzer};
+use tardis_chronos::pipeline::{analyzer, ContextAugmenter};
 
 fn bench_query_analyzer(c: &mut Criterion) {
     let mut group = c.benchmark_group("query_analyzer");
 
-    group.bench_function("QueryAnalyzer::new", |b| {
-        b.iter(|| black_box(QueryAnalyzer::new()));
+    // QueryAnalyzer::new is removed (it was stateless anyway)
+
+    group.bench_function("analyzer::analyze_simple", |b| {
+        b.iter(|| black_box(analyzer::analyze("What is Rust?")));
     });
 
-    let analyzer = QueryAnalyzer::new();
-
-    group.bench_function("QueryAnalyzer::analyze_simple", |b| {
-        b.iter(|| black_box(analyzer.analyze("What is Rust?")));
+    group.bench_function("analyzer::analyze_temporal", |b| {
+        b.iter(|| black_box(analyzer::analyze("What did we discuss yesterday about async?")));
     });
 
-    group.bench_function("QueryAnalyzer::analyze_temporal", |b| {
-        b.iter(|| black_box(analyzer.analyze("What did we discuss yesterday about async?")));
-    });
-
-    group.bench_function("QueryAnalyzer::analyze_complex", |b| {
+    group.bench_function("analyzer::analyze_complex", |b| {
         b.iter(|| {
-            black_box(analyzer.analyze(
+            black_box(analyzer::analyze(
             "Last week before the meeting, what changes were made to the authentication system?"
         ))
         });
@@ -41,8 +37,7 @@ fn bench_context_augmenter(c: &mut Criterion) {
     });
 
     let augmenter = ContextAugmenter::new();
-    let analyzer = QueryAnalyzer::new();
-    let analysis = analyzer.analyze("What is Rust?").unwrap();
+    let analysis = analyzer::analyze("What is Rust?").unwrap();
 
     group.bench_function("ContextAugmenter::augment_empty", |b| {
         b.iter(|| black_box(augmenter.augment("What is Rust?", &[], &analysis)));

--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -116,244 +116,205 @@ const INTENT_RULES: &[IntentRule] = &[
     },
 ];
 
-/// Query analyzer.
+/// Analyze a query.
 ///
-/// The analyzer is the first step in the RAG pipeline. It normalizes the query
-/// and runs it through a set of heuristic rules to determine:
+/// # Examples
 ///
-/// 1. **Intent**: What action should the system take? (e.g. search knowledge, store memory, diff states).
-/// 2. **Temporality**: Does the query refer to a specific time in the past?
-/// 3. **Entities**: (Future) Which specific entities are being discussed?
-#[derive(Debug)]
-pub struct QueryAnalyzer {
-    // Configuration
+/// Basic recall query:
+/// ```
+/// use tardis_chronos::pipeline::{analyzer, QueryIntent};
+/// use tardis_common::temporal::TemporalReference;
+///
+/// let analysis = analyzer::analyze("What did we do yesterday?").unwrap();
+///
+/// assert_eq!(analysis.intent, QueryIntent::Recall);
+/// assert!(!analysis.temporal_refs.is_empty());
+/// match &analysis.temporal_refs[0] {
+///    TemporalReference::Relative { text, .. } => assert_eq!(text, "yesterday"),
+///    _ => panic!("Expected relative reference"),
+/// }
+/// ```
+///
+/// Storing a memory:
+/// ```
+/// use tardis_chronos::pipeline::{analyzer, QueryIntent};
+///
+/// let analysis = analyzer::analyze("Remember that the sky is blue").unwrap();
+///
+/// assert_eq!(analysis.intent, QueryIntent::Remember);
+/// ```
+///
+/// Comparing states (temporal diff):
+/// ```
+/// use tardis_chronos::pipeline::{analyzer, QueryIntent};
+///
+/// let analysis = analyzer::analyze("How has the user profile changed?").unwrap();
+///
+/// assert_eq!(analysis.intent, QueryIntent::TemporalDiff);
+/// ```
+///
+/// System introspection:
+/// ```
+/// use tardis_chronos::pipeline::{analyzer, QueryIntent};
+///
+/// let analysis = analyzer::analyze("Take a system snapshot").unwrap();
+///
+/// assert_eq!(analysis.intent, QueryIntent::SystemQuery);
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if analysis fails.
+pub fn analyze(query: &str) -> ChronosResult<AnalyzedQuery> {
+    // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
+    let query_lower = query.to_lowercase();
+    let intent = classify_intent(&query_lower);
+    let temporal_refs = extract_temporal_refs(&query_lower, Utc::now());
+    let entities = extract_entities(query);
+
+    let temporal_description = if temporal_refs.is_empty() {
+        None
+    } else {
+        Some(describe_temporal_context(&temporal_refs))
+    };
+
+    Ok(AnalyzedQuery {
+        text: query.to_string(),
+        intent,
+        temporal_refs,
+        temporal_description,
+        entities,
+    })
 }
 
-impl QueryAnalyzer {
-    /// Create a new query analyzer.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {}
+/// Classify the intent of a query.
+fn classify_intent(query_lower: &str) -> QueryIntent {
+    for rule in INTENT_RULES {
+        if rule.matches(query_lower) {
+            return rule.intent.clone();
+        }
     }
 
-    /// Analyze a query.
-    ///
-    /// # Examples
-    ///
-    /// Basic recall query:
-    /// ```
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, QueryIntent};
-    /// use tardis_common::temporal::TemporalReference;
-    ///
-    /// let analyzer = QueryAnalyzer::new();
-    /// let analysis = analyzer.analyze("What did we do yesterday?").unwrap();
-    ///
-    /// assert_eq!(analysis.intent, QueryIntent::Recall);
-    /// assert!(!analysis.temporal_refs.is_empty());
-    /// match &analysis.temporal_refs[0] {
-    ///    TemporalReference::Relative { text, .. } => assert_eq!(text, "yesterday"),
-    ///    _ => panic!("Expected relative reference"),
-    /// }
-    /// ```
-    ///
-    /// Storing a memory:
-    /// ```
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, QueryIntent};
-    ///
-    /// let analyzer = QueryAnalyzer::new();
-    /// let analysis = analyzer.analyze("Remember that the sky is blue").unwrap();
-    ///
-    /// assert_eq!(analysis.intent, QueryIntent::Remember);
-    /// ```
-    ///
-    /// Comparing states (temporal diff):
-    /// ```
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, QueryIntent};
-    ///
-    /// let analyzer = QueryAnalyzer::new();
-    /// let analysis = analyzer.analyze("How has the user profile changed?").unwrap();
-    ///
-    /// assert_eq!(analysis.intent, QueryIntent::TemporalDiff);
-    /// ```
-    ///
-    /// System introspection:
-    /// ```
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, QueryIntent};
-    ///
-    /// let analyzer = QueryAnalyzer::new();
-    /// let analysis = analyzer.analyze("Take a system snapshot").unwrap();
-    ///
-    /// assert_eq!(analysis.intent, QueryIntent::SystemQuery);
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if analysis fails.
-    pub fn analyze(&self, query: &str) -> ChronosResult<AnalyzedQuery> {
-        // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
-        let query_lower = query.to_lowercase();
-        let intent = self.classify_intent(&query_lower);
-        let temporal_refs = self.extract_temporal_refs(&query_lower, Utc::now());
-        let entities = self.extract_entities(query);
+    if query_lower.ends_with('?') {
+        return QueryIntent::Question;
+    }
 
-        let temporal_description = if temporal_refs.is_empty() {
-            None
-        } else {
-            Some(self.describe_temporal_context(&temporal_refs))
-        };
+    QueryIntent::Chat
+}
 
-        Ok(AnalyzedQuery {
-            text: query.to_string(),
-            intent,
-            temporal_refs,
-            temporal_description,
-            entities,
+/// Extract temporal references from a query.
+fn extract_temporal_refs(
+    query_lower: &str,
+    now: DateTime<Utc>,
+) -> Vec<TemporalReference> {
+    let mut refs = Vec::new();
+
+    for rule in TEMPORAL_RULES {
+        if query_lower.contains(rule.keyword) {
+            let resolved = rule.resolve(now);
+
+            refs.push(TemporalReference::Relative {
+                text: rule.keyword.to_string(),
+                resolved,
+            });
+        }
+    }
+
+    // TODO: Add more sophisticated temporal extraction
+    // - NLP-based extraction
+    // - Absolute date parsing
+    // - Event-based references
+
+    refs
+}
+
+/// Extract entity mentions from a query.
+const fn extract_entities(query: &str) -> Vec<String> {
+    // TODO: Implement NER or pattern matching
+    // For now, just return empty
+    let _ = query;
+    Vec::new()
+}
+
+/// Generate human-readable description of temporal context.
+fn describe_temporal_context(refs: &[TemporalReference]) -> String {
+    if refs.is_empty() {
+        return "current time".to_string();
+    }
+
+    refs.iter()
+        .map(|r| match r {
+            TemporalReference::Relative { text, resolved } => {
+                format!("{} ({})", text, resolved.format("%Y-%m-%d"))
+            }
+            TemporalReference::Absolute(resolved) => resolved.format("%Y-%m-%d").to_string(),
+            TemporalReference::EventBased { event, resolved } => {
+                if let Some(res) = resolved {
+                    format!("{} ({})", event, res.format("%Y-%m-%d"))
+                } else {
+                    event.clone()
+                }
+            }
+            TemporalReference::Implicit => "implicit".to_string(),
         })
-    }
-
-    /// Classify the intent of a query.
-    #[allow(clippy::unused_self)]
-    fn classify_intent(&self, query_lower: &str) -> QueryIntent {
-        for rule in INTENT_RULES {
-            if rule.matches(query_lower) {
-                return rule.intent.clone();
-            }
-        }
-
-        if query_lower.ends_with('?') {
-            return QueryIntent::Question;
-        }
-
-        QueryIntent::Chat
-    }
-
-    /// Extract temporal references from a query.
-    #[allow(clippy::unused_self)]
-    fn extract_temporal_refs(
-        &self,
-        query_lower: &str,
-        now: DateTime<Utc>,
-    ) -> Vec<TemporalReference> {
-        let mut refs = Vec::new();
-
-        for rule in TEMPORAL_RULES {
-            if query_lower.contains(rule.keyword) {
-                let resolved = rule.resolve(now);
-
-                refs.push(TemporalReference::Relative {
-                    text: rule.keyword.to_string(),
-                    resolved,
-                });
-            }
-        }
-
-        // TODO: Add more sophisticated temporal extraction
-        // - NLP-based extraction
-        // - Absolute date parsing
-        // - Event-based references
-
-        refs
-    }
-
-    /// Extract entity mentions from a query.
-    #[allow(clippy::unused_self)]
-    const fn extract_entities(&self, query: &str) -> Vec<String> {
-        // TODO: Implement NER or pattern matching
-        // For now, just return empty
-        let _ = query;
-        Vec::new()
-    }
-
-    /// Generate human-readable description of temporal context.
-    #[allow(clippy::unused_self)]
-    fn describe_temporal_context(&self, refs: &[TemporalReference]) -> String {
-        if refs.is_empty() {
-            return "current time".to_string();
-        }
-
-        refs.iter()
-            .map(|r| match r {
-                TemporalReference::Relative { text, resolved } => {
-                    format!("{} ({})", text, resolved.format("%Y-%m-%d"))
-                }
-                TemporalReference::Absolute(resolved) => resolved.format("%Y-%m-%d").to_string(),
-                TemporalReference::EventBased { event, resolved } => {
-                    if let Some(res) = resolved {
-                        format!("{} ({})", event, res.format("%Y-%m-%d"))
-                    } else {
-                        event.clone()
-                    }
-                }
-                TemporalReference::Implicit => "implicit".to_string(),
-            })
-            .collect::<Vec<_>>()
-            .join(", ")
-    }
-}
-
-impl Default for QueryAnalyzer {
-    fn default() -> Self {
-        Self::new()
-    }
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_classify_intent() {
-        let analyzer = QueryAnalyzer::new();
-
         assert_eq!(
-            analyzer.classify_intent(&"Remember that I like pizza".to_lowercase()),
+            classify_intent(&"Remember that I like pizza".to_lowercase()),
             QueryIntent::Remember
         );
         assert_eq!(
-            analyzer.classify_intent(&"Please remember this conversation".to_lowercase()),
+            classify_intent(&"Please remember this conversation".to_lowercase()),
             QueryIntent::Remember
         );
         assert_eq!(
-            analyzer.classify_intent(&"What did we discuss yesterday?".to_lowercase()),
+            classify_intent(&"What did we discuss yesterday?".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"Recall the meeting notes".to_lowercase()),
+            classify_intent(&"Recall the meeting notes".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"What was the result?".to_lowercase()),
+            classify_intent(&"What was the result?".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"How has the project changed?".to_lowercase()),
+            classify_intent(&"How has the project changed?".to_lowercase()),
             QueryIntent::TemporalDiff
         );
         assert_eq!(
-            analyzer.classify_intent(&"Show me the system state".to_lowercase()),
+            classify_intent(&"Show me the system state".to_lowercase()),
             QueryIntent::SystemQuery
         );
         assert_eq!(
-            analyzer.classify_intent(&"Take a snapshot".to_lowercase()),
+            classify_intent(&"Take a snapshot".to_lowercase()),
             QueryIntent::SystemQuery
         );
         assert_eq!(
-            analyzer.classify_intent(&"Is this a question?".to_lowercase()),
+            classify_intent(&"Is this a question?".to_lowercase()),
             QueryIntent::Question
         );
         assert_eq!(
-            analyzer.classify_intent(&"Just chatting".to_lowercase()),
+            classify_intent(&"Just chatting".to_lowercase()),
             QueryIntent::Chat
         );
     }
 
     #[test]
     fn test_extract_temporal_refs() {
-        let analyzer = QueryAnalyzer::new();
         let now = Utc::now();
 
-        let refs = analyzer.extract_temporal_refs(&"What happened yesterday?".to_lowercase(), now);
+        let refs = extract_temporal_refs(&"What happened yesterday?".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
 
         match &refs[0] {
@@ -361,27 +322,26 @@ mod tests {
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Check last week logs".to_lowercase(), now);
+        let refs = extract_temporal_refs(&"Check last week logs".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "last week"),
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Do it today".to_lowercase(), now);
+        let refs = extract_temporal_refs(&"Do it today".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "today"),
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Yesterday and today".to_lowercase(), now);
+        let refs = extract_temporal_refs(&"Yesterday and today".to_lowercase(), now);
         assert_eq!(refs.len(), 2);
     }
 
     #[test]
     fn test_extract_temporal_refs_resolved() {
-        let analyzer = QueryAnalyzer::new();
         // Use a fixed date for deterministic testing
         // 2024-03-15 12:00:00 UTC
         let now = DateTime::parse_from_rfc3339("2024-03-15T12:00:00Z")
@@ -389,7 +349,7 @@ mod tests {
             .with_timezone(&Utc);
 
         // "yesterday" should be 2024-03-14 12:00:00 UTC
-        let refs = analyzer.extract_temporal_refs("yesterday", now);
+        let refs = extract_temporal_refs("yesterday", now);
         assert_eq!(refs.len(), 1);
         assert_eq!(
             refs[0].resolved().unwrap().to_rfc3339(),
@@ -397,7 +357,7 @@ mod tests {
         );
 
         // "last week" should be 2024-03-08 12:00:00 UTC
-        let refs = analyzer.extract_temporal_refs("last week", now);
+        let refs = extract_temporal_refs("last week", now);
         assert_eq!(refs.len(), 1);
         assert_eq!(
             refs[0].resolved().unwrap().to_rfc3339(),
@@ -407,10 +367,9 @@ mod tests {
 
     #[test]
     fn test_describe_temporal_context() {
-        let analyzer = QueryAnalyzer::new();
         let now = Utc::now();
-        let refs = analyzer.extract_temporal_refs("yesterday", now);
-        let desc = analyzer.describe_temporal_context(&refs);
+        let refs = extract_temporal_refs("yesterday", now);
+        let desc = describe_temporal_context(&refs);
         assert!(desc.contains("yesterday"));
     }
 }

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -56,7 +56,7 @@ impl ContextAugmenter {
     ///
     /// ```
     /// use tardis_chronos::pipeline::{ContextAugmenter, ContextSource, ContextSourceType};
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, AnalyzedQuery, QueryIntent};
+    /// use tardis_chronos::pipeline::{AnalyzedQuery, QueryIntent};
     /// use tardis_common::temporal::TemporalReference;
     /// use chrono::Utc;
     ///
@@ -156,7 +156,7 @@ impl ContextAugmenter {
 
             // Rough token estimate (4 chars per token)
             // Ceiling division to ensure non-empty sources cost at least 1 token
-            let source_tokens = (source.content.len() + 3) / 4;
+            let source_tokens = source.content.len().div_ceil(4);
 
             if token_estimate + source_tokens > self.max_context_tokens {
                 // Calculate remaining budget
@@ -165,13 +165,13 @@ impl ContextAugmenter {
 
                 // If we have space for at least some content, include it partially
                 if chars_to_take > 0 {
-                    let content: String = source.content.chars().take(chars_to_take).collect();
+                    let truncated_content: String = source.content.chars().take(chars_to_take).collect();
                     let _ = writeln!(
                         buffer,
                         "### {source_type} {} (relevance: {:.2})\n{}...\n",
                         i + 1,
                         source.relevance,
-                        content
+                        truncated_content
                     );
                 }
 
@@ -187,8 +187,7 @@ impl ContextAugmenter {
                 if sources_fully_dropped > 0 {
                     let _ = writeln!(
                         buffer,
-                        "\n... ({} more sources truncated)",
-                        sources_fully_dropped
+                        "\n... ({sources_fully_dropped} more sources truncated)"
                     );
                 }
                 break;
@@ -241,6 +240,7 @@ impl Default for ContextAugmenter {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::pipeline::analyzer::{AnalyzedQuery, QueryIntent};
@@ -405,7 +405,7 @@ mod tests {
         let sources: Vec<ContextSource> = (0..20)
             .map(|i| ContextSource {
                 source_type: ContextSourceType::Knowledge,
-                content: format!("s{:02}", i),
+                content: format!("s{i:02}"),
                 relevance: 1.0,
                 entity_id: None,
             })
@@ -419,9 +419,8 @@ mod tests {
         // With limit=5, we expect 5 sources to be included (indices 0..5)
         for i in 0..5 {
             assert!(
-                result.contains(&format!("s{:02}", i)),
-                "Should contain source {}",
-                i
+                result.contains(&format!("s{i:02}")),
+                "Should contain source {i}"
             );
         }
 

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -30,11 +30,11 @@
 //! # }
 //! ```
 
-mod analyzer;
+pub mod analyzer;
 mod augmenter;
 mod retriever;
 
-pub use analyzer::{AnalyzedQuery, QueryAnalyzer, QueryIntent};
+pub use analyzer::{AnalyzedQuery, QueryIntent};
 pub use augmenter::ContextAugmenter;
 pub use retriever::Retriever;
 
@@ -120,7 +120,6 @@ pub struct Chronos {
     gallifrey: Arc<Gallifrey>,
     #[cfg(feature = "telemetry")]
     telemetry: Option<Arc<TelemetryStore>>,
-    analyzer: QueryAnalyzer,
     retriever: Retriever,
     augmenter: ContextAugmenter,
 }
@@ -134,7 +133,6 @@ impl Chronos {
             gallifrey: Arc::clone(&gallifrey),
             #[cfg(feature = "telemetry")]
             telemetry: None,
-            analyzer: QueryAnalyzer::new(),
             retriever: Retriever::new(gallifrey),
             augmenter: ContextAugmenter::new(),
         }
@@ -173,7 +171,7 @@ impl Chronos {
         info!("Processing RAG query");
 
         // 1. Analyze the query
-        let analysis = self.analyzer.analyze(prompt)?;
+        let analysis = analyzer::analyze(prompt)?;
         info!("Query analyzed: {:?}", analysis.intent);
 
         // 2. Retrieve relevant context

--- a/shell/benches/router_benchmarks.rs
+++ b/shell/benches/router_benchmarks.rs
@@ -2,63 +2,53 @@
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use std::hint::black_box;
-use tardis_shell::router::Router;
-
-fn bench_router_creation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("router_creation");
-
-    group.bench_function("Router::new", |b| {
-        b.iter(|| black_box(Router::new()));
-    });
-
-    group.finish();
-}
+use tardis_shell::router;
 
 fn bench_router_routing(c: &mut Criterion) {
     let mut group = c.benchmark_group("router_routing");
     group.throughput(Throughput::Elements(1));
 
-    let router = Router::new();
+    // router::route is now a free function, so no instance needed
 
     // Shell commands
     group.bench_function("route_shell_command", |b| {
-        b.iter(|| black_box(router.route("!ls -la")));
+        b.iter(|| black_box(router::route("!ls -la")));
     });
 
     // Built-in commands
     group.bench_function("route_builtin_help", |b| {
-        b.iter(|| black_box(router.route("help")));
+        b.iter(|| black_box(router::route("help")));
     });
 
     group.bench_function("route_builtin_history", |b| {
-        b.iter(|| black_box(router.route("history")));
+        b.iter(|| black_box(router::route("history")));
     });
 
     group.bench_function("route_builtin_with_args", |b| {
-        b.iter(|| black_box(router.route("remember this is important")));
+        b.iter(|| black_box(router::route("remember this is important")));
     });
 
     // Time travel
     group.bench_function("route_time_travel", |b| {
-        b.iter(|| black_box(router.route("@yesterday what did we discuss")));
+        b.iter(|| black_box(router::route("@yesterday what did we discuss")));
     });
 
     // Direct query
     group.bench_function("route_direct_query", |b| {
-        b.iter(|| black_box(router.route("?explain async await")));
+        b.iter(|| black_box(router::route("?explain async await")));
     });
 
     // Chronos query (default)
     group.bench_function("route_chronos_simple", |b| {
-        b.iter(|| black_box(router.route("What is Rust?")));
+        b.iter(|| black_box(router::route("What is Rust?")));
     });
 
     group.bench_function("route_chronos_temporal", |b| {
-        b.iter(|| black_box(router.route("What did we discuss yesterday about the project?")));
+        b.iter(|| black_box(router::route("What did we discuss yesterday about the project?")));
     });
 
     group.bench_function("route_chronos_long", |b| {
-        b.iter(|| black_box(router.route(
+        b.iter(|| black_box(router::route(
             "Can you explain how the authentication system works and what changes were made last week?"
         )));
     });
@@ -66,5 +56,5 @@ fn bench_router_routing(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_router_creation, bench_router_routing,);
+criterion_group!(benches, bench_router_routing,);
 criterion_main!(benches);

--- a/shell/src/commands.rs
+++ b/shell/src/commands.rs
@@ -15,188 +15,160 @@ use std::sync::Arc;
 use tardis_common::SessionId;
 use tardis_gallifrey::Gallifrey;
 
-/// Handler for built-in shell commands.
+/// Display help information.
 ///
-/// The command handler is stateless but receives the application state (like `Gallifrey` instances)
-/// during method calls to perform its duties.
-#[derive(Debug)]
-pub struct CommandHandler {
-    // Configuration
+/// If an argument is provided, displays help for that specific command.
+/// Otherwise, displays the general help menu.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tardis_shell::commands;
+///
+/// commands::help(&[]); // General help
+/// commands::help(&["remember".to_string()]); // Help for 'remember'
+/// ```
+pub fn help(args: &[String]) {
+    if args.is_empty() {
+        general_help();
+    } else {
+        command_help(&args[0]);
+    }
 }
 
-impl CommandHandler {
-    /// Create a new command handler.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {}
-    }
+/// Display general help.
+fn general_help() {
+    println!("Tardis Shell Commands:");
+    println!();
+    println!("  BUILT-IN COMMANDS:");
+    println!("    help [command]    Show help (for a specific command)");
+    println!("    history           Show conversation history");
+    println!("    remember <text>   Store information for later recall");
+    println!("    recall <query>    Retrieve stored memories");
+    println!("    models            List available LLM models");
+    println!("    context           Show current session context");
+    println!("    snapshot <name>   Save system state snapshot");
+    println!("    restore <name>    Restore a saved snapshot");
+    println!("    timeline <entity> Show history of an entity");
+    println!("    clear             Clear the screen");
+    println!("    exit / quit       Exit the shell");
+    println!();
+    println!("  INPUT MODES:");
+    println!("    <query>           Natural language (default) -> RAG response");
+    println!("    !<command>        Shell command (e.g., !ls -la)");
+    println!("    @<time> <query>   Time-travel query (e.g., @yesterday what did we discuss)");
+    println!("    ?<query>          Direct LLM query (no RAG)");
+    println!();
+    println!("  EXAMPLES:");
+    println!("    What did we discuss about Rust?");
+    println!("    remember that the API uses JWT tokens");
+    println!("    @last-week show file changes");
+    println!("    !cargo build");
+    println!();
+}
 
-    /// Display help information.
-    ///
-    /// If an argument is provided, displays help for that specific command.
-    /// Otherwise, displays the general help menu.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tardis_shell::commands::CommandHandler;
-    ///
-    /// let handler = CommandHandler::new();
-    /// handler.help(&[]); // General help
-    /// handler.help(&["remember".to_string()]); // Help for 'remember'
-    /// ```
-    #[allow(clippy::unused_self)]
-    pub fn help(&self, args: &[String]) {
-        if args.is_empty() {
-            Self::general_help();
-        } else {
-            Self::command_help(&args[0]);
+/// Display help for a specific command.
+fn command_help(command: &str) {
+    match command {
+        "remember" => {
+            println!("remember <text>");
+            println!();
+            println!("Store information in the knowledge graph for later recall.");
+            println!();
+            println!("Examples:");
+            println!("  remember that the API uses JWT tokens");
+            println!("  remember project deadline is March 15");
+        }
+        "recall" => {
+            println!("recall <query>");
+            println!();
+            println!("Retrieve stored memories matching the query.");
+            println!();
+            println!("Examples:");
+            println!("  recall what I know about authentication");
+            println!("  recall project deadlines");
+        }
+        "snapshot" => {
+            println!("snapshot <name>");
+            println!();
+            println!("Save a snapshot of the current system state.");
+            println!("Snapshots can be used for time-travel debugging.");
+            println!();
+            println!("Examples:");
+            println!("  snapshot before-refactor");
+            println!("  snapshot working-state");
+        }
+        "timeline" => {
+            println!("timeline <entity>");
+            println!();
+            println!("Show the history of changes to an entity.");
+            println!();
+            println!("Examples:");
+            println!("  timeline authentication-module");
+            println!("  timeline config.toml");
+        }
+        _ => {
+            println!("No help available for '{command}'");
         }
     }
+}
 
-    /// Display general help.
-    fn general_help() {
-        println!("Tardis Shell Commands:");
-        println!();
-        println!("  BUILT-IN COMMANDS:");
-        println!("    help [command]    Show help (for a specific command)");
-        println!("    history           Show conversation history");
-        println!("    remember <text>   Store information for later recall");
-        println!("    recall <query>    Retrieve stored memories");
-        println!("    models            List available LLM models");
-        println!("    context           Show current session context");
-        println!("    snapshot <name>   Save system state snapshot");
-        println!("    restore <name>    Restore a saved snapshot");
-        println!("    timeline <entity> Show history of an entity");
-        println!("    clear             Clear the screen");
-        println!("    exit / quit       Exit the shell");
-        println!();
-        println!("  INPUT MODES:");
-        println!("    <query>           Natural language (default) -> RAG response");
-        println!("    !<command>        Shell command (e.g., !ls -la)");
-        println!("    @<time> <query>   Time-travel query (e.g., @yesterday what did we discuss)");
-        println!("    ?<query>          Direct LLM query (no RAG)");
-        println!();
-        println!("  EXAMPLES:");
-        println!("    What did we discuss about Rust?");
-        println!("    remember that the API uses JWT tokens");
-        println!("    @last-week show file changes");
-        println!("    !cargo build");
-        println!();
-    }
-
-    /// Display help for a specific command.
-    fn command_help(command: &str) {
-        match command {
-            "remember" => {
-                println!("remember <text>");
+/// Show conversation history.
+///
+/// Fetches and displays recent messages from the current session.
+pub fn history(gallifrey: &Arc<Gallifrey>, session_id: SessionId) {
+    match gallifrey.conversation().get_messages(session_id) {
+        Ok(messages) => {
+            if messages.is_empty() {
+                println!("No messages in current session.");
+            } else {
+                println!("Session history ({} messages):", messages.len());
                 println!();
-                println!("Store information in the knowledge graph for later recall.");
-                println!();
-                println!("Examples:");
-                println!("  remember that the API uses JWT tokens");
-                println!("  remember project deadline is March 15");
-            }
-            "recall" => {
-                println!("recall <query>");
-                println!();
-                println!("Retrieve stored memories matching the query.");
-                println!();
-                println!("Examples:");
-                println!("  recall what I know about authentication");
-                println!("  recall project deadlines");
-            }
-            "snapshot" => {
-                println!("snapshot <name>");
-                println!();
-                println!("Save a snapshot of the current system state.");
-                println!("Snapshots can be used for time-travel debugging.");
-                println!();
-                println!("Examples:");
-                println!("  snapshot before-refactor");
-                println!("  snapshot working-state");
-            }
-            "timeline" => {
-                println!("timeline <entity>");
-                println!();
-                println!("Show the history of changes to an entity.");
-                println!();
-                println!("Examples:");
-                println!("  timeline authentication-module");
-                println!("  timeline config.toml");
-            }
-            _ => {
-                println!("No help available for '{command}'");
-            }
-        }
-    }
-
-    /// Show conversation history.
-    ///
-    /// Fetches and displays recent messages from the current session.
-    #[allow(clippy::unused_self)]
-    pub fn history(&self, gallifrey: &Arc<Gallifrey>, session_id: SessionId) {
-        match gallifrey.conversation().get_messages(session_id) {
-            Ok(messages) => {
-                if messages.is_empty() {
-                    println!("No messages in current session.");
-                } else {
-                    println!("Session history ({} messages):", messages.len());
-                    println!();
-                    for msg in messages.iter().take(20) {
-                        let role = match msg.role {
-                            tardis_gallifrey::stores::Role::User => "You",
-                            tardis_gallifrey::stores::Role::Assistant => "Tardis",
-                            tardis_gallifrey::stores::Role::System => "System",
-                        };
-                        let content = if msg.content.len() > 80 {
-                            format!("{}...", &msg.content[..77])
-                        } else {
-                            msg.content.clone()
-                        };
-                        println!(
-                            "  [{}] {}: {}",
-                            msg.timestamp.format("%H:%M"),
-                            role,
-                            content
-                        );
-                    }
-                    if messages.len() > 20 {
-                        println!("  ... and {} more", messages.len() - 20);
-                    }
+                for msg in messages.iter().take(20) {
+                    let role = match msg.role {
+                        tardis_gallifrey::stores::Role::User => "You",
+                        tardis_gallifrey::stores::Role::Assistant => "Tardis",
+                        tardis_gallifrey::stores::Role::System => "System",
+                    };
+                    let content = if msg.content.len() > 80 {
+                        format!("{}...", &msg.content[..77])
+                    } else {
+                        msg.content.clone()
+                    };
+                    println!(
+                        "  [{}] {}: {}",
+                        msg.timestamp.format("%H:%M"),
+                        role,
+                        content
+                    );
+                }
+                if messages.len() > 20 {
+                    println!("  ... and {} more", messages.len() - 20);
                 }
             }
-            Err(e) => {
-                println!("Failed to get history: {e}");
-            }
         }
-    }
-
-    /// List available models.
-    #[allow(clippy::unused_self)]
-    pub fn list_models(&self) {
-        println!("Available models:");
-        println!();
-        println!("  (No models loaded yet)");
-        println!();
-        println!("Use 'models load <path>' to load a model.");
-    }
-
-    /// Show current session context.
-    #[allow(clippy::unused_self)]
-    pub fn show_context(&self, session_id: SessionId) {
-        println!("Current Context:");
-        println!();
-        println!("  Session ID: {session_id}");
-        println!("  Model: (none loaded)");
-        println!("  Project: (none set)");
-        println!();
-        println!("Use 'context project:<name>' to set project context.");
+        Err(e) => {
+            println!("Failed to get history: {e}");
+        }
     }
 }
 
-impl Default for CommandHandler {
-    fn default() -> Self {
-        Self::new()
-    }
+/// List available models.
+pub fn list_models() {
+    println!("Available models:");
+    println!();
+    println!("  (No models loaded yet)");
+    println!();
+    println!("Use 'models load <path>' to load a model.");
+}
+
+/// Show current session context.
+pub fn show_context(session_id: SessionId) {
+    println!("Current Context:");
+    println!();
+    println!("  Session ID: {session_id}");
+    println!("  Model: (none loaded)");
+    println!("  Project: (none set)");
+    println!();
+    println!("Use 'context project:<name>' to set project context.");
 }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -1,7 +1,7 @@
 //! REPL (Read-Eval-Print Loop) for the Tardis shell.
 
-use crate::commands::CommandHandler;
-use crate::router::{Intent, Router};
+use crate::commands;
+use crate::router::{self, Intent};
 use anyhow::Result;
 use rustyline::error::ReadlineError;
 use rustyline::{DefaultEditor, Result as RlResult};
@@ -20,15 +20,12 @@ use tardis_chronos::experimental::prophecy::Prophet;
 pub struct Repl {
     /// Readline editor.
     editor: DefaultEditor,
-    /// Router for intent classification.
-    router: Router,
-    /// Command handler for built-in commands.
-    commands: CommandHandler,
     /// Chronos RAG engine.
     chronos: Arc<Chronos>,
     /// Gallifrey database.
     gallifrey: Arc<Gallifrey>,
     /// Telemetry store (optional).
+    #[allow(dead_code)]
     telemetry_store: Option<Arc<TelemetryStore>>,
     /// Prophet engine (optional, Nova only).
     #[cfg(feature = "nova")]
@@ -59,8 +56,6 @@ impl Repl {
 
         Ok(Self {
             editor,
-            router: Router::new(),
-            commands: CommandHandler::new(),
             chronos,
             gallifrey,
             telemetry_store,
@@ -115,7 +110,7 @@ impl Repl {
         let _ = self.editor.add_history_entry(input);
 
         // Route the input
-        let intent = self.router.route(input);
+        let intent = router::route(input);
 
         match intent {
             Intent::BuiltinCommand { command, args } => {
@@ -139,12 +134,12 @@ impl Repl {
     /// Handle a built-in command.
     async fn handle_builtin(&mut self, command: &str, args: &[String]) {
         match command {
-            "help" => self.commands.help(args),
+            "help" => commands::help(args),
             "exit" | "quit" => {
                 println!("Goodbye!");
                 self.running = false;
             }
-            "history" => self.commands.history(&self.gallifrey, self.session_id),
+            "history" => commands::history(&self.gallifrey, self.session_id),
             "remember" => {
                 let content = args.join(" ");
                 match self
@@ -167,8 +162,8 @@ impl Repl {
                     Err(e) => println!("Failed to recall: {e}"),
                 }
             }
-            "models" => self.commands.list_models(),
-            "context" => self.commands.show_context(self.session_id),
+            "models" => commands::list_models(),
+            "context" => commands::show_context(self.session_id),
             "clear" => {
                 print!("\x1B[2J\x1B[1;1H");
             }

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -50,145 +50,117 @@ pub enum Intent {
     },
 }
 
-/// Router for classifying user input intent.
+const BUILTINS: &[&str] = &[
+    "help", "exit", "quit", "history", "remember", "recall", "models", "context",
+    "clear", "snapshot", "restore", "timeline", "forget", "export",
+];
+
+/// Route user input to an intent.
 ///
-/// The router maintains a list of built-in commands and uses prefix matching
-/// to determine the intent of the user's input.
-#[derive(Debug)]
-pub struct Router {
-    /// Built-in command names.
-    builtins: Vec<&'static str>,
-}
+/// # Examples
+///
+/// ```
+/// use tardis_shell::router::{self, Intent};
+///
+/// // Built-in command
+/// let intent = router::route("help me");
+/// matches!(intent, Intent::BuiltinCommand { command, .. } if command == "help");
+///
+/// // Shell command
+/// let intent = router::route("!ls -la");
+/// matches!(intent, Intent::ShellCommand { command } if command == "ls -la");
+///
+/// // Time travel
+/// let intent = router::route("@yesterday what happened?");
+/// matches!(intent, Intent::TimeTravel { timestamp, .. } if timestamp == "yesterday");
+///
+/// // Chronos query (default)
+/// let intent = router::route("What is the meaning of life?");
+/// matches!(intent, Intent::ChronosQuery { .. });
+/// ```
+#[must_use]
+pub fn route(input: &str) -> Intent {
+    let input = input.trim();
 
-impl Router {
-    /// Create a new router.
-    ///
-    /// Initializes the router with the standard list of built-in commands.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            builtins: vec![
-                "help", "exit", "quit", "history", "remember", "recall", "models", "context",
-                "clear", "snapshot", "restore", "timeline", "forget", "export",
-            ],
-        }
+    // Check for prefix commands
+    if let Some(cmd) = input.strip_prefix('!') {
+        return Intent::ShellCommand {
+            command: cmd.to_string(),
+        };
     }
 
-    /// Route user input to an intent.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tardis_shell::router::{Router, Intent};
-    ///
-    /// let router = Router::new();
-    ///
-    /// // Built-in command
-    /// let intent = router.route("help me");
-    /// matches!(intent, Intent::BuiltinCommand { command, .. } if command == "help");
-    ///
-    /// // Shell command
-    /// let intent = router.route("!ls -la");
-    /// matches!(intent, Intent::ShellCommand { command } if command == "ls -la");
-    ///
-    /// // Time travel
-    /// let intent = router.route("@yesterday what happened?");
-    /// matches!(intent, Intent::TimeTravel { timestamp, .. } if timestamp == "yesterday");
-    ///
-    /// // Chronos query (default)
-    /// let intent = router.route("What is the meaning of life?");
-    /// matches!(intent, Intent::ChronosQuery { .. });
-    /// ```
-    #[must_use]
-    pub fn route(&self, input: &str) -> Intent {
-        let input = input.trim();
+    if let Some(rest) = input.strip_prefix('@') {
+        return parse_time_travel(rest);
+    }
 
-        // Check for prefix commands
-        if let Some(cmd) = input.strip_prefix('!') {
-            return Intent::ShellCommand {
-                command: cmd.to_string(),
+    if let Some(query) = input.strip_prefix('?') {
+        return Intent::DirectQuery {
+            query: query.trim().to_string(),
+        };
+    }
+
+    // Check for built-in commands
+    let parts: Vec<&str> = input.splitn(2, ' ').collect();
+    let first_word = parts.first().map(|s| s.to_lowercase());
+
+    if let Some(ref cmd) = first_word {
+        if BUILTINS.contains(&cmd.as_str()) {
+            let args = if parts.len() > 1 {
+                parts[1].split_whitespace().map(String::from).collect()
+            } else {
+                Vec::new()
+            };
+
+            return Intent::BuiltinCommand {
+                command: cmd.clone(),
+                args,
             };
         }
-
-        if let Some(rest) = input.strip_prefix('@') {
-            return Self::parse_time_travel(rest);
-        }
-
-        if let Some(query) = input.strip_prefix('?') {
-            return Intent::DirectQuery {
-                query: query.trim().to_string(),
-            };
-        }
-
-        // Check for built-in commands
-        let parts: Vec<&str> = input.splitn(2, ' ').collect();
-        let first_word = parts.first().map(|s| s.to_lowercase());
-
-        if let Some(ref cmd) = first_word {
-            if self.builtins.contains(&cmd.as_str()) {
-                let args = if parts.len() > 1 {
-                    parts[1].split_whitespace().map(String::from).collect()
-                } else {
-                    Vec::new()
-                };
-
-                return Intent::BuiltinCommand {
-                    command: cmd.clone(),
-                    args,
-                };
-            }
-        }
-
-        // Default: Chronos query
-        Intent::ChronosQuery {
-            query: input.to_string(),
-            temporal_context: Self::detect_temporal_context(input),
-        }
     }
 
-    /// Parse a time-travel command.
-    fn parse_time_travel(input: &str) -> Intent {
-        // Expected format: @<timestamp> <query>
-        // e.g., "@yesterday what did we discuss"
-        // e.g., "@2024-03-15 show system state"
-
-        let parts: Vec<&str> = input.splitn(2, ' ').collect();
-
-        let timestamp = parts.first().unwrap_or(&"").to_string();
-        let query = parts.get(1).unwrap_or(&"").to_string();
-
-        Intent::TimeTravel { timestamp, query }
-    }
-
-    /// Detect temporal context in a query.
-    fn detect_temporal_context(query: &str) -> Option<String> {
-        let lower = query.to_lowercase();
-
-        let temporal_patterns = [
-            "yesterday",
-            "last week",
-            "last month",
-            "today",
-            "this morning",
-            "earlier",
-            "before",
-            "after",
-        ];
-
-        for pattern in temporal_patterns {
-            if lower.contains(pattern) {
-                return Some(pattern.to_string());
-            }
-        }
-
-        None
+    // Default: Chronos query
+    Intent::ChronosQuery {
+        query: input.to_string(),
+        temporal_context: detect_temporal_context(input),
     }
 }
 
-impl Default for Router {
-    fn default() -> Self {
-        Self::new()
+/// Parse a time-travel command.
+fn parse_time_travel(input: &str) -> Intent {
+    // Expected format: @<timestamp> <query>
+    // e.g., "@yesterday what did we discuss"
+    // e.g., "@2024-03-15 show system state"
+
+    let parts: Vec<&str> = input.splitn(2, ' ').collect();
+
+    let timestamp = parts.first().unwrap_or(&"").to_string();
+    let query = parts.get(1).unwrap_or(&"").to_string();
+
+    Intent::TimeTravel { timestamp, query }
+}
+
+/// Detect temporal context in a query.
+fn detect_temporal_context(query: &str) -> Option<String> {
+    let lower = query.to_lowercase();
+
+    let temporal_patterns = [
+        "yesterday",
+        "last week",
+        "last month",
+        "today",
+        "this morning",
+        "earlier",
+        "before",
+        "after",
+    ];
+
+    for pattern in temporal_patterns {
+        if lower.contains(pattern) {
+            return Some(pattern.to_string());
+        }
     }
+
+    None
 }
 
 #[cfg(test)]
@@ -198,8 +170,7 @@ mod tests {
 
     #[test]
     fn test_shell_command() {
-        let router = Router::new();
-        let intent = router.route("!ls -la");
+        let intent = route("!ls -la");
 
         match intent {
             Intent::ShellCommand { command } => assert_eq!(command, "ls -la"),
@@ -209,8 +180,7 @@ mod tests {
 
     #[test]
     fn test_builtin_command() {
-        let router = Router::new();
-        let intent = router.route("help");
+        let intent = route("help");
 
         match intent {
             Intent::BuiltinCommand { command, args } => {
@@ -223,8 +193,7 @@ mod tests {
 
     #[test]
     fn test_chronos_query() {
-        let router = Router::new();
-        let intent = router.route("what is rust?");
+        let intent = route("what is rust?");
 
         match intent {
             Intent::ChronosQuery { query, .. } => {
@@ -236,8 +205,7 @@ mod tests {
 
     #[test]
     fn test_time_travel() {
-        let router = Router::new();
-        let intent = router.route("@yesterday what did we discuss");
+        let intent = route("@yesterday what did we discuss");
 
         match intent {
             Intent::TimeTravel { timestamp, query } => {

--- a/telemetry/tests/ring_buffer_race.rs
+++ b/telemetry/tests/ring_buffer_race.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "kernel")]
 #![allow(clippy::all, clippy::pedantic)]
 #![allow(clippy::unwrap_used, clippy::panic)]


### PR DESCRIPTION
Implemented Razor's philosophy by removing unnecessary stateless structs (`QueryAnalyzer`, `CommandHandler`, `Router`) and converting them into modules with free functions. This simplifies the codebase, removes boilerplate, and reduces cognitive load. Updated all call sites and tests to reflect these changes. Also fixed several clippy warnings encountered during verification.

---
*PR created automatically by Jules for task [13678517692104352619](https://jules.google.com/task/13678517692104352619) started by @madmax983*