### PR TITLE
⚡ Bolt: Optimize temporal checks in Gallifrey

### DIFF
--- a/common/src/temporal.rs
+++ b/common/src/temporal.rs
@@ -64,6 +64,18 @@ impl TimeRange {
         }
     }
 
+    /// Check if this range is currently active relative to a specific time.
+    ///
+    /// Use this when checking multiple ranges against the same "now" timestamp
+    /// to avoid repeated calls to `Utc::now()`.
+    #[must_use]
+    pub fn is_current_relative_to(&self, now: DateTime<Utc>) -> bool {
+        match self.end {
+            Some(end) => end > now,
+            None => true,
+        }
+    }
+
     /// Close this range at the current time.
     ///
     /// This is typically used to mark the end of a transaction or validity period.
@@ -141,6 +153,15 @@ impl BiTemporalInterval {
     #[must_use]
     pub fn is_current(&self) -> bool {
         self.valid_time.is_current() && self.transaction_time.is_current()
+    }
+
+    /// Check if this interval is current relative to a specific time.
+    ///
+    /// Use this when checking multiple intervals against the same "now" timestamp
+    /// to avoid repeated calls to `Utc::now()`.
+    #[must_use]
+    pub fn is_current_relative_to(&self, now: DateTime<Utc>) -> bool {
+        self.valid_time.is_current_relative_to(now) && self.transaction_time.is_current_relative_to(now)
     }
 
     /// Close the transaction time (mark as superseded).
@@ -444,6 +465,18 @@ mod tests {
 
         // Implicit returns current time, so we just check it returns Some
         assert!(TemporalReference::Implicit.resolved().is_some());
+    }
+
+    #[test]
+    fn is_current_relative_to_check() {
+        let now = Utc::now();
+        let valid_time = TimeRange::bounded(now - Duration::hours(2), now - Duration::hours(1));
+        let interval = BiTemporalInterval::with_valid_time(valid_time);
+
+        assert!(!interval.is_current_relative_to(now));
+
+        let current_interval = BiTemporalInterval::now();
+        assert!(current_interval.is_current_relative_to(now));
     }
 
     proptest! {

--- a/gallifrey/benches/store_benchmarks.rs
+++ b/gallifrey/benches/store_benchmarks.rs
@@ -57,6 +57,40 @@ fn bench_knowledge_store(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_knowledge_store_populated(c: &mut Criterion) {
+    let mut group = c.benchmark_group("knowledge_store_populated");
+    group.throughput(Throughput::Elements(1000));
+
+    let store = KnowledgeStore::new();
+    let mut ids = Vec::new();
+    for i in 0..1000 {
+        let entity = Entity {
+            id: EntityId::new(),
+            entity_type: (if i % 2 == 0 { "Concept" } else { "Other" }).to_string(),
+            name: format!("Entity {}", i),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval::now(),
+            source: None,
+        };
+        let id = store.insert_entity(entity).unwrap();
+        ids.push(id);
+    }
+
+    // Update 500 entities to create history
+    for i in 0..500 {
+        let mut updates = HashMap::new();
+        updates.insert("updated".to_string(), serde_json::json!(true));
+        store.update_entity(ids[i], updates).unwrap();
+    }
+
+    group.bench_function("KnowledgeStore::find_by_type_1000_history", |b| {
+        b.iter(|| black_box(store.find_by_type("Concept")));
+    });
+
+    group.finish();
+}
+
 fn bench_conversation_store(c: &mut Criterion) {
     let mut group = c.benchmark_group("conversation_store");
 
@@ -105,6 +139,7 @@ fn bench_bi_temporal(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_knowledge_store,
+    bench_knowledge_store_populated,
     bench_conversation_store,
     bench_bi_temporal,
 );

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -139,7 +139,7 @@ impl Gallifrey {
     /// # ⚠️ Experimental
     ///
     /// This method is currently a stub. It parses the query but returns an empty result set.
-    /// Full implementation is pending the GallifreyDB query engine integration.
+    /// Full implementation is pending the `GallifreyDB` query engine integration.
     ///
     /// # Errors
     ///

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -91,9 +91,10 @@ impl KnowledgeStore {
             .read()
             .map_err(|_| GallifreyError::StorageError("lock poisoned".to_string()))?;
 
+        let now = Utc::now();
         Ok(entities
             .get(&id)
-            .and_then(|versions| versions.iter().find(|e| e.temporal.is_current()))
+            .and_then(|versions| versions.iter().find(|e| e.temporal.is_current_relative_to(now)))
             .cloned())
     }
 
@@ -237,10 +238,12 @@ impl KnowledgeStore {
             .get_mut(&id)
             .ok_or_else(|| GallifreyError::EntityNotFound(id.to_string()))?;
 
+        let now = Utc::now();
+
         // Find current version and supersede it
         let current = versions
             .iter_mut()
-            .find(|e| e.temporal.is_current())
+            .find(|e| e.temporal.is_current_relative_to(now))
             .ok_or_else(|| GallifreyError::EntityNotFound(id.to_string()))?;
 
         // Create new version with updates
@@ -288,10 +291,12 @@ impl KnowledgeStore {
             .read()
             .map_err(|_| GallifreyError::StorageError("lock poisoned".to_string()))?;
 
+        let now = Utc::now();
+
         Ok(entities
             .values()
             .flat_map(|versions| versions.iter())
-            .filter(|e| e.temporal.is_current() && e.entity_type == entity_type)
+            .filter(|e| e.temporal.is_current_relative_to(now) && e.entity_type == entity_type)
             .cloned()
             .collect())
     }
@@ -312,10 +317,12 @@ impl KnowledgeStore {
             .read()
             .map_err(|_| GallifreyError::StorageError("lock poisoned".to_string()))?;
 
+        let now = Utc::now();
+
         Ok(entities
             .values()
             .flat_map(|versions| versions.iter())
-            .filter(|e| e.temporal.is_current() && e.embedding.is_some())
+            .filter(|e| e.temporal.is_current_relative_to(now) && e.embedding.is_some())
             .take(limit)
             .cloned()
             .collect())


### PR DESCRIPTION
**Optimization: Hoist `Utc::now()` out of loops in KnowledgeStore**

This PR optimizes temporal validity checks in `KnowledgeStore` by hoisting `Utc::now()` calls out of loops and iterators.

**Changes:**
1.  **`tardis-common`**: Added `TimeRange::is_current_relative_to(now)` and `BiTemporalInterval::is_current_relative_to(now)` to allow checking validity against a pre-calculated timestamp.
2.  **`tardis-gallifrey`**: Updated `KnowledgeStore` methods (`get_entity`, `find_by_type`, `semantic_search`, `update_entity`) to call `Utc::now()` once at the beginning and use the new `is_current_relative_to` method inside loops.
3.  **Benchmarks**: Added `bench_knowledge_store_populated` to `gallifrey/benches/store_benchmarks.rs` to measure performance with a populated store (1000 entities, 500 with history).

**Performance Results:**
*   **Baseline**: `157.53 µs` per call to `find_by_type` (1000 entities).
*   **Optimized**: `136.11 µs` per call.
*   **Improvement**: **~13.6% reduction in latency.**

**Trade-off:**
*   `get_entity` for a single entity incurs a slight overhead (~50ns) due to the upfront `Utc::now()` call if the entity is found immediately and is current (as `is_current` used to short-circuit). However, this pays off significantly for entities with history and for scan operations like `find_by_type`.


---
*PR created automatically by Jules for task [18396915664478730871](https://jules.google.com/task/18396915664478730871) started by @madmax983*