### PR TITLE
🎻 Bard: Documentation improvements and runnable examples

### DIFF
--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -25,6 +25,15 @@
 //! - If a source fits entirely within the remaining budget, it is included.
 //! - If a source partially fits, it is **truncated** to fit the remaining budget.
 //! - Any subsequent sources are dropped, and a note "... (N more sources truncated)" is appended.
+//!
+//! # ⚠️ Silent Truncation Warning
+//!
+//! Because sources are processed in order of relevance, it is possible for a single large,
+//! highly relevant source to consume the entire token budget, causing all subsequent sources
+//! to be silently dropped.
+//!
+//! This is by design: we prioritize high-relevance context over quantity. However, if you are
+//! getting "missing context" errors, check if your top results are excessively long.
 
 use super::{ContextSource, ContextSourceType};
 use crate::error::ChronosResult;

--- a/gallifrey/src/stores/conversation.rs
+++ b/gallifrey/src/stores/conversation.rs
@@ -33,6 +33,16 @@ impl ConversationStore {
 
     /// Create a new session.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tardis_gallifrey::stores::ConversationStore;
+    ///
+    /// let store = ConversationStore::new();
+    /// let session_id = store.create_session().unwrap();
+    /// assert!(store.get_session(session_id).unwrap().is_some());
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns an error if the lock is poisoned.
@@ -92,6 +102,34 @@ impl ConversationStore {
     }
 
     /// Add a message to a session.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tardis_gallifrey::stores::ConversationStore;
+    /// use tardis_gallifrey::domain::{Message, Role};
+    /// use tardis_common::id::{EntityId, SessionId};
+    /// use chrono::Utc;
+    ///
+    /// let store = ConversationStore::new();
+    /// let session_id = store.create_session().unwrap();
+    ///
+    /// let message = Message {
+    ///     id: EntityId::new(),
+    ///     session_id,
+    ///     role: Role::User,
+    ///     content: "Hello, Tardis!".to_string(),
+    ///     timestamp: Utc::now(),
+    ///     embedding: None,
+    ///     entity_refs: vec![],
+    /// };
+    ///
+    /// store.add_message(message).unwrap();
+    ///
+    /// let messages = store.get_messages(session_id).unwrap();
+    /// assert_eq!(messages.len(), 1);
+    /// assert_eq!(messages[0].content, "Hello, Tardis!");
+    /// ```
     ///
     /// # Errors
     ///

--- a/gallifrey/src/stores/system_state.rs
+++ b/gallifrey/src/stores/system_state.rs
@@ -40,6 +40,29 @@ impl SystemStateStore {
 
     /// Take a snapshot.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tardis_gallifrey::stores::SystemStateStore;
+    /// use tardis_gallifrey::domain::{SystemState, SnapshotTrigger};
+    /// use std::collections::HashMap;
+    ///
+    /// let store = SystemStateStore::new();
+    /// let state = SystemState {
+    ///     processes: HashMap::new(),
+    ///     config: HashMap::new(),
+    ///     files: HashMap::new(),
+    /// };
+    ///
+    /// let snapshot_id = store.take_snapshot(
+    ///     "Initial State",
+    ///     SnapshotTrigger::Manual,
+    ///     state
+    /// ).unwrap();
+    ///
+    /// assert!(store.get_snapshot(snapshot_id).unwrap().is_some());
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns an error if the lock is poisoned.

--- a/shell/src/commands.rs
+++ b/shell/src/commands.rs
@@ -150,6 +150,23 @@ impl CommandHandler {
     /// Show conversation history.
     ///
     /// Fetches and displays recent messages from the current session.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tardis_shell::commands::CommandHandler;
+    /// use tardis_gallifrey::Gallifrey;
+    /// use std::sync::Arc;
+    /// use tardis_common::id::SessionId;
+    ///
+    /// // 1. Setup
+    /// let handler = CommandHandler::new();
+    /// let gallifrey = Arc::new(Gallifrey::new());
+    /// let session_id = SessionId::new();
+    ///
+    /// // 2. Display history (will be empty)
+    /// handler.history(&gallifrey, session_id);
+    /// ```
     #[allow(clippy::unused_self)]
     pub fn history(&self, gallifrey: &Arc<Gallifrey>, session_id: SessionId) {
         match gallifrey.conversation().get_messages(session_id) {

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -101,19 +101,19 @@ impl Router {
     ///
     /// // Built-in command
     /// let intent = router.route("help me");
-    /// matches!(intent, Intent::BuiltinCommand { command, .. } if command == "help");
+    /// assert!(matches!(intent, Intent::BuiltinCommand { command, .. } if command == "help"));
     ///
     /// // Shell command
     /// let intent = router.route("!ls -la");
-    /// matches!(intent, Intent::ShellCommand { command } if command == "ls -la");
+    /// assert!(matches!(intent, Intent::ShellCommand { command } if command == "ls -la"));
     ///
     /// // Time travel
     /// let intent = router.route("@yesterday what happened?");
-    /// matches!(intent, Intent::TimeTravel { timestamp, .. } if timestamp == "yesterday");
+    /// assert!(matches!(intent, Intent::TimeTravel { timestamp, .. } if timestamp == "yesterday"));
     ///
     /// // Chronos query (default)
     /// let intent = router.route("What is the meaning of life?");
-    /// matches!(intent, Intent::ChronosQuery { .. });
+    /// assert!(matches!(intent, Intent::ChronosQuery { .. }));
     /// ```
     #[must_use]
     pub fn route(&self, input: &str) -> Intent {


### PR DESCRIPTION
Improved documentation by adding executable examples to key stores and commands, and clarified truncation behavior in the RAG pipeline.

Detailed changes:
- `gallifrey/src/stores/conversation.rs`: Added doc tests for session creation and message addition.
- `gallifrey/src/stores/system_state.rs`: Added doc test for taking snapshots.
- `chronos/src/pipeline/augmenter.rs`: Explicitly documented the silent truncation behavior to avoid confusion about missing context.
- `shell/src/router.rs`: Fixed the `route` example to use `assert!(matches!(...))` so it actually tests the logic, and made it self-contained.
- `shell/src/commands.rs`: Added usage example for the `history` command.


---
*PR created automatically by Jules for task [1173897213639776110](https://jules.google.com/task/1173897213639776110) started by @madmax983*