### PR TITLE
🗺️ Atlas: Refactor CommandHandler and fix split personality in shell

### DIFF
--- a/shell/src/commands.rs
+++ b/shell/src/commands.rs
@@ -15,204 +15,176 @@ use std::sync::Arc;
 use tardis_common::SessionId;
 use tardis_gallifrey::Gallifrey;
 
-/// Handler for built-in shell commands.
+/// Display help information.
 ///
-/// The command handler is stateless but receives the application state (like `Gallifrey` instances)
-/// during method calls to perform its duties.
-#[derive(Debug)]
-pub struct CommandHandler {
-    // Configuration
+/// If an argument is provided, displays help for that specific command.
+/// Otherwise, displays the general help menu.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tardis_shell::commands;
+///
+/// commands::help(&[]); // General help
+/// commands::help(&["remember".to_string()]); // Help for 'remember'
+/// ```
+pub fn help(args: &[String]) {
+    if args.is_empty() {
+        general_help();
+    } else {
+        command_help(&args[0]);
+    }
 }
 
-impl CommandHandler {
-    /// Create a new command handler.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {}
-    }
+/// Display general help.
+fn general_help() {
+    println!("Tardis Shell Commands:");
+    println!();
+    println!("  BUILT-IN COMMANDS:");
+    println!("    help [command]    Show help (for a specific command)");
+    println!("    history           Show conversation history");
+    println!("    remember <text>   Store information for later recall");
+    println!("    recall <query>    Retrieve stored memories");
+    println!("    models            List available LLM models");
+    println!("    context           Show current session context");
+    println!("    snapshot <name>   Save system state snapshot");
+    println!("    restore <name>    Restore a saved snapshot");
+    println!("    timeline <entity> Show history of an entity");
+    println!("    clear             Clear the screen");
+    println!("    exit / quit       Exit the shell");
+    println!();
+    println!("  INPUT MODES:");
+    println!("    <query>           Natural language (default) -> RAG response");
+    println!("    !<command>        Shell command (e.g., !ls -la)");
+    println!("    @<time> <query>   Time-travel query (e.g., @yesterday what did we discuss)");
+    println!("    ?<query>          Direct LLM query (no RAG)");
+    println!();
+    println!("  EXAMPLES:");
+    println!("    > What did we discuss about Rust?");
+    println!("    > remember that the API uses JWT tokens");
+    println!("    > @last-week show file changes");
+    println!("    > !cargo build");
+    println!("    > ?Write a poem about time travel");
+    println!();
+}
 
-    /// Display help information.
-    ///
-    /// If an argument is provided, displays help for that specific command.
-    /// Otherwise, displays the general help menu.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tardis_shell::commands::CommandHandler;
-    ///
-    /// let handler = CommandHandler::new();
-    /// handler.help(&[]); // General help
-    /// handler.help(&["remember".to_string()]); // Help for 'remember'
-    /// ```
-    #[allow(clippy::unused_self)]
-    pub fn help(&self, args: &[String]) {
-        if args.is_empty() {
-            Self::general_help();
-        } else {
-            Self::command_help(&args[0]);
+/// Display help for a specific command.
+fn command_help(command: &str) {
+    match command {
+        "remember" => {
+            println!("remember <text>");
+            println!();
+            println!("Store information in the knowledge graph for later recall.");
+            println!();
+            println!("Examples:");
+            println!("  remember that the API uses JWT tokens");
+            println!("  remember project deadline is March 15");
+        }
+        "recall" => {
+            println!("recall <query>");
+            println!();
+            println!("Retrieve stored memories matching the query.");
+            println!();
+            println!("Examples:");
+            println!("  recall what I know about authentication");
+            println!("  recall project deadlines");
+        }
+        "models" => {
+            println!("models");
+            println!();
+            println!("List available LLM models and their status.");
+            println!("Use 'models load <path>' to load a specific model.");
+        }
+        "context" => {
+            println!("context [subcommand]");
+            println!();
+            println!("Inspect or modify the current session context.");
+            println!();
+            println!("Subcommands:");
+            println!("  (none)      Show summary");
+            println!("  project     Set project context");
+        }
+        "snapshot" => {
+            println!("snapshot <name>");
+            println!();
+            println!("Save a snapshot of the current system state.");
+            println!("Snapshots can be used for time-travel debugging.");
+            println!();
+            println!("Examples:");
+            println!("  snapshot before-refactor");
+            println!("  snapshot working-state");
+        }
+        "timeline" => {
+            println!("timeline <entity>");
+            println!();
+            println!("Show the history of changes to an entity.");
+            println!();
+            println!("Examples:");
+            println!("  timeline authentication-module");
+            println!("  timeline config.toml");
+        }
+        _ => {
+            println!("No help available for '{command}'");
         }
     }
+}
 
-    /// Display general help.
-    fn general_help() {
-        println!("Tardis Shell Commands:");
-        println!();
-        println!("  BUILT-IN COMMANDS:");
-        println!("    help [command]    Show help (for a specific command)");
-        println!("    history           Show conversation history");
-        println!("    remember <text>   Store information for later recall");
-        println!("    recall <query>    Retrieve stored memories");
-        println!("    models            List available LLM models");
-        println!("    context           Show current session context");
-        println!("    snapshot <name>   Save system state snapshot");
-        println!("    restore <name>    Restore a saved snapshot");
-        println!("    timeline <entity> Show history of an entity");
-        println!("    clear             Clear the screen");
-        println!("    exit / quit       Exit the shell");
-        println!();
-        println!("  INPUT MODES:");
-        println!("    <query>           Natural language (default) -> RAG response");
-        println!("    !<command>        Shell command (e.g., !ls -la)");
-        println!("    @<time> <query>   Time-travel query (e.g., @yesterday what did we discuss)");
-        println!("    ?<query>          Direct LLM query (no RAG)");
-        println!();
-        println!("  EXAMPLES:");
-        println!("    > What did we discuss about Rust?");
-        println!("    > remember that the API uses JWT tokens");
-        println!("    > @last-week show file changes");
-        println!("    > !cargo build");
-        println!("    > ?Write a poem about time travel");
-        println!();
-    }
-
-    /// Display help for a specific command.
-    fn command_help(command: &str) {
-        match command {
-            "remember" => {
-                println!("remember <text>");
+/// Show conversation history.
+///
+/// Fetches and displays recent messages from the current session.
+pub fn history(gallifrey: &Arc<Gallifrey>, session_id: SessionId) {
+    match gallifrey.conversation().get_messages(session_id) {
+        Ok(messages) => {
+            if messages.is_empty() {
+                println!("No messages in current session.");
+            } else {
+                println!("Session history ({} messages):", messages.len());
                 println!();
-                println!("Store information in the knowledge graph for later recall.");
-                println!();
-                println!("Examples:");
-                println!("  remember that the API uses JWT tokens");
-                println!("  remember project deadline is March 15");
-            }
-            "recall" => {
-                println!("recall <query>");
-                println!();
-                println!("Retrieve stored memories matching the query.");
-                println!();
-                println!("Examples:");
-                println!("  recall what I know about authentication");
-                println!("  recall project deadlines");
-            }
-            "models" => {
-                println!("models");
-                println!();
-                println!("List available LLM models and their status.");
-                println!("Use 'models load <path>' to load a specific model.");
-            }
-            "context" => {
-                println!("context [subcommand]");
-                println!();
-                println!("Inspect or modify the current session context.");
-                println!();
-                println!("Subcommands:");
-                println!("  (none)      Show summary");
-                println!("  project     Set project context");
-            }
-            "snapshot" => {
-                println!("snapshot <name>");
-                println!();
-                println!("Save a snapshot of the current system state.");
-                println!("Snapshots can be used for time-travel debugging.");
-                println!();
-                println!("Examples:");
-                println!("  snapshot before-refactor");
-                println!("  snapshot working-state");
-            }
-            "timeline" => {
-                println!("timeline <entity>");
-                println!();
-                println!("Show the history of changes to an entity.");
-                println!();
-                println!("Examples:");
-                println!("  timeline authentication-module");
-                println!("  timeline config.toml");
-            }
-            _ => {
-                println!("No help available for '{command}'");
-            }
-        }
-    }
-
-    /// Show conversation history.
-    ///
-    /// Fetches and displays recent messages from the current session.
-    #[allow(clippy::unused_self)]
-    pub fn history(&self, gallifrey: &Arc<Gallifrey>, session_id: SessionId) {
-        match gallifrey.conversation().get_messages(session_id) {
-            Ok(messages) => {
-                if messages.is_empty() {
-                    println!("No messages in current session.");
-                } else {
-                    println!("Session history ({} messages):", messages.len());
-                    println!();
-                    for msg in messages.iter().take(20) {
-                        let role = match msg.role {
-                            tardis_gallifrey::stores::Role::User => "You",
-                            tardis_gallifrey::stores::Role::Assistant => "Tardis",
-                            tardis_gallifrey::stores::Role::System => "System",
-                        };
-                        let content = if msg.content.len() > 80 {
-                            format!("{}...", &msg.content[..77])
-                        } else {
-                            msg.content.clone()
-                        };
-                        println!(
-                            "  [{}] {}: {}",
-                            msg.timestamp.format("%H:%M"),
-                            role,
-                            content
-                        );
-                    }
-                    if messages.len() > 20 {
-                        println!("  ... and {} more", messages.len() - 20);
-                    }
+                for msg in messages.iter().take(20) {
+                    let role = match msg.role {
+                        tardis_gallifrey::stores::Role::User => "You",
+                        tardis_gallifrey::stores::Role::Assistant => "Tardis",
+                        tardis_gallifrey::stores::Role::System => "System",
+                    };
+                    let content = if msg.content.len() > 80 {
+                        format!("{}...", &msg.content[..77])
+                    } else {
+                        msg.content.clone()
+                    };
+                    println!(
+                        "  [{}] {}: {}",
+                        msg.timestamp.format("%H:%M"),
+                        role,
+                        content
+                    );
+                }
+                if messages.len() > 20 {
+                    println!("  ... and {} more", messages.len() - 20);
                 }
             }
-            Err(e) => {
-                println!("Failed to get history: {e}");
-            }
         }
-    }
-
-    /// List available models.
-    #[allow(clippy::unused_self)]
-    pub fn list_models(&self) {
-        println!("Available models:");
-        println!();
-        println!("  (No models loaded yet)");
-        println!();
-        println!("Use 'models load <path>' to load a model.");
-    }
-
-    /// Show current session context.
-    #[allow(clippy::unused_self)]
-    pub fn show_context(&self, session_id: SessionId) {
-        println!("Current Context:");
-        println!();
-        println!("  Session ID: {session_id}");
-        println!("  Model: (none loaded)");
-        println!("  Project: (none set)");
-        println!();
-        println!("Use 'context project:<name>' to set project context.");
+        Err(e) => {
+            println!("Failed to get history: {e}");
+        }
     }
 }
 
-impl Default for CommandHandler {
-    fn default() -> Self {
-        Self::new()
-    }
+/// List available models.
+pub fn list_models() {
+    println!("Available models:");
+    println!();
+    println!("  (No models loaded yet)");
+    println!();
+    println!("Use 'models load <path>' to load a model.");
+}
+
+/// Show current session context.
+pub fn show_context(session_id: SessionId) {
+    println!("Current Context:");
+    println!();
+    println!("  Session ID: {session_id}");
+    println!("  Model: (none loaded)");
+    println!("  Project: (none set)");
+    println!();
+    println!("Use 'context project:<name>' to set project context.");
 }

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -6,22 +6,13 @@ use anyhow::Result;
 use std::sync::Arc;
 use tardis_chronos::Chronos;
 use tardis_gallifrey::Gallifrey;
+use tardis_shell::repl::Repl;
 use tardis_telemetry::{init, TelemetryConfig};
 use tardis_vortex::Vortex;
 use tracing::info;
 
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::prophecy::Prophet;
-
-mod commands;
-#[cfg(feature = "nova")]
-mod dashboard;
-#[cfg(feature = "nova")]
-mod experimental;
-mod repl;
-mod router;
-
-use repl::Repl;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -1,6 +1,6 @@
 //! REPL (Read-Eval-Print Loop) for the Tardis shell.
 
-use crate::commands::CommandHandler;
+use crate::commands;
 use crate::router::{Intent, Router};
 use anyhow::Result;
 use rustyline::error::ReadlineError;
@@ -24,8 +24,6 @@ pub struct Repl {
     editor: DefaultEditor,
     /// Router for intent classification.
     router: Router,
-    /// Command handler for built-in commands.
-    commands: CommandHandler,
     /// Chronos RAG engine.
     chronos: Arc<Chronos>,
     /// Gallifrey database.
@@ -63,7 +61,6 @@ impl Repl {
         Ok(Self {
             editor,
             router: Router::new(),
-            commands: CommandHandler::new(),
             chronos,
             gallifrey,
             telemetry_store,
@@ -142,12 +139,12 @@ impl Repl {
     /// Handle a built-in command.
     async fn handle_builtin(&mut self, command: &str, args: &[String]) {
         match command {
-            "help" => self.commands.help(args),
+            "help" => commands::help(args),
             "exit" | "quit" => {
                 println!("Goodbye!");
                 self.running = false;
             }
-            "history" => self.commands.history(&self.gallifrey, self.session_id),
+            "history" => commands::history(&self.gallifrey, self.session_id),
             "remember" => {
                 let content = args.join(" ");
                 match self
@@ -170,8 +167,8 @@ impl Repl {
                     Err(e) => println!("Failed to recall: {e}"),
                 }
             }
-            "models" => self.commands.list_models(),
-            "context" => self.commands.show_context(self.session_id),
+            "models" => commands::list_models(),
+            "context" => commands::show_context(self.session_id),
             "clear" => {
                 print!("\x1B[2J\x1B[1;1H");
             }


### PR DESCRIPTION
This PR refactors the `CommandHandler` in `tardis-shell` from a stateless struct into a module of free functions, adhering to the project's architectural guidelines. It also fixes a structural issue in `shell/src/main.rs` where modules were being redeclared instead of imported from the `tardis_shell` library, causing double compilation and type mismatches.

Changes:
- `shell/src/commands.rs`: Converted `CommandHandler` to free functions (`help`, `history`, etc.).
- `shell/src/repl.rs`: Updated to call `commands` functions directly.
- `shell/src/main.rs`: Removed module declarations and imported types from `tardis_shell`.

---
*PR created automatically by Jules for task [11050744011524433530](https://jules.google.com/task/11050744011524433530) started by @madmax983*