### PR TITLE
Refactor: Simplify abstractions in Chronos, Shell, and Gallifrey

### DIFF
--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -116,7 +116,7 @@ const INTENT_RULES: &[IntentRule] = &[
     },
 ];
 
-/// Query analyzer.
+/// Analyze a query.
 ///
 /// The analyzer is the first step in the RAG pipeline. It normalizes the query
 /// and runs it through a set of heuristic rules to determine:
@@ -124,169 +124,138 @@ const INTENT_RULES: &[IntentRule] = &[
 /// 1. **Intent**: What action should the system take? (e.g. search knowledge, store memory, diff states).
 /// 2. **Temporality**: Does the query refer to a specific time in the past?
 /// 3. **Entities**: (Future) Which specific entities are being discussed?
-#[derive(Debug)]
-pub struct QueryAnalyzer {
-    // Configuration
+///
+/// # Examples
+///
+/// **Recall Query with Temporal Reference:**
+/// ```
+/// use tardis_chronos::pipeline::{analyze, QueryIntent};
+/// use tardis_common::temporal::TemporalReference;
+///
+/// let analysis = analyze("What did we do yesterday?").unwrap();
+///
+/// assert_eq!(analysis.intent, QueryIntent::Recall);
+///
+/// // Verify temporal extraction
+/// let reference = &analysis.temporal_refs[0];
+/// match reference {
+///    TemporalReference::Relative { text, .. } => assert_eq!(text, "yesterday"),
+///    _ => panic!("Expected relative reference"),
+/// }
+/// ```
+///
+/// **Storing a Memory:**
+/// ```
+/// use tardis_chronos::pipeline::{analyze, QueryIntent};
+///
+/// let analysis = analyze("Remember that the sky is blue").unwrap();
+///
+/// assert_eq!(analysis.intent, QueryIntent::Remember);
+/// ```
+///
+/// **System Introspection:**
+/// ```
+/// use tardis_chronos::pipeline::{analyze, QueryIntent};
+///
+/// let analysis = analyze("Take a system snapshot").unwrap();
+///
+/// assert_eq!(analysis.intent, QueryIntent::SystemQuery);
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if analysis fails.
+pub fn analyze(query: &str) -> ChronosResult<AnalyzedQuery> {
+    // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
+    let query_lower = query.to_lowercase();
+    let intent = classify_intent(&query_lower);
+    let temporal_refs = extract_temporal_refs(&query_lower, Utc::now());
+    let entities = extract_entities(query);
+
+    let temporal_description = if temporal_refs.is_empty() {
+        None
+    } else {
+        Some(describe_temporal_context(&temporal_refs))
+    };
+
+    Ok(AnalyzedQuery {
+        text: query.to_string(),
+        intent,
+        temporal_refs,
+        temporal_description,
+        entities,
+    })
 }
 
-impl QueryAnalyzer {
-    /// Create a new query analyzer.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {}
+/// Classify the intent of a query.
+fn classify_intent(query_lower: &str) -> QueryIntent {
+    for rule in INTENT_RULES {
+        if rule.matches(query_lower) {
+            return rule.intent.clone();
+        }
     }
 
-    /// Analyze a query.
-    ///
-    /// # Examples
-    ///
-    /// **Recall Query with Temporal Reference:**
-    /// ```
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, QueryIntent};
-    /// use tardis_common::temporal::TemporalReference;
-    ///
-    /// let analyzer = QueryAnalyzer::new();
-    /// let analysis = analyzer.analyze("What did we do yesterday?").unwrap();
-    ///
-    /// assert_eq!(analysis.intent, QueryIntent::Recall);
-    ///
-    /// // Verify temporal extraction
-    /// let reference = &analysis.temporal_refs[0];
-    /// match reference {
-    ///    TemporalReference::Relative { text, .. } => assert_eq!(text, "yesterday"),
-    ///    _ => panic!("Expected relative reference"),
-    /// }
-    /// ```
-    ///
-    /// **Storing a Memory:**
-    /// ```
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, QueryIntent};
-    ///
-    /// let analyzer = QueryAnalyzer::new();
-    /// let analysis = analyzer.analyze("Remember that the sky is blue").unwrap();
-    ///
-    /// assert_eq!(analysis.intent, QueryIntent::Remember);
-    /// ```
-    ///
-    /// **System Introspection:**
-    /// ```
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, QueryIntent};
-    ///
-    /// let analyzer = QueryAnalyzer::new();
-    /// let analysis = analyzer.analyze("Take a system snapshot").unwrap();
-    ///
-    /// assert_eq!(analysis.intent, QueryIntent::SystemQuery);
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if analysis fails.
-    pub fn analyze(&self, query: &str) -> ChronosResult<AnalyzedQuery> {
-        // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
-        let query_lower = query.to_lowercase();
-        let intent = self.classify_intent(&query_lower);
-        let temporal_refs = self.extract_temporal_refs(&query_lower, Utc::now());
-        let entities = self.extract_entities(query);
+    if query_lower.ends_with('?') {
+        return QueryIntent::Question;
+    }
 
-        let temporal_description = if temporal_refs.is_empty() {
-            None
-        } else {
-            Some(self.describe_temporal_context(&temporal_refs))
-        };
+    QueryIntent::Chat
+}
 
-        Ok(AnalyzedQuery {
-            text: query.to_string(),
-            intent,
-            temporal_refs,
-            temporal_description,
-            entities,
+/// Extract temporal references from a query.
+fn extract_temporal_refs(query_lower: &str, now: DateTime<Utc>) -> Vec<TemporalReference> {
+    let mut refs = Vec::new();
+
+    for rule in TEMPORAL_RULES {
+        if query_lower.contains(rule.keyword) {
+            let resolved = rule.resolve(now);
+
+            refs.push(TemporalReference::Relative {
+                text: rule.keyword.to_string(),
+                resolved,
+            });
+        }
+    }
+
+    // TODO: Add more sophisticated temporal extraction
+    // - NLP-based extraction
+    // - Absolute date parsing
+    // - Event-based references
+
+    refs
+}
+
+/// Extract entity mentions from a query.
+const fn extract_entities(query: &str) -> Vec<String> {
+    // TODO: Implement NER or pattern matching
+    // For now, just return empty
+    let _ = query;
+    Vec::new()
+}
+
+/// Generate human-readable description of temporal context.
+fn describe_temporal_context(refs: &[TemporalReference]) -> String {
+    if refs.is_empty() {
+        return "current time".to_string();
+    }
+
+    refs.iter()
+        .map(|r| match r {
+            TemporalReference::Relative { text, resolved } => {
+                format!("{} ({})", text, resolved.format("%Y-%m-%d"))
+            }
+            TemporalReference::Absolute(resolved) => resolved.format("%Y-%m-%d").to_string(),
+            TemporalReference::EventBased { event, resolved } => {
+                if let Some(res) = resolved {
+                    format!("{} ({})", event, res.format("%Y-%m-%d"))
+                } else {
+                    event.clone()
+                }
+            }
+            TemporalReference::Implicit => "implicit".to_string(),
         })
-    }
-
-    /// Classify the intent of a query.
-    #[allow(clippy::unused_self)]
-    fn classify_intent(&self, query_lower: &str) -> QueryIntent {
-        for rule in INTENT_RULES {
-            if rule.matches(query_lower) {
-                return rule.intent.clone();
-            }
-        }
-
-        if query_lower.ends_with('?') {
-            return QueryIntent::Question;
-        }
-
-        QueryIntent::Chat
-    }
-
-    /// Extract temporal references from a query.
-    #[allow(clippy::unused_self)]
-    fn extract_temporal_refs(
-        &self,
-        query_lower: &str,
-        now: DateTime<Utc>,
-    ) -> Vec<TemporalReference> {
-        let mut refs = Vec::new();
-
-        for rule in TEMPORAL_RULES {
-            if query_lower.contains(rule.keyword) {
-                let resolved = rule.resolve(now);
-
-                refs.push(TemporalReference::Relative {
-                    text: rule.keyword.to_string(),
-                    resolved,
-                });
-            }
-        }
-
-        // TODO: Add more sophisticated temporal extraction
-        // - NLP-based extraction
-        // - Absolute date parsing
-        // - Event-based references
-
-        refs
-    }
-
-    /// Extract entity mentions from a query.
-    #[allow(clippy::unused_self)]
-    const fn extract_entities(&self, query: &str) -> Vec<String> {
-        // TODO: Implement NER or pattern matching
-        // For now, just return empty
-        let _ = query;
-        Vec::new()
-    }
-
-    /// Generate human-readable description of temporal context.
-    #[allow(clippy::unused_self)]
-    fn describe_temporal_context(&self, refs: &[TemporalReference]) -> String {
-        if refs.is_empty() {
-            return "current time".to_string();
-        }
-
-        refs.iter()
-            .map(|r| match r {
-                TemporalReference::Relative { text, resolved } => {
-                    format!("{} ({})", text, resolved.format("%Y-%m-%d"))
-                }
-                TemporalReference::Absolute(resolved) => resolved.format("%Y-%m-%d").to_string(),
-                TemporalReference::EventBased { event, resolved } => {
-                    if let Some(res) = resolved {
-                        format!("{} ({})", event, res.format("%Y-%m-%d"))
-                    } else {
-                        event.clone()
-                    }
-                }
-                TemporalReference::Implicit => "implicit".to_string(),
-            })
-            .collect::<Vec<_>>()
-            .join(", ")
-    }
-}
-
-impl Default for QueryAnalyzer {
-    fn default() -> Self {
-        Self::new()
-    }
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[cfg(test)]
@@ -296,56 +265,53 @@ mod tests {
 
     #[test]
     fn test_classify_intent() {
-        let analyzer = QueryAnalyzer::new();
-
         assert_eq!(
-            analyzer.classify_intent(&"Remember that I like pizza".to_lowercase()),
+            classify_intent(&"Remember that I like pizza".to_lowercase()),
             QueryIntent::Remember
         );
         assert_eq!(
-            analyzer.classify_intent(&"Please remember this conversation".to_lowercase()),
+            classify_intent(&"Please remember this conversation".to_lowercase()),
             QueryIntent::Remember
         );
         assert_eq!(
-            analyzer.classify_intent(&"What did we discuss yesterday?".to_lowercase()),
+            classify_intent(&"What did we discuss yesterday?".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"Recall the meeting notes".to_lowercase()),
+            classify_intent(&"Recall the meeting notes".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"What was the result?".to_lowercase()),
+            classify_intent(&"What was the result?".to_lowercase()),
             QueryIntent::Recall
         );
         assert_eq!(
-            analyzer.classify_intent(&"How has the project changed?".to_lowercase()),
+            classify_intent(&"How has the project changed?".to_lowercase()),
             QueryIntent::TemporalDiff
         );
         assert_eq!(
-            analyzer.classify_intent(&"Show me the system state".to_lowercase()),
+            classify_intent(&"Show me the system state".to_lowercase()),
             QueryIntent::SystemQuery
         );
         assert_eq!(
-            analyzer.classify_intent(&"Take a snapshot".to_lowercase()),
+            classify_intent(&"Take a snapshot".to_lowercase()),
             QueryIntent::SystemQuery
         );
         assert_eq!(
-            analyzer.classify_intent(&"Is this a question?".to_lowercase()),
+            classify_intent(&"Is this a question?".to_lowercase()),
             QueryIntent::Question
         );
         assert_eq!(
-            analyzer.classify_intent(&"Just chatting".to_lowercase()),
+            classify_intent(&"Just chatting".to_lowercase()),
             QueryIntent::Chat
         );
     }
 
     #[test]
     fn test_extract_temporal_refs() {
-        let analyzer = QueryAnalyzer::new();
         let now = Utc::now();
 
-        let refs = analyzer.extract_temporal_refs(&"What happened yesterday?".to_lowercase(), now);
+        let refs = extract_temporal_refs(&"What happened yesterday?".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
 
         match &refs[0] {
@@ -353,27 +319,26 @@ mod tests {
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Check last week logs".to_lowercase(), now);
+        let refs = extract_temporal_refs(&"Check last week logs".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "last week"),
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Do it today".to_lowercase(), now);
+        let refs = extract_temporal_refs(&"Do it today".to_lowercase(), now);
         assert_eq!(refs.len(), 1);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "today"),
             _ => panic!("Expected relative"),
         }
 
-        let refs = analyzer.extract_temporal_refs(&"Yesterday and today".to_lowercase(), now);
+        let refs = extract_temporal_refs(&"Yesterday and today".to_lowercase(), now);
         assert_eq!(refs.len(), 2);
     }
 
     #[test]
     fn test_extract_temporal_refs_resolved() {
-        let analyzer = QueryAnalyzer::new();
         // Use a fixed date for deterministic testing
         // 2024-03-15 12:00:00 UTC
         let now = DateTime::parse_from_rfc3339("2024-03-15T12:00:00Z")
@@ -381,7 +346,7 @@ mod tests {
             .with_timezone(&Utc);
 
         // "yesterday" should be 2024-03-14 12:00:00 UTC
-        let refs = analyzer.extract_temporal_refs("yesterday", now);
+        let refs = extract_temporal_refs("yesterday", now);
         assert_eq!(refs.len(), 1);
         assert_eq!(
             refs[0].resolved().unwrap().to_rfc3339(),
@@ -389,7 +354,7 @@ mod tests {
         );
 
         // "last week" should be 2024-03-08 12:00:00 UTC
-        let refs = analyzer.extract_temporal_refs("last week", now);
+        let refs = extract_temporal_refs("last week", now);
         assert_eq!(refs.len(), 1);
         assert_eq!(
             refs[0].resolved().unwrap().to_rfc3339(),
@@ -399,10 +364,9 @@ mod tests {
 
     #[test]
     fn test_describe_temporal_context() {
-        let analyzer = QueryAnalyzer::new();
         let now = Utc::now();
-        let refs = analyzer.extract_temporal_refs("yesterday", now);
-        let desc = analyzer.describe_temporal_context(&refs);
+        let refs = extract_temporal_refs("yesterday", now);
+        let desc = describe_temporal_context(&refs);
         assert!(desc.contains("yesterday"));
     }
 }

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -56,7 +56,7 @@ impl ContextAugmenter {
     ///
     /// ```
     /// use tardis_chronos::pipeline::{ContextAugmenter, ContextSource, ContextSourceType};
-    /// use tardis_chronos::pipeline::{QueryAnalyzer, AnalyzedQuery, QueryIntent};
+    /// use tardis_chronos::pipeline::{AnalyzedQuery, QueryIntent};
     /// use tardis_common::temporal::TemporalReference;
     /// use chrono::Utc;
     ///

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -34,7 +34,7 @@ mod analyzer;
 mod augmenter;
 mod retriever;
 
-pub use analyzer::{AnalyzedQuery, QueryAnalyzer, QueryIntent};
+pub use analyzer::{analyze, AnalyzedQuery, QueryIntent};
 pub use augmenter::ContextAugmenter;
 pub use retriever::Retriever;
 
@@ -137,7 +137,6 @@ pub struct Chronos {
     gallifrey: Arc<Gallifrey>,
     #[cfg(feature = "telemetry")]
     telemetry: Option<Arc<TelemetryStore>>,
-    analyzer: QueryAnalyzer,
     retriever: Retriever,
     augmenter: ContextAugmenter,
 }
@@ -151,7 +150,6 @@ impl Chronos {
             gallifrey: Arc::clone(&gallifrey),
             #[cfg(feature = "telemetry")]
             telemetry: None,
-            analyzer: QueryAnalyzer::new(),
             retriever: Retriever::new(gallifrey),
             augmenter: ContextAugmenter::new(),
         }
@@ -192,7 +190,7 @@ impl Chronos {
         info!("Processing RAG query");
 
         // 1. Analyze the query
-        let analysis = self.analyzer.analyze(prompt)?;
+        let analysis = analyzer::analyze(prompt)?;
         info!("Query analyzed: {:?}", analysis.intent);
 
         // 2. Retrieve relevant context
@@ -254,9 +252,9 @@ impl Chronos {
 
         let id = self
             .gallifrey
-            .insert(entity)
-            .await
-            .map_err(ChronosError::Common)?;
+            .knowledge()
+            .insert_entity(entity)
+            .map_err(ChronosError::Gallifrey)?;
 
         Ok(id)
     }
@@ -273,9 +271,9 @@ impl Chronos {
         // Search knowledge graph
         let results = self
             .gallifrey
-            .search_knowledge(&[], limit)
-            .await
-            .map_err(ChronosError::Common)?;
+            .knowledge()
+            .semantic_search(&[], limit)
+            .map_err(ChronosError::Gallifrey)?;
 
         Ok(results
             .into_iter()

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -77,9 +77,9 @@ impl Retriever {
 
         let entities = self
             .gallifrey
-            .search_knowledge(&embedding, config.max_context_items)
-            .await
-            .map_err(ChronosError::Common)?;
+            .knowledge()
+            .semantic_search(&embedding, config.max_context_items)
+            .map_err(ChronosError::Gallifrey)?;
 
         for e in entities {
             sources.push(ContextSource {
@@ -107,9 +107,9 @@ impl Retriever {
         if let Some(session_id) = config.session_id {
             let messages = self
                 .gallifrey
+                .conversation()
                 .get_recent_messages(session_id, 5)
-                .await
-                .map_err(ChronosError::Common)?;
+                .map_err(ChronosError::Gallifrey)?;
 
             for msg in messages {
                 sources.push(ContextSource {
@@ -125,9 +125,9 @@ impl Retriever {
         let embedding: Vec<f32> = Vec::new();
         let historical = self
             .gallifrey
-            .search_conversation(&embedding, config.max_context_items)
-            .await
-            .map_err(ChronosError::Common)?;
+            .conversation()
+            .semantic_search(&embedding, config.max_context_items)
+            .map_err(ChronosError::Gallifrey)?;
 
         for msg in historical {
             sources.push(ContextSource {
@@ -159,9 +159,9 @@ impl Retriever {
 
             if let Some(snapshot) = self
                 .gallifrey
-                .find_snapshot(resolved)
-                .await
-                .map_err(ChronosError::Common)?
+                .system_state()
+                .find_snapshot_at(resolved)
+                .map_err(ChronosError::Gallifrey)?
             {
                 sources.push(ContextSource {
                     source_type: ContextSourceType::SystemState,

--- a/chronos/tests/doctor_integration.rs
+++ b/chronos/tests/doctor_integration.rs
@@ -28,7 +28,7 @@ async fn test_doctor_correlates_changes_with_errors() {
         old_value: None,
         new_value: None,
     };
-    gallifrey.record_change(change).await.unwrap();
+    gallifrey.system_state().record_change(change).unwrap();
 
     // 3. Record an error (e.g. 1 minute ago)
     let error_event = EventData {

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -45,13 +45,14 @@
 //! };
 //!
 //! // 3. Insert it into the Knowledge Store
-//! let id = gallifrey.insert(entity).await?;
+//! let id = gallifrey.knowledge().insert_entity(entity)?;
 //!
 //! // 4. Update it (creates a new version, preserving history)
-//! gallifrey.update(id, serde_json::json!({"color": "dark_blue"})).await?;
+//! let updates: HashMap<String, serde_json::Value> = serde_json::from_value(serde_json::json!({"color": "dark_blue"}))?;
+//! gallifrey.knowledge().update_entity(id, updates)?;
 //!
 //! // 5. Retrieve history to see both versions
-//! let history = gallifrey.get_history(id).await?;
+//! let history = gallifrey.knowledge().get_entity_history(id)?;
 //! assert_eq!(history.len(), 2);
 //! # Ok(())
 //! # }
@@ -75,12 +76,7 @@ pub use error::{GallifreyError, GallifreyResult};
 pub use stores::{ConversationStore, KnowledgeStore, SystemStateStore};
 pub use temporal::{BiTemporalInterval, TimeRange};
 
-use crate::domain::{Change, Entity, Message, Snapshot};
 use std::sync::Arc;
-use tardis_common::id::{EntityId, SessionId};
-use tardis_common::temporal::TemporalQuery;
-
-use crate::query::QueryResult;
 
 /// The main Gallifrey database instance.
 ///
@@ -120,174 +116,6 @@ impl Gallifrey {
     #[must_use]
     pub fn system_state(&self) -> Arc<SystemStateStore> {
         Arc::clone(&self.system_state)
-    }
-
-    // --- Knowledge Graph ---
-
-    /// Execute a query with optional temporal parameters.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the query parsing or execution fails.
-    #[allow(clippy::unused_async)]
-    pub async fn query(
-        &self,
-        _query: &str,
-        _temporal: TemporalQuery,
-    ) -> tardis_common::Result<QueryResult> {
-        // TODO: Implement actual query parsing and execution
-        Ok(QueryResult {
-            nodes: Vec::new(),
-            execution_time_ms: 0,
-            truncated: false,
-        })
-    }
-
-    /// Insert a node into the knowledge graph.
-    ///
-    /// This delegates to [`KnowledgeStore::insert_entity`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the node cannot be inserted (e.g. storage error).
-    #[allow(clippy::unused_async)]
-    pub async fn insert(&self, node: Entity) -> tardis_common::Result<EntityId> {
-        self.knowledge
-            .insert_entity(node)
-            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
-    }
-
-    /// Update an existing node.
-    ///
-    /// This delegates to [`KnowledgeStore::update_entity`], performing a bi-temporal update.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the node cannot be updated or properties are invalid.
-    #[allow(clippy::unused_async)]
-    pub async fn update(
-        &self,
-        id: EntityId,
-        properties: serde_json::Value,
-    ) -> tardis_common::Result<()> {
-        let props: std::collections::HashMap<String, serde_json::Value> =
-            serde_json::from_value(properties)
-                .map_err(|e| tardis_common::Error::Internal(e.to_string()))?;
-
-        self.knowledge
-            .update_entity(id, props)
-            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
-    }
-
-    /// Get the history of an entity.
-    ///
-    /// Returns all versions of the entity, both current and historical.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if history cannot be retrieved.
-    #[allow(clippy::unused_async)]
-    pub async fn get_history(&self, id: EntityId) -> tardis_common::Result<Vec<Entity>> {
-        self.knowledge
-            .get_entity_history(id)
-            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
-    }
-
-    /// Travel to a point in time and get a snapshot.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if time travel fails.
-    #[allow(clippy::unused_async)]
-    pub async fn time_travel(
-        &self,
-        _timestamp: chrono::DateTime<chrono::Utc>,
-    ) -> tardis_common::Result<QueryResult> {
-        // TODO: Implement time travel query
-        Ok(QueryResult {
-            nodes: Vec::new(),
-            execution_time_ms: 0,
-            truncated: false,
-        })
-    }
-
-    /// Semantic search for entities.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the search fails.
-    #[allow(clippy::unused_async)]
-    pub async fn search_knowledge(
-        &self,
-        embedding: &[f32],
-        limit: usize,
-    ) -> tardis_common::Result<Vec<Entity>> {
-        self.knowledge
-            .semantic_search(embedding, limit)
-            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
-    }
-
-    // --- Conversation ---
-
-    /// Get recent messages from a session.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if messages cannot be retrieved.
-    #[allow(clippy::unused_async)]
-    pub async fn get_recent_messages(
-        &self,
-        session_id: SessionId,
-        limit: usize,
-    ) -> tardis_common::Result<Vec<Message>> {
-        self.conversation
-            .get_recent_messages(session_id, limit)
-            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
-    }
-
-    /// Semantic search for messages.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the search fails.
-    #[allow(clippy::unused_async)]
-    pub async fn search_conversation(
-        &self,
-        embedding: &[f32],
-        limit: usize,
-    ) -> tardis_common::Result<Vec<Message>> {
-        self.conversation
-            .semantic_search(embedding, limit)
-            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
-    }
-
-    // --- System State ---
-
-    /// Find a system snapshot at a specific time.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the snapshot cannot be found.
-    #[allow(clippy::unused_async)]
-    pub async fn find_snapshot(
-        &self,
-        timestamp: chrono::DateTime<chrono::Utc>,
-    ) -> tardis_common::Result<Option<Snapshot>> {
-        self.system_state
-            .find_snapshot_at(timestamp)
-            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
-    }
-
-    /// Record a system change.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the change cannot be recorded.
-    #[allow(clippy::unused_async)]
-    pub async fn record_change(&self, change: Change) -> tardis_common::Result<()> {
-        self.system_state
-            .record_change(change)
-            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
     }
 }
 

--- a/gallifrey/tests/system_state_timeline.rs
+++ b/gallifrey/tests/system_state_timeline.rs
@@ -44,10 +44,7 @@ fn test_find_snapshot_at_timeline() {
 
     // Check slightly after s1, before s2
     let mid_time = s1.timestamp + (s2.timestamp - s1.timestamp) / 2;
-    let f1_later = store
-        .find_snapshot_at(mid_time)
-        .unwrap()
-        .unwrap();
+    let f1_later = store.find_snapshot_at(mid_time).unwrap().unwrap();
     assert_eq!(f1_later.id, id1);
 
     // Check exact match s2
@@ -77,11 +74,17 @@ fn test_list_snapshots_order() {
         files: HashMap::new(),
     };
 
-    let id1 = store.take_snapshot("s1", SnapshotTrigger::Manual, state.clone()).unwrap();
+    let id1 = store
+        .take_snapshot("s1", SnapshotTrigger::Manual, state.clone())
+        .unwrap();
     std::thread::sleep(std::time::Duration::from_millis(10));
-    let id2 = store.take_snapshot("s2", SnapshotTrigger::Manual, state.clone()).unwrap();
+    let id2 = store
+        .take_snapshot("s2", SnapshotTrigger::Manual, state.clone())
+        .unwrap();
     std::thread::sleep(std::time::Duration::from_millis(10));
-    let id3 = store.take_snapshot("s3", SnapshotTrigger::Manual, state.clone()).unwrap();
+    let id3 = store
+        .take_snapshot("s3", SnapshotTrigger::Manual, state.clone())
+        .unwrap();
 
     let list = store.list_snapshots().unwrap();
     assert_eq!(list.len(), 3);

--- a/shell/src/commands.rs
+++ b/shell/src/commands.rs
@@ -15,188 +15,160 @@ use std::sync::Arc;
 use tardis_common::SessionId;
 use tardis_gallifrey::Gallifrey;
 
-/// Handler for built-in shell commands.
+/// Display help information.
 ///
-/// The command handler is stateless but receives the application state (like `Gallifrey` instances)
-/// during method calls to perform its duties.
-#[derive(Debug)]
-pub struct CommandHandler {
-    // Configuration
+/// If an argument is provided, displays help for that specific command.
+/// Otherwise, displays the general help menu.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tardis_shell::commands;
+///
+/// commands::help(&[]); // General help
+/// commands::help(&["remember".to_string()]); // Help for 'remember'
+/// ```
+pub fn help(args: &[String]) {
+    if args.is_empty() {
+        general_help();
+    } else {
+        command_help(&args[0]);
+    }
 }
 
-impl CommandHandler {
-    /// Create a new command handler.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {}
-    }
+/// Display general help.
+fn general_help() {
+    println!("Tardis Shell Commands:");
+    println!();
+    println!("  BUILT-IN COMMANDS:");
+    println!("    help [command]    Show help (for a specific command)");
+    println!("    history           Show conversation history");
+    println!("    remember <text>   Store information for later recall");
+    println!("    recall <query>    Retrieve stored memories");
+    println!("    models            List available LLM models");
+    println!("    context           Show current session context");
+    println!("    snapshot <name>   Save system state snapshot");
+    println!("    restore <name>    Restore a saved snapshot");
+    println!("    timeline <entity> Show history of an entity");
+    println!("    clear             Clear the screen");
+    println!("    exit / quit       Exit the shell");
+    println!();
+    println!("  INPUT MODES:");
+    println!("    <query>           Natural language (default) -> RAG response");
+    println!("    !<command>        Shell command (e.g., !ls -la)");
+    println!("    @<time> <query>   Time-travel query (e.g., @yesterday what did we discuss)");
+    println!("    ?<query>          Direct LLM query (no RAG)");
+    println!();
+    println!("  EXAMPLES:");
+    println!("    What did we discuss about Rust?");
+    println!("    remember that the API uses JWT tokens");
+    println!("    @last-week show file changes");
+    println!("    !cargo build");
+    println!();
+}
 
-    /// Display help information.
-    ///
-    /// If an argument is provided, displays help for that specific command.
-    /// Otherwise, displays the general help menu.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tardis_shell::commands::CommandHandler;
-    ///
-    /// let handler = CommandHandler::new();
-    /// handler.help(&[]); // General help
-    /// handler.help(&["remember".to_string()]); // Help for 'remember'
-    /// ```
-    #[allow(clippy::unused_self)]
-    pub fn help(&self, args: &[String]) {
-        if args.is_empty() {
-            Self::general_help();
-        } else {
-            Self::command_help(&args[0]);
+/// Display help for a specific command.
+fn command_help(command: &str) {
+    match command {
+        "remember" => {
+            println!("remember <text>");
+            println!();
+            println!("Store information in the knowledge graph for later recall.");
+            println!();
+            println!("Examples:");
+            println!("  remember that the API uses JWT tokens");
+            println!("  remember project deadline is March 15");
+        }
+        "recall" => {
+            println!("recall <query>");
+            println!();
+            println!("Retrieve stored memories matching the query.");
+            println!();
+            println!("Examples:");
+            println!("  recall what I know about authentication");
+            println!("  recall project deadlines");
+        }
+        "snapshot" => {
+            println!("snapshot <name>");
+            println!();
+            println!("Save a snapshot of the current system state.");
+            println!("Snapshots can be used for time-travel debugging.");
+            println!();
+            println!("Examples:");
+            println!("  snapshot before-refactor");
+            println!("  snapshot working-state");
+        }
+        "timeline" => {
+            println!("timeline <entity>");
+            println!();
+            println!("Show the history of changes to an entity.");
+            println!();
+            println!("Examples:");
+            println!("  timeline authentication-module");
+            println!("  timeline config.toml");
+        }
+        _ => {
+            println!("No help available for '{command}'");
         }
     }
+}
 
-    /// Display general help.
-    fn general_help() {
-        println!("Tardis Shell Commands:");
-        println!();
-        println!("  BUILT-IN COMMANDS:");
-        println!("    help [command]    Show help (for a specific command)");
-        println!("    history           Show conversation history");
-        println!("    remember <text>   Store information for later recall");
-        println!("    recall <query>    Retrieve stored memories");
-        println!("    models            List available LLM models");
-        println!("    context           Show current session context");
-        println!("    snapshot <name>   Save system state snapshot");
-        println!("    restore <name>    Restore a saved snapshot");
-        println!("    timeline <entity> Show history of an entity");
-        println!("    clear             Clear the screen");
-        println!("    exit / quit       Exit the shell");
-        println!();
-        println!("  INPUT MODES:");
-        println!("    <query>           Natural language (default) -> RAG response");
-        println!("    !<command>        Shell command (e.g., !ls -la)");
-        println!("    @<time> <query>   Time-travel query (e.g., @yesterday what did we discuss)");
-        println!("    ?<query>          Direct LLM query (no RAG)");
-        println!();
-        println!("  EXAMPLES:");
-        println!("    What did we discuss about Rust?");
-        println!("    remember that the API uses JWT tokens");
-        println!("    @last-week show file changes");
-        println!("    !cargo build");
-        println!();
-    }
-
-    /// Display help for a specific command.
-    fn command_help(command: &str) {
-        match command {
-            "remember" => {
-                println!("remember <text>");
+/// Show conversation history.
+///
+/// Fetches and displays recent messages from the current session.
+pub fn history(gallifrey: &Arc<Gallifrey>, session_id: SessionId) {
+    match gallifrey.conversation().get_messages(session_id) {
+        Ok(messages) => {
+            if messages.is_empty() {
+                println!("No messages in current session.");
+            } else {
+                println!("Session history ({} messages):", messages.len());
                 println!();
-                println!("Store information in the knowledge graph for later recall.");
-                println!();
-                println!("Examples:");
-                println!("  remember that the API uses JWT tokens");
-                println!("  remember project deadline is March 15");
-            }
-            "recall" => {
-                println!("recall <query>");
-                println!();
-                println!("Retrieve stored memories matching the query.");
-                println!();
-                println!("Examples:");
-                println!("  recall what I know about authentication");
-                println!("  recall project deadlines");
-            }
-            "snapshot" => {
-                println!("snapshot <name>");
-                println!();
-                println!("Save a snapshot of the current system state.");
-                println!("Snapshots can be used for time-travel debugging.");
-                println!();
-                println!("Examples:");
-                println!("  snapshot before-refactor");
-                println!("  snapshot working-state");
-            }
-            "timeline" => {
-                println!("timeline <entity>");
-                println!();
-                println!("Show the history of changes to an entity.");
-                println!();
-                println!("Examples:");
-                println!("  timeline authentication-module");
-                println!("  timeline config.toml");
-            }
-            _ => {
-                println!("No help available for '{command}'");
-            }
-        }
-    }
-
-    /// Show conversation history.
-    ///
-    /// Fetches and displays recent messages from the current session.
-    #[allow(clippy::unused_self)]
-    pub fn history(&self, gallifrey: &Arc<Gallifrey>, session_id: SessionId) {
-        match gallifrey.conversation().get_messages(session_id) {
-            Ok(messages) => {
-                if messages.is_empty() {
-                    println!("No messages in current session.");
-                } else {
-                    println!("Session history ({} messages):", messages.len());
-                    println!();
-                    for msg in messages.iter().take(20) {
-                        let role = match msg.role {
-                            tardis_gallifrey::stores::Role::User => "You",
-                            tardis_gallifrey::stores::Role::Assistant => "Tardis",
-                            tardis_gallifrey::stores::Role::System => "System",
-                        };
-                        let content = if msg.content.len() > 80 {
-                            format!("{}...", &msg.content[..77])
-                        } else {
-                            msg.content.clone()
-                        };
-                        println!(
-                            "  [{}] {}: {}",
-                            msg.timestamp.format("%H:%M"),
-                            role,
-                            content
-                        );
-                    }
-                    if messages.len() > 20 {
-                        println!("  ... and {} more", messages.len() - 20);
-                    }
+                for msg in messages.iter().take(20) {
+                    let role = match msg.role {
+                        tardis_gallifrey::stores::Role::User => "You",
+                        tardis_gallifrey::stores::Role::Assistant => "Tardis",
+                        tardis_gallifrey::stores::Role::System => "System",
+                    };
+                    let content = if msg.content.len() > 80 {
+                        format!("{}...", &msg.content[..77])
+                    } else {
+                        msg.content.clone()
+                    };
+                    println!(
+                        "  [{}] {}: {}",
+                        msg.timestamp.format("%H:%M"),
+                        role,
+                        content
+                    );
+                }
+                if messages.len() > 20 {
+                    println!("  ... and {} more", messages.len() - 20);
                 }
             }
-            Err(e) => {
-                println!("Failed to get history: {e}");
-            }
         }
-    }
-
-    /// List available models.
-    #[allow(clippy::unused_self)]
-    pub fn list_models(&self) {
-        println!("Available models:");
-        println!();
-        println!("  (No models loaded yet)");
-        println!();
-        println!("Use 'models load <path>' to load a model.");
-    }
-
-    /// Show current session context.
-    #[allow(clippy::unused_self)]
-    pub fn show_context(&self, session_id: SessionId) {
-        println!("Current Context:");
-        println!();
-        println!("  Session ID: {session_id}");
-        println!("  Model: (none loaded)");
-        println!("  Project: (none set)");
-        println!();
-        println!("Use 'context project:<name>' to set project context.");
+        Err(e) => {
+            println!("Failed to get history: {e}");
+        }
     }
 }
 
-impl Default for CommandHandler {
-    fn default() -> Self {
-        Self::new()
-    }
+/// List available models.
+pub fn list_models() {
+    println!("Available models:");
+    println!();
+    println!("  (No models loaded yet)");
+    println!();
+    println!("Use 'models load <path>' to load a model.");
+}
+
+/// Show current session context.
+pub fn show_context(session_id: SessionId) {
+    println!("Current Context:");
+    println!();
+    println!("  Session ID: {session_id}");
+    println!("  Model: (none loaded)");
+    println!("  Project: (none set)");
+    println!();
+    println!("Use 'context project:<name>' to set project context.");
 }

--- a/shell/src/dashboard.rs
+++ b/shell/src/dashboard.rs
@@ -1,5 +1,11 @@
 #[cfg(feature = "nova")]
 /// The TUI Dashboard module.
+#[allow(
+    clippy::too_many_lines,
+    clippy::cast_precision_loss,
+    clippy::manual_range_contains,
+    clippy::cast_lossless
+)]
 pub mod tui {
     use anyhow::Result;
     use chrono::{DateTime, Utc};

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -2,7 +2,7 @@
 //!
 //! "It's a scientific instrument, not a magic wand!"
 //!
-//! A CLI tool for file repair and analysis, leveraging PsychicPaper
+//! A CLI tool for file repair and analysis, leveraging `PsychicPaper`
 //! for heuristic parsing and validation.
 
 use anyhow::{Context, Result};
@@ -32,22 +32,25 @@ impl SonicScrewdriver {
     ///
     /// Returns an error if the file cannot be read.
     pub fn inspect(&self, path: &Path) -> Result<String> {
-        let content =
-            fs::read_to_string(path).with_context(|| format!("Failed to read file: {:?}", path))?;
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read file: {}", path.display()))?;
 
         let size = content.len();
         let lines = content.lines().count();
 
-        let mut diagnosis = format!("File: {:?}\nSize: {} bytes\nLines: {}\n", path, size, lines);
+        let mut diagnosis = format!(
+            "File: {}\nSize: {size} bytes\nLines: {lines}\n",
+            path.display()
+        );
 
         // Try to interpret as JSON
         match self.paper.interpret(&content, Intent::Json) {
             Ok(_) => diagnosis.push_str("Type: Valid JSON\nStatus: Healthy 🟢"),
             Err(_) => {
                 // Try other formats
-                if let Ok(_) = self.paper.interpret(&content, Intent::KeyValue) {
+                if self.paper.interpret(&content, Intent::KeyValue).is_ok() {
                     diagnosis.push_str("Type: Key-Value Pairs\nStatus: Healthy 🟢");
-                } else if let Ok(_) = self.paper.interpret(&content, Intent::List) {
+                } else if self.paper.interpret(&content, Intent::List).is_ok() {
                     diagnosis.push_str("Type: List\nStatus: Healthy 🟢");
                 } else {
                     match self.paper.interpret(&content, Intent::Auto) {
@@ -60,8 +63,11 @@ impl SonicScrewdriver {
                                 );
                             }
                         }
-                        Err(e) => diagnosis
-                            .push_str(&format!("Type: Unknown\nStatus: Broken 🔴\nError: {}", e)),
+                        Err(e) => {
+                            use std::fmt::Write;
+                            let _ =
+                                write!(diagnosis, "Type: Unknown\nStatus: Broken 🔴\nError: {e}");
+                        }
                     }
                 }
             }
@@ -80,37 +86,38 @@ impl SonicScrewdriver {
     ///
     /// Returns an error if the file cannot be read or written.
     pub fn repair(&self, path: &Path) -> Result<String> {
-        let content =
-            fs::read_to_string(path).with_context(|| format!("Failed to read file: {:?}", path))?;
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read file: {}", path.display()))?;
 
         // Create backup
         let backup_path = path.with_extension("bak");
         fs::write(&backup_path, &content)
-            .with_context(|| format!("Failed to create backup: {:?}", backup_path))?;
+            .with_context(|| format!("Failed to create backup: {}", backup_path.display()))?;
 
         // Attempt repair via interpretation
         // We use Auto intent to let PsychicPaper figure it out
         let interpreted = self
             .paper
             .interpret(&content, Intent::Auto)
-            .map_err(|e| anyhow::anyhow!("Failed to interpret file: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to interpret file: {e}"))?;
 
         // If it's a string, we probably didn't parse anything structured
         if let Value::String(_) = interpreted {
             return Ok(format!(
-                "Could not identify structure to repair. Backup created at {:?}",
-                backup_path
+                "Could not identify structure to repair. Backup created at {}",
+                backup_path.display()
             ));
         }
 
         // Write back as pretty-printed JSON
         let fixed_content = serde_json::to_string_pretty(&interpreted)?;
         fs::write(path, fixed_content)
-            .with_context(|| format!("Failed to write fixed file: {:?}", path))?;
+            .with_context(|| format!("Failed to write fixed file: {}", path.display()))?;
 
         Ok(format!(
-            "Repaired file: {:?}\nBackup saved to: {:?}\nFormat: JSON (Normalized)",
-            path, backup_path
+            "Repaired file: {}\nBackup saved to: {}\nFormat: JSON (Normalized)",
+            path.display(),
+            backup_path.display()
         ))
     }
 }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -1,6 +1,6 @@
 //! REPL (Read-Eval-Print Loop) for the Tardis shell.
 
-use crate::commands::CommandHandler;
+use crate::commands;
 use crate::router::{Intent, Router};
 use anyhow::Result;
 use rustyline::error::ReadlineError;
@@ -24,13 +24,12 @@ pub struct Repl {
     editor: DefaultEditor,
     /// Router for intent classification.
     router: Router,
-    /// Command handler for built-in commands.
-    commands: CommandHandler,
     /// Chronos RAG engine.
     chronos: Arc<Chronos>,
     /// Gallifrey database.
     gallifrey: Arc<Gallifrey>,
     /// Telemetry store (optional).
+    #[allow(dead_code)]
     telemetry_store: Option<Arc<TelemetryStore>>,
     /// Prophet engine (optional, Nova only).
     #[cfg(feature = "nova")]
@@ -62,7 +61,6 @@ impl Repl {
         Ok(Self {
             editor,
             router: Router::new(),
-            commands: CommandHandler::new(),
             chronos,
             gallifrey,
             telemetry_store,
@@ -141,12 +139,12 @@ impl Repl {
     /// Handle a built-in command.
     async fn handle_builtin(&mut self, command: &str, args: &[String]) {
         match command {
-            "help" => self.commands.help(args),
+            "help" => commands::help(args),
             "exit" | "quit" => {
                 println!("Goodbye!");
                 self.running = false;
             }
-            "history" => self.commands.history(&self.gallifrey, self.session_id),
+            "history" => commands::history(&self.gallifrey, self.session_id),
             "remember" => {
                 let content = args.join(" ");
                 match self
@@ -169,8 +167,8 @@ impl Repl {
                     Err(e) => println!("Failed to recall: {e}"),
                 }
             }
-            "models" => self.commands.list_models(),
-            "context" => self.commands.show_context(self.session_id),
+            "models" => commands::list_models(),
+            "context" => commands::show_context(self.session_id),
             "clear" => {
                 print!("\x1B[2J\x1B[1;1H");
             }
@@ -212,8 +210,8 @@ impl Repl {
                 };
 
                 match result {
-                    Ok(report) => println!("{}", report),
-                    Err(e) => println!("Sonic Screwdriver error: {}", e),
+                    Ok(report) => println!("{report}"),
+                    Err(e) => println!("Sonic Screwdriver error: {e}"),
                 }
             }
             _ => println!("Unknown command: {command}. Type 'help' for available commands."),


### PR DESCRIPTION
This PR implements several "Razor" simplifications:
1.  **De-Abstraction**: Converted `QueryAnalyzer` and `CommandHandler` from stateless structs to modules with free functions.
2.  **Explicit > Implicit**: Removed `Gallifrey` facade wrapper methods (like `gallifrey.insert()`) in favor of direct store access (e.g., `gallifrey.knowledge().insert_entity()`). This makes data flow and error handling more explicit.
3.  **Clean Up**: Addressed existing Clippy warnings in `tardis-shell` to ensure a clean build with strict linting.

These changes follow the KISS and YAGNI principles by removing unnecessary boilerplate and indirection.

---
*PR created automatically by Jules for task [5706392946306493373](https://jules.google.com/task/5706392946306493373) started by @madmax983*