### PR TITLE
⚒️ Forge: Refactor REPL to remove God Function

### DIFF
--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -404,7 +404,9 @@ mod tests {
 
     #[test]
     fn test_augment_many_small_sources() {
-        let augmenter = ContextAugmenter { max_context_tokens: 5 };
+        let augmenter = ContextAugmenter {
+            max_context_tokens: 5,
+        };
 
         // Create 20 sources of 3 chars each ("s00", "s01", etc.)
         // Current logic: 3/4 = 0 tokens. All 20 fit.

--- a/gallifrey/src/domain/mod.rs
+++ b/gallifrey/src/domain/mod.rs
@@ -1,9 +1,9 @@
 //! Domain entities shared across Tardis OS.
 
-pub(crate) mod knowledge;
 pub(crate) mod conversation;
+pub(crate) mod knowledge;
 pub(crate) mod state;
 
-pub use knowledge::*;
 pub use conversation::*;
+pub use knowledge::*;
 pub use state::*;

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -357,7 +357,7 @@ impl Default for KnowledgeStore {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use chrono::{Utc};
+    use chrono::Utc;
     use serde_json::json;
     use std::collections::HashMap;
     use std::thread;
@@ -410,12 +410,21 @@ mod tests {
 
         // Version 1 (Old)
         let v1 = &history[0];
-        assert!(!v1.temporal.transaction_time.is_current(), "Old version should be superseded");
-        assert!(v1.temporal.valid_time.is_current(), "Old version valid time should remain current (unless corrected)");
+        assert!(
+            !v1.temporal.transaction_time.is_current(),
+            "Old version should be superseded"
+        );
+        assert!(
+            v1.temporal.valid_time.is_current(),
+            "Old version valid time should remain current (unless corrected)"
+        );
 
         // Version 2 (New)
         let v2 = &history[1];
-        assert!(v2.temporal.transaction_time.is_current(), "New version should be current");
+        assert!(
+            v2.temporal.transaction_time.is_current(),
+            "New version should be current"
+        );
         assert_eq!(v2.properties.get("status"), Some(&json!("Updated")));
         assert_eq!(v2.name, "Original", "Name should be preserved");
     }
@@ -457,15 +466,24 @@ mod tests {
         // Query at T2
         let at_t2 = store.get_entity_at(id, t2, t2).unwrap();
         assert!(at_t2.is_some());
-        assert_eq!(at_t2.unwrap().properties.get("status"), Some(&json!("Changed")));
+        assert_eq!(
+            at_t2.unwrap().properties.get("status"),
+            Some(&json!("Changed"))
+        );
     }
 
     #[test]
     fn test_find_by_type() {
         let store = KnowledgeStore::new();
-        store.insert_entity(create_test_entity("A", "Type1")).unwrap();
-        store.insert_entity(create_test_entity("B", "Type2")).unwrap();
-        store.insert_entity(create_test_entity("C", "Type1")).unwrap();
+        store
+            .insert_entity(create_test_entity("A", "Type1"))
+            .unwrap();
+        store
+            .insert_entity(create_test_entity("B", "Type2"))
+            .unwrap();
+        store
+            .insert_entity(create_test_entity("C", "Type1"))
+            .unwrap();
 
         let type1 = store.find_by_type("Type1").unwrap();
         assert_eq!(type1.len(), 2);
@@ -500,8 +518,8 @@ mod tests {
         let result = store.update_entity(id, updates);
         assert!(result.is_err());
         match result {
-             Err(GallifreyError::EntityNotFound(_)) => {},
-             _ => panic!("Expected EntityNotFound error"),
+            Err(GallifreyError::EntityNotFound(_)) => {}
+            _ => panic!("Expected EntityNotFound error"),
         }
     }
 

--- a/shell/src/commands.rs
+++ b/shell/src/commands.rs
@@ -12,6 +12,7 @@
 //! - `context`: Inspect session state.
 
 use std::sync::Arc;
+use tardis_chronos::Chronos;
 use tardis_common::SessionId;
 use tardis_gallifrey::Gallifrey;
 
@@ -192,6 +193,33 @@ impl CommandHandler {
         println!("  Project: (none set)");
         println!();
         println!("Use 'context project:<name>' to set project context.");
+    }
+
+    /// Remember information for later recall.
+    #[allow(clippy::unused_self)]
+    pub async fn remember(&self, chronos: &Arc<Chronos>, args: &[String]) {
+        let content = args.join(" ");
+        match chronos
+            .remember(&content, tardis_chronos::MemoryCategory::Knowledge)
+            .await
+        {
+            Ok(id) => println!("Remembered: {id}"),
+            Err(e) => println!("Failed to remember: {e}"),
+        }
+    }
+
+    /// Recall stored memories.
+    #[allow(clippy::unused_self)]
+    pub async fn recall(&self, chronos: &Arc<Chronos>, args: &[String]) {
+        let query = args.join(" ");
+        match chronos.recall(&query, 5).await {
+            Ok(results) => {
+                for result in results {
+                    println!("- {}", result.content);
+                }
+            }
+            Err(e) => println!("Failed to recall: {e}"),
+        }
     }
 }
 

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -5,10 +5,10 @@
 //! A CLI tool for file repair and analysis, leveraging PsychicPaper
 //! for heuristic parsing and validation.
 
-use std::fs;
-use std::path::Path;
 use anyhow::{Context, Result};
 use serde_json::Value;
+use std::fs;
+use std::path::Path;
 use tardis_chronos::experimental::psychic_paper::{Intent, PsychicPaper};
 
 /// The Sonic Screwdriver.
@@ -32,16 +32,13 @@ impl SonicScrewdriver {
     ///
     /// Returns an error if the file cannot be read.
     pub fn inspect(&self, path: &Path) -> Result<String> {
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("Failed to read file: {:?}", path))?;
+        let content =
+            fs::read_to_string(path).with_context(|| format!("Failed to read file: {:?}", path))?;
 
         let size = content.len();
         let lines = content.lines().count();
 
-        let mut diagnosis = format!(
-            "File: {:?}\nSize: {} bytes\nLines: {}\n",
-            path, size, lines
-        );
+        let mut diagnosis = format!("File: {:?}\nSize: {} bytes\nLines: {}\n", path, size, lines);
 
         // Try to interpret as JSON
         match self.paper.interpret(&content, Intent::Json) {
@@ -53,15 +50,18 @@ impl SonicScrewdriver {
                 } else if let Ok(_) = self.paper.interpret(&content, Intent::List) {
                     diagnosis.push_str("Type: List\nStatus: Healthy 🟢");
                 } else {
-                     match self.paper.interpret(&content, Intent::Auto) {
+                    match self.paper.interpret(&content, Intent::Auto) {
                         Ok(val) => {
                             if val.is_string() {
                                 diagnosis.push_str("Type: Unknown / Text\nStatus: Ambiguous 🟡");
                             } else {
-                                diagnosis.push_str("Type: Structured (Auto-detected)\nStatus: Healthy 🟢");
+                                diagnosis.push_str(
+                                    "Type: Structured (Auto-detected)\nStatus: Healthy 🟢",
+                                );
                             }
                         }
-                        Err(e) => diagnosis.push_str(&format!("Type: Unknown\nStatus: Broken 🔴\nError: {}", e)),
+                        Err(e) => diagnosis
+                            .push_str(&format!("Type: Unknown\nStatus: Broken 🔴\nError: {}", e)),
                     }
                 }
             }
@@ -80,8 +80,8 @@ impl SonicScrewdriver {
     ///
     /// Returns an error if the file cannot be read or written.
     pub fn repair(&self, path: &Path) -> Result<String> {
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("Failed to read file: {:?}", path))?;
+        let content =
+            fs::read_to_string(path).with_context(|| format!("Failed to read file: {:?}", path))?;
 
         // Create backup
         let backup_path = path.with_extension("bak");
@@ -90,12 +90,17 @@ impl SonicScrewdriver {
 
         // Attempt repair via interpretation
         // We use Auto intent to let PsychicPaper figure it out
-        let interpreted = self.paper.interpret(&content, Intent::Auto)
+        let interpreted = self
+            .paper
+            .interpret(&content, Intent::Auto)
             .map_err(|e| anyhow::anyhow!("Failed to interpret file: {}", e))?;
 
         // If it's a string, we probably didn't parse anything structured
         if let Value::String(_) = interpreted {
-            return Ok(format!("Could not identify structure to repair. Backup created at {:?}", backup_path));
+            return Ok(format!(
+                "Could not identify structure to repair. Backup created at {:?}",
+                backup_path
+            ));
         }
 
         // Write back as pretty-printed JSON
@@ -113,8 +118,8 @@ impl SonicScrewdriver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
     use std::fs::File;
+    use std::io::Write;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn create_temp_file(content: &str) -> (std::path::PathBuf, impl FnOnce()) {

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -13,9 +13,9 @@ use tardis_telemetry::gallifrey::TelemetryStore;
 use tracing::{error, info};
 
 #[cfg(feature = "nova")]
-use tardis_chronos::experimental::prophecy::Prophet;
-#[cfg(feature = "nova")]
 use crate::experimental::sonic::SonicScrewdriver;
+#[cfg(feature = "nova")]
+use tardis_chronos::experimental::prophecy::Prophet;
 
 /// The main REPL for Tardis shell.
 #[derive(Debug)]
@@ -31,6 +31,7 @@ pub struct Repl {
     /// Gallifrey database.
     gallifrey: Arc<Gallifrey>,
     /// Telemetry store (optional).
+    #[allow(dead_code)]
     telemetry_store: Option<Arc<TelemetryStore>>,
     /// Prophet engine (optional, Nova only).
     #[cfg(feature = "nova")]
@@ -147,75 +148,62 @@ impl Repl {
                 self.running = false;
             }
             "history" => self.commands.history(&self.gallifrey, self.session_id),
-            "remember" => {
-                let content = args.join(" ");
-                match self
-                    .chronos
-                    .remember(&content, tardis_chronos::MemoryCategory::Knowledge)
-                    .await
-                {
-                    Ok(id) => println!("Remembered: {id}"),
-                    Err(e) => println!("Failed to remember: {e}"),
-                }
-            }
-            "recall" => {
-                let query = args.join(" ");
-                match self.chronos.recall(&query, 5).await {
-                    Ok(results) => {
-                        for result in results {
-                            println!("- {}", result.content);
-                        }
-                    }
-                    Err(e) => println!("Failed to recall: {e}"),
-                }
-            }
+            "remember" => self.commands.remember(&self.chronos, args).await,
+            "recall" => self.commands.recall(&self.chronos, args).await,
             "models" => self.commands.list_models(),
             "context" => self.commands.show_context(self.session_id),
             "clear" => {
                 print!("\x1B[2J\x1B[1;1H");
             }
             #[cfg(feature = "nova")]
-            "dashboard" => {
-                match crate::dashboard::tui::Dashboard::new(
-                    std::sync::Arc::clone(&self.gallifrey),
-                    self.telemetry_store.clone(),
-                    self.prophet.clone(),
-                ) {
-                    Ok(mut dashboard) => {
-                        if let Err(e) = dashboard.run() {
-                            println!("Dashboard failed: {e}");
-                        }
-                    }
-                    Err(e) => println!("Failed to initialize dashboard: {e}"),
-                }
-            }
+            "dashboard" => self.handle_dashboard(),
             #[cfg(feature = "nova")]
-            "sonic" | "fix" => {
-                if args.is_empty() {
-                    println!("Usage: sonic <file> or sonic repair <file>");
-                    return;
-                }
+            "sonic" | "fix" => self.handle_sonic(command, args),
+            _ => println!("Unknown command: {command}. Type 'help' for available commands."),
+        }
+    }
 
-                let screwdriver = SonicScrewdriver::new();
-                let path = std::path::Path::new(&args[args.len() - 1]);
-
-                // Check if user wants repair (e.g. "sonic repair file.json" or "fix file.json")
-                // If command is "fix", we repair.
-                // If command is "sonic" and first arg is "repair" or "fix", we repair.
-                let repair = command == "fix" || (args.len() > 1 && (args[0] == "repair" || args[0] == "fix"));
-
-                let result = if repair {
-                    screwdriver.repair(path)
-                } else {
-                    screwdriver.inspect(path)
-                };
-
-                match result {
-                    Ok(report) => println!("{}", report),
-                    Err(e) => println!("Sonic Screwdriver error: {}", e),
+    #[cfg(feature = "nova")]
+    fn handle_dashboard(&self) {
+        match crate::dashboard::tui::Dashboard::new(
+            std::sync::Arc::clone(&self.gallifrey),
+            self.telemetry_store.clone(),
+            self.prophet.clone(),
+        ) {
+            Ok(mut dashboard) => {
+                if let Err(e) = dashboard.run() {
+                    println!("Dashboard failed: {e}");
                 }
             }
-            _ => println!("Unknown command: {command}. Type 'help' for available commands."),
+            Err(e) => println!("Failed to initialize dashboard: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    fn handle_sonic(&self, command: &str, args: &[String]) {
+        if args.is_empty() {
+            println!("Usage: sonic <file> or sonic repair <file>");
+            return;
+        }
+
+        let screwdriver = SonicScrewdriver::new();
+        let path = std::path::Path::new(&args[args.len() - 1]);
+
+        // Check if user wants repair (e.g. "sonic repair file.json" or "fix file.json")
+        // If command is "fix", we repair.
+        // If command is "sonic" and first arg is "repair" or "fix", we repair.
+        let repair =
+            command == "fix" || (args.len() > 1 && (args[0] == "repair" || args[0] == "fix"));
+
+        let result = if repair {
+            screwdriver.repair(path)
+        } else {
+            screwdriver.inspect(path)
+        };
+
+        match result {
+            Ok(report) => println!("{}", report),
+            Err(e) => println!("Sonic Screwdriver error: {}", e),
         }
     }
 

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -68,8 +68,20 @@ impl Router {
     pub fn new() -> Self {
         Self {
             builtins: vec![
-                "help", "exit", "quit", "history", "remember", "recall", "models", "context",
-                "clear", "snapshot", "restore", "timeline", "forget", "export",
+                "help",
+                "exit",
+                "quit",
+                "history",
+                "remember",
+                "recall",
+                "models",
+                "context",
+                "clear",
+                "snapshot",
+                "restore",
+                "timeline",
+                "forget",
+                "export",
                 #[cfg(feature = "nova")]
                 "sonic",
                 #[cfg(feature = "nova")]


### PR DESCRIPTION
* 🚮 Smell: `handle_builtin` in `shell/src/repl.rs` was a growing "God Function" with mixed levels of abstraction and direct implementation of complex commands like `remember`, `recall`, `sonic`, and `dashboard`.
* ✨ Solution:
    * Extracted `remember` and `recall` logic into `CommandHandler` in `shell/src/commands.rs`.
    * Extracted `sonic` and `dashboard` logic into private helper methods in `shell/src/repl.rs`, gated by `nova` feature.
    * Added `#[allow(dead_code)]` to `telemetry_store` in `Repl` to handle conditionally compiled usage.
* 🧼 Benefit: `handle_builtin` is now a clean dispatcher. Command logic is grouped appropriately. `repl.rs` is easier to read and maintain.
* 🛡️ Verification: Tests passed (`cargo test -p tardis-shell`). Clippy passed (`cargo clippy -p tardis-shell`). No logic changed.

---
*PR created automatically by Jules for task [3292927672010836610](https://jules.google.com/task/3292927672010836610) started by @madmax983*