### PR TITLE
test(chronos): enable deterministic testing for QueryAnalyzer

### DIFF
--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -183,10 +183,21 @@ impl QueryAnalyzer {
     ///
     /// Returns an error if analysis fails.
     pub fn analyze(&self, query: &str) -> ChronosResult<AnalyzedQuery> {
+        self.analyze_at(query, Utc::now())
+    }
+
+    /// Analyze a query at a specific point in time.
+    ///
+    /// This is useful for deterministic testing or processing historical queries.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if analysis fails.
+    pub fn analyze_at(&self, query: &str, now: DateTime<Utc>) -> ChronosResult<AnalyzedQuery> {
         // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
         let query_lower = query.to_lowercase();
         let intent = self.classify_intent(&query_lower);
-        let temporal_refs = self.extract_temporal_refs(&query_lower, Utc::now());
+        let temporal_refs = self.extract_temporal_refs(&query_lower, now);
         let entities = self.extract_entities(query);
 
         let temporal_description = if temporal_refs.is_empty() {
@@ -413,5 +424,142 @@ mod tests {
         let refs = analyzer.extract_temporal_refs("yesterday", now);
         let desc = analyzer.describe_temporal_context(&refs);
         assert!(desc.contains("yesterday"));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod deterministic_tests {
+    use super::*;
+
+    // Helper to get a fixed "now"
+    fn get_fixed_now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2024-03-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn test_analyze_at_temporal_resolution() {
+        let analyzer = QueryAnalyzer::new();
+        let now = get_fixed_now();
+
+        // "yesterday" -> 2024-03-14
+        let res = analyzer
+            .analyze_at("What happened yesterday?", now)
+            .unwrap();
+        assert_eq!(res.temporal_refs.len(), 1);
+        assert_eq!(
+            res.temporal_refs[0].resolved().unwrap().to_rfc3339(),
+            "2024-03-14T12:00:00+00:00"
+        );
+
+        // "last week" -> 2024-03-08
+        let res = analyzer.analyze_at("Check last week logs", now).unwrap();
+        assert_eq!(res.temporal_refs.len(), 1);
+        assert_eq!(
+            res.temporal_refs[0].resolved().unwrap().to_rfc3339(),
+            "2024-03-08T12:00:00+00:00"
+        );
+
+        // "today" -> 2024-03-15
+        let res = analyzer.analyze_at("Do it today", now).unwrap();
+        assert_eq!(res.temporal_refs.len(), 1);
+        assert_eq!(
+            res.temporal_refs[0].resolved().unwrap().to_rfc3339(),
+            "2024-03-15T12:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn test_analyze_at_intent_classification() {
+        let analyzer = QueryAnalyzer::new();
+        let now = get_fixed_now();
+
+        let cases = vec![
+            ("Remember that I like pizza", QueryIntent::Remember),
+            ("Please remember this conversation", QueryIntent::Remember),
+            ("What did we discuss?", QueryIntent::Recall),
+            ("Recall the meeting notes", QueryIntent::Recall),
+            ("How has it changed?", QueryIntent::TemporalDiff),
+            ("Take a system snapshot", QueryIntent::SystemQuery),
+            ("Is this a question?", QueryIntent::Question),
+            ("Just chatting", QueryIntent::Chat),
+        ];
+
+        for (query, expected) in cases {
+            let res = analyzer.analyze_at(query, now).unwrap();
+            assert_eq!(res.intent, expected, "Failed for query: {}", query);
+        }
+    }
+
+    #[test]
+    fn test_analyze_at_mixed_references() {
+        let analyzer = QueryAnalyzer::new();
+        let now = get_fixed_now();
+
+        // "yesterday" and "today"
+        let res = analyzer
+            .analyze_at("Compare yesterday and today", now)
+            .unwrap();
+        assert_eq!(res.temporal_refs.len(), 2);
+
+        // Order depends on implementation (TEMPORAL_RULES order or scan order).
+        // TEMPORAL_RULES: yesterday, last week, today.
+        // It iterates over rules and checks contains.
+        // "yesterday" (rule 1) matches. Added first.
+        // "today" (rule 3) matches. Added second.
+
+        let texts: Vec<String> = res
+            .temporal_refs
+            .iter()
+            .map(|r| match r {
+                TemporalReference::Relative { text, .. } => text.clone(),
+                _ => panic!("Expected relative"),
+            })
+            .collect();
+
+        assert!(texts.contains(&"yesterday".to_string()));
+        assert!(texts.contains(&"today".to_string()));
+    }
+
+    #[test]
+    fn test_analyze_at_case_insensitivity() {
+        let analyzer = QueryAnalyzer::new();
+        let now = get_fixed_now();
+
+        let res = analyzer
+            .analyze_at("WHAT HAPPENED YESTERDAY?", now)
+            .unwrap();
+        assert_eq!(res.temporal_refs.len(), 1);
+        match &res.temporal_refs[0] {
+            TemporalReference::Relative { text, .. } => assert_eq!(text, "yesterday"),
+            _ => panic!("Expected relative reference"),
+        }
+    }
+
+    #[test]
+    fn test_analyze_at_no_temporal_reference() {
+        let analyzer = QueryAnalyzer::new();
+        let now = get_fixed_now();
+
+        let res = analyzer.analyze_at("Hello world", now).unwrap();
+        assert!(res.temporal_refs.is_empty());
+        assert!(res.temporal_description.is_none());
+    }
+
+    #[test]
+    fn test_analyze_at_mixed_intents_edge_case() {
+        let analyzer = QueryAnalyzer::new();
+        let now = get_fixed_now();
+
+        // "Remember this: recall is important"
+        // Matches "remember this" -> Remember (First rule)
+        // Matches "recall" -> Recall (Second rule)
+        // Should pick Remember because it's first in INTENT_RULES.
+        let res = analyzer
+            .analyze_at("Remember this: recall is important", now)
+            .unwrap();
+        assert_eq!(res.intent, QueryIntent::Remember);
     }
 }

--- a/shell/src/experimental/chronograph.rs
+++ b/shell/src/experimental/chronograph.rs
@@ -124,21 +124,10 @@ impl ChronoGraph {
             }
 
             let indent_rel = "  ".repeat(current_depth + 1);
-            writeln!(
-                output,
-                "{}|--[{}]-->",
-                indent_rel, rel.relationship_type
-            )?;
+            writeln!(output, "{}|--[{}]-->", indent_rel, rel.relationship_type)?;
 
             if let Some(target) = self.resolve_entity(rel.target, time)? {
-                self.traverse(
-                    &target,
-                    max_depth,
-                    current_depth + 1,
-                    time,
-                    visited,
-                    output,
-                )?;
+                self.traverse(&target, max_depth, current_depth + 1, time, visited, output)?;
             } else {
                 writeln!(output, "{}(Unknown Entity)", indent_rel)?;
             }
@@ -183,9 +172,7 @@ impl ChronoGraph {
                 .get_entity_at(id, t, Utc::now())
                 .map_err(|e| anyhow!(e.to_string()))
         } else {
-            knowledge
-                .get_entity(id)
-                .map_err(|e| anyhow!(e.to_string()))
+            knowledge.get_entity(id).map_err(|e| anyhow!(e.to_string()))
         }
     }
 }
@@ -245,46 +232,46 @@ mod tests {
 
     #[tokio::test]
     async fn test_chronograph_cycle() {
-         let gallifrey = Arc::new(Gallifrey::new());
-         let graph = ChronoGraph::new(gallifrey.clone());
+        let gallifrey = Arc::new(Gallifrey::new());
+        let graph = ChronoGraph::new(gallifrey.clone());
 
-         let id_a = EntityId::new();
-         let id_b = EntityId::new();
+        let id_a = EntityId::new();
+        let id_b = EntityId::new();
 
-         let entity_a = create_test_entity("A", id_a);
-         let entity_b = create_test_entity("B", id_b);
+        let entity_a = create_test_entity("A", id_a);
+        let entity_b = create_test_entity("B", id_b);
 
-         gallifrey.insert(entity_a).await.unwrap();
-         gallifrey.insert(entity_b).await.unwrap();
+        gallifrey.insert(entity_a).await.unwrap();
+        gallifrey.insert(entity_b).await.unwrap();
 
-         // A -> B
-         let rel1 = Relationship {
-             id: EntityId::new(),
-             relationship_type: "TO".to_string(),
-             source: id_a,
-             target: id_b,
-             properties: HashMap::new(),
-             temporal: BiTemporalInterval::now(),
-         };
-         // B -> A
-         let rel2 = Relationship {
-             id: EntityId::new(),
-             relationship_type: "BACK".to_string(),
-             source: id_b,
-             target: id_a,
-             properties: HashMap::new(),
-             temporal: BiTemporalInterval::now(),
-         };
+        // A -> B
+        let rel1 = Relationship {
+            id: EntityId::new(),
+            relationship_type: "TO".to_string(),
+            source: id_a,
+            target: id_b,
+            properties: HashMap::new(),
+            temporal: BiTemporalInterval::now(),
+        };
+        // B -> A
+        let rel2 = Relationship {
+            id: EntityId::new(),
+            relationship_type: "BACK".to_string(),
+            source: id_b,
+            target: id_a,
+            properties: HashMap::new(),
+            temporal: BiTemporalInterval::now(),
+        };
 
-         gallifrey.knowledge().insert_relationship(rel1).unwrap();
-         gallifrey.knowledge().insert_relationship(rel2).unwrap();
+        gallifrey.knowledge().insert_relationship(rel1).unwrap();
+        gallifrey.knowledge().insert_relationship(rel2).unwrap();
 
-         let map = graph.generate_map("A", 3, None).unwrap();
-         println!("{}", map);
+        let map = graph.generate_map("A", 3, None).unwrap();
+        println!("{}", map);
 
-         // Should contain A, B, and a cycle marker
-         assert!(map.contains("A (Test)"));
-         assert!(map.contains("B (Test)"));
-         assert!(map.contains("🔄"));
+        // Should contain A, B, and a cycle marker
+        assert!(map.contains("A (Test)"));
+        assert!(map.contains("B (Test)"));
+        assert!(map.contains("🔄"));
     }
 }

--- a/vortex/src/tokenizer/template.rs
+++ b/vortex/src/tokenizer/template.rs
@@ -228,17 +228,20 @@ mod tests {
         let messages = vec![ChatMessage::system("You are a poet")];
 
         let result = apply_llama2_template(&messages, true);
-        assert!(result.contains("You are a poet"), "Should contain system message");
+        assert!(
+            result.contains("You are a poet"),
+            "Should contain system message"
+        );
         assert!(result.starts_with("[INST]"), "Should start with [INST]");
-        assert!(result.ends_with(" [/INST] "), "Should end with space for generation");
+        assert!(
+            result.ends_with(" [/INST] "),
+            "Should end with space for generation"
+        );
     }
 
     #[test]
     fn test_apply_llama2_template_system_assistant() {
-        let messages = vec![
-            ChatMessage::system("Sys"),
-            ChatMessage::assistant("Hi"),
-        ];
+        let messages = vec![ChatMessage::system("Sys"), ChatMessage::assistant("Hi")];
 
         let result = apply_llama2_template(&messages, true);
         assert!(result.contains("Sys"), "Should contain system message");
@@ -246,6 +249,9 @@ mod tests {
         // Structure: [INST] <<SYS>>\nSys\n<</SYS>>\n\n [/INST] Hi </s><s>
         assert!(result.contains("[INST]"), "Should contain INST block");
         assert!(result.contains(" [/INST]"), "Should contain closing INST");
-        assert!(result.ends_with(" Hi </s><s>"), "Should end with assistant response");
+        assert!(
+            result.ends_with(" Hi </s><s>"),
+            "Should end with assistant response"
+        );
     }
 }


### PR DESCRIPTION
# 🛡️ Sentry Report

**Target:** `chronos/src/pipeline/analyzer.rs` (QueryAnalyzer)
**Risk:** Logic depending on `Utc::now()` was untestable deterministically, leading to potential regressions in temporal resolution (e.g., "yesterday" resolving differently based on when tests run) and intent classification.
**Strategy:**
1.  Extracted `analyze_at(&self, query, now)` method to allow dependency injection of time.
2.  Added a `deterministic_tests` module with fixed timestamps to verify:
    -   Temporal keywords ("yesterday", "last week", "today").
    -   Intent classification priorities.
    -   Case insensitivity.
    -   Edge cases with multiple references.

**Verification:**
-   `cargo test -p tardis-chronos` passed (including new tests).
-   `cargo clippy -p tardis-chronos --no-deps` passed.


---
*PR created automatically by Jules for task [7973547541080622030](https://jules.google.com/task/7973547541080622030) started by @madmax983*