### PR TITLE
🛡️ Sentry: Fix dropped system messages in Llama 2 chat template

### DIFF
--- a/vortex/src/tokenizer/template.rs
+++ b/vortex/src/tokenizer/template.rs
@@ -77,11 +77,25 @@ fn apply_llama2_template(messages: &[ChatMessage], add_generation_prompt: bool) 
                 result.push_str(" [/INST]");
             }
             ChatRole::Assistant => {
+                // If there's a pending system message, flush it before assistant response
+                if let Some(sys) = system_msg.take() {
+                    result.push_str("[INST] <<SYS>>\n");
+                    result.push_str(sys);
+                    result.push_str("\n<</SYS>>\n\n [/INST]");
+                }
+
                 result.push(' ');
                 result.push_str(&msg.content);
                 result.push_str(" </s><s>");
             }
         }
+    }
+
+    // Flush pending system message if no User/Assistant message consumed it
+    if let Some(sys) = system_msg {
+        result.push_str("[INST] <<SYS>>\n");
+        result.push_str(sys);
+        result.push_str("\n<</SYS>>\n\n [/INST]");
     }
 
     // Add space after [/INST] for assistant to generate
@@ -207,5 +221,31 @@ mod tests {
         assert!(result.contains(" Hello! </s><s>"));
         assert!(result.contains("[INST] How are you? [/INST]"));
         assert!(result.ends_with(" [/INST] "));
+    }
+
+    #[test]
+    fn test_apply_llama2_template_system_only() {
+        let messages = vec![ChatMessage::system("You are a poet")];
+
+        let result = apply_llama2_template(&messages, true);
+        assert!(result.contains("You are a poet"), "Should contain system message");
+        assert!(result.starts_with("[INST]"), "Should start with [INST]");
+        assert!(result.ends_with(" [/INST] "), "Should end with space for generation");
+    }
+
+    #[test]
+    fn test_apply_llama2_template_system_assistant() {
+        let messages = vec![
+            ChatMessage::system("Sys"),
+            ChatMessage::assistant("Hi"),
+        ];
+
+        let result = apply_llama2_template(&messages, true);
+        assert!(result.contains("Sys"), "Should contain system message");
+        assert!(result.contains("Hi"), "Should contain assistant message");
+        // Structure: [INST] <<SYS>>\nSys\n<</SYS>>\n\n [/INST] Hi </s><s>
+        assert!(result.contains("[INST]"), "Should contain INST block");
+        assert!(result.contains(" [/INST]"), "Should contain closing INST");
+        assert!(result.ends_with(" Hi </s><s>"), "Should end with assistant response");
     }
 }


### PR DESCRIPTION
🎯 Target: `vortex/src/tokenizer/template.rs` (specifically `apply_llama2_template`).
💣 Risk: System messages (e.g., "You are a helpful assistant") were silently ignored if the conversation history did not contain a User message, or if the System message was followed immediately by an Assistant message. This is a correctness issue where the model context is incomplete.
🧪 Strategy: Added two new test cases (`test_apply_llama2_template_system_only`, `test_apply_llama2_template_system_assistant`) to expose the bug. Refactored the function to explicitly flush any pending `system_msg` before processing an Assistant message or at the end of the prompt construction.
🔬 Verification: `cargo test -p tardis-vortex --lib tokenizer::template` passes.

---
*PR created automatically by Jules for task [2112994312002343601](https://jules.google.com/task/2112994312002343601) started by @madmax983*