### PR TITLE
⚒️ Forge: Refactor Repl commands and Analyzer time dependency

### DIFF
--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -183,10 +183,22 @@ impl QueryAnalyzer {
     ///
     /// Returns an error if analysis fails.
     pub fn analyze(&self, query: &str) -> ChronosResult<AnalyzedQuery> {
+        self.analyze_at(query, Utc::now())
+    }
+
+    /// Analyze a query at a specific point in time.
+    ///
+    /// This method is identical to `analyze`, but allows specifying the current time
+    /// for deterministic temporal resolution.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if analysis fails.
+    pub fn analyze_at(&self, query: &str, now: DateTime<Utc>) -> ChronosResult<AnalyzedQuery> {
         // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
         let query_lower = query.to_lowercase();
         let intent = self.classify_intent(&query_lower);
-        let temporal_refs = self.extract_temporal_refs(&query_lower, Utc::now());
+        let temporal_refs = self.extract_temporal_refs(&query_lower, now);
         let entities = self.extract_entities(query);
 
         let temporal_description = if temporal_refs.is_empty() {
@@ -413,5 +425,26 @@ mod tests {
         let refs = analyzer.extract_temporal_refs("yesterday", now);
         let desc = analyzer.describe_temporal_context(&refs);
         assert!(desc.contains("yesterday"));
+    }
+
+    #[test]
+    fn test_analyze_at_deterministic() {
+        let analyzer = QueryAnalyzer::new();
+        let now = DateTime::parse_from_rfc3339("2024-03-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let analysis = analyzer
+            .analyze_at("What happened yesterday?", now)
+            .unwrap();
+
+        assert_eq!(analysis.temporal_refs.len(), 1);
+        match &analysis.temporal_refs[0] {
+            TemporalReference::Relative { text, resolved } => {
+                assert_eq!(text, "yesterday");
+                assert_eq!(resolved.to_rfc3339(), "2024-03-14T12:00:00+00:00");
+            }
+            _ => panic!("Expected relative reference"),
+        }
     }
 }

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -139,7 +139,7 @@ impl Gallifrey {
     /// # ⚠️ Experimental
     ///
     /// This method is currently a stub. It parses the query but returns an empty result set.
-    /// Full implementation is pending the GallifreyDB query engine integration.
+    /// Full implementation is pending the `GallifreyDB` query engine integration.
     ///
     /// # Errors
     ///

--- a/shell/src/experimental/chronograph.rs
+++ b/shell/src/experimental/chronograph.rs
@@ -124,21 +124,10 @@ impl ChronoGraph {
             }
 
             let indent_rel = "  ".repeat(current_depth + 1);
-            writeln!(
-                output,
-                "{}|--[{}]-->",
-                indent_rel, rel.relationship_type
-            )?;
+            writeln!(output, "{}|--[{}]-->", indent_rel, rel.relationship_type)?;
 
             if let Some(target) = self.resolve_entity(rel.target, time)? {
-                self.traverse(
-                    &target,
-                    max_depth,
-                    current_depth + 1,
-                    time,
-                    visited,
-                    output,
-                )?;
+                self.traverse(&target, max_depth, current_depth + 1, time, visited, output)?;
             } else {
                 writeln!(output, "{}(Unknown Entity)", indent_rel)?;
             }
@@ -183,9 +172,7 @@ impl ChronoGraph {
                 .get_entity_at(id, t, Utc::now())
                 .map_err(|e| anyhow!(e.to_string()))
         } else {
-            knowledge
-                .get_entity(id)
-                .map_err(|e| anyhow!(e.to_string()))
+            knowledge.get_entity(id).map_err(|e| anyhow!(e.to_string()))
         }
     }
 }
@@ -245,46 +232,46 @@ mod tests {
 
     #[tokio::test]
     async fn test_chronograph_cycle() {
-         let gallifrey = Arc::new(Gallifrey::new());
-         let graph = ChronoGraph::new(gallifrey.clone());
+        let gallifrey = Arc::new(Gallifrey::new());
+        let graph = ChronoGraph::new(gallifrey.clone());
 
-         let id_a = EntityId::new();
-         let id_b = EntityId::new();
+        let id_a = EntityId::new();
+        let id_b = EntityId::new();
 
-         let entity_a = create_test_entity("A", id_a);
-         let entity_b = create_test_entity("B", id_b);
+        let entity_a = create_test_entity("A", id_a);
+        let entity_b = create_test_entity("B", id_b);
 
-         gallifrey.insert(entity_a).await.unwrap();
-         gallifrey.insert(entity_b).await.unwrap();
+        gallifrey.insert(entity_a).await.unwrap();
+        gallifrey.insert(entity_b).await.unwrap();
 
-         // A -> B
-         let rel1 = Relationship {
-             id: EntityId::new(),
-             relationship_type: "TO".to_string(),
-             source: id_a,
-             target: id_b,
-             properties: HashMap::new(),
-             temporal: BiTemporalInterval::now(),
-         };
-         // B -> A
-         let rel2 = Relationship {
-             id: EntityId::new(),
-             relationship_type: "BACK".to_string(),
-             source: id_b,
-             target: id_a,
-             properties: HashMap::new(),
-             temporal: BiTemporalInterval::now(),
-         };
+        // A -> B
+        let rel1 = Relationship {
+            id: EntityId::new(),
+            relationship_type: "TO".to_string(),
+            source: id_a,
+            target: id_b,
+            properties: HashMap::new(),
+            temporal: BiTemporalInterval::now(),
+        };
+        // B -> A
+        let rel2 = Relationship {
+            id: EntityId::new(),
+            relationship_type: "BACK".to_string(),
+            source: id_b,
+            target: id_a,
+            properties: HashMap::new(),
+            temporal: BiTemporalInterval::now(),
+        };
 
-         gallifrey.knowledge().insert_relationship(rel1).unwrap();
-         gallifrey.knowledge().insert_relationship(rel2).unwrap();
+        gallifrey.knowledge().insert_relationship(rel1).unwrap();
+        gallifrey.knowledge().insert_relationship(rel2).unwrap();
 
-         let map = graph.generate_map("A", 3, None).unwrap();
-         println!("{}", map);
+        let map = graph.generate_map("A", 3, None).unwrap();
+        println!("{}", map);
 
-         // Should contain A, B, and a cycle marker
-         assert!(map.contains("A (Test)"));
-         assert!(map.contains("B (Test)"));
-         assert!(map.contains("🔄"));
+        // Should contain A, B, and a cycle marker
+        assert!(map.contains("A (Test)"));
+        assert!(map.contains("B (Test)"));
+        assert!(map.contains("🔄"));
     }
 }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -147,106 +147,119 @@ impl Repl {
                 self.running = false;
             }
             "history" => commands::history(&self.gallifrey, self.session_id),
-            "remember" => {
-                let content = args.join(" ");
-                match self
-                    .chronos
-                    .remember(&content, tardis_chronos::MemoryCategory::Knowledge)
-                    .await
-                {
-                    Ok(id) => println!("Remembered: {id}"),
-                    Err(e) => println!("Failed to remember: {e}"),
-                }
-            }
-            "recall" => {
-                let query = args.join(" ");
-                match self.chronos.recall(&query, 5).await {
-                    Ok(results) => {
-                        for result in results {
-                            println!("- {}", result.content);
-                        }
-                    }
-                    Err(e) => println!("Failed to recall: {e}"),
-                }
-            }
+            "remember" => self.handle_remember(args).await,
+            "recall" => self.handle_recall(args).await,
             "models" => commands::list_models(),
             "context" => commands::show_context(self.session_id),
             "clear" => {
                 print!("\x1B[2J\x1B[1;1H");
             }
             #[cfg(feature = "nova")]
-            "dashboard" => {
-                match crate::dashboard::tui::Dashboard::new(
-                    std::sync::Arc::clone(&self.gallifrey),
-                    self.telemetry_store.clone(),
-                    self.prophet.clone(),
-                ) {
-                    Ok(mut dashboard) => {
-                        if let Err(e) = dashboard.run() {
-                            println!("Dashboard failed: {e}");
-                        }
-                    }
-                    Err(e) => println!("Failed to initialize dashboard: {e}"),
-                }
-            }
+            "dashboard" => self.handle_dashboard(),
             #[cfg(feature = "nova")]
-            "map" => {
-                if args.is_empty() {
-                    println!("Usage: map <entity_name> [depth]");
-                    return;
-                }
-                let entity_name = &args[0];
-                let depth = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2);
-
-                let graph = ChronoGraph::new(self.gallifrey.clone());
-                match graph.generate_map(entity_name, depth, None) {
-                    Ok(map) => println!("{map}"),
-                    Err(e) => println!("Failed to generate map: {e}"),
-                }
-            }
+            "map" => self.handle_map(args),
             #[cfg(feature = "nova")]
-            "sonic" | "fix" => {
-                if args.is_empty() {
-                    println!("Usage: sonic <file> | sonic repair <file> | sonic diagnose");
-                    return;
-                }
-
-                let screwdriver = SonicScrewdriver::new(
-                    self.telemetry_store.clone(),
-                    Some(std::sync::Arc::clone(&self.gallifrey)),
-                    Some(self.chronos.vortex()),
-                    None, // TODO: Pass loaded model handle if available
-                );
-
-                if args[0] == "diagnose" {
-                    println!("{}", screwdriver.buzz());
-                    match screwdriver.diagnose().await {
-                        Ok(report) => println!("{report}"),
-                        Err(e) => println!("Diagnosis failed: {e}"),
-                    }
-                    return;
-                }
-
-                let path = std::path::Path::new(&args[args.len() - 1]);
-
-                // Check if user wants repair (e.g. "sonic repair file.json" or "fix file.json")
-                // If command is "fix", we repair.
-                // If command is "sonic" and first arg is "repair" or "fix", we repair.
-                let repair = command == "fix"
-                    || (args.len() > 1 && (args[0] == "repair" || args[0] == "fix"));
-
-                let result = if repair {
-                    screwdriver.repair(path)
-                } else {
-                    screwdriver.inspect(path)
-                };
-
-                match result {
-                    Ok(report) => println!("{report}"),
-                    Err(e) => println!("Sonic Screwdriver error: {e}"),
-                }
-            }
+            "sonic" | "fix" => self.handle_sonic(command, args).await,
             _ => println!("Unknown command: {command}. Type 'help' for available commands."),
+        }
+    }
+
+    async fn handle_remember(&self, args: &[String]) {
+        let content = args.join(" ");
+        match self
+            .chronos
+            .remember(&content, tardis_chronos::MemoryCategory::Knowledge)
+            .await
+        {
+            Ok(id) => println!("Remembered: {id}"),
+            Err(e) => println!("Failed to remember: {e}"),
+        }
+    }
+
+    async fn handle_recall(&self, args: &[String]) {
+        let query = args.join(" ");
+        match self.chronos.recall(&query, 5).await {
+            Ok(results) => {
+                for result in results {
+                    println!("- {}", result.content);
+                }
+            }
+            Err(e) => println!("Failed to recall: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    fn handle_dashboard(&self) {
+        match crate::dashboard::tui::Dashboard::new(
+            std::sync::Arc::clone(&self.gallifrey),
+            self.telemetry_store.clone(),
+            self.prophet.clone(),
+        ) {
+            Ok(mut dashboard) => {
+                if let Err(e) = dashboard.run() {
+                    println!("Dashboard failed: {e}");
+                }
+            }
+            Err(e) => println!("Failed to initialize dashboard: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    fn handle_map(&self, args: &[String]) {
+        if args.is_empty() {
+            println!("Usage: map <entity_name> [depth]");
+            return;
+        }
+        let entity_name = &args[0];
+        let depth = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2);
+
+        let graph = ChronoGraph::new(self.gallifrey.clone());
+        match graph.generate_map(entity_name, depth, None) {
+            Ok(map) => println!("{map}"),
+            Err(e) => println!("Failed to generate map: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    async fn handle_sonic(&self, command: &str, args: &[String]) {
+        if args.is_empty() {
+            println!("Usage: sonic <file> | sonic repair <file> | sonic diagnose");
+            return;
+        }
+
+        let screwdriver = SonicScrewdriver::new(
+            self.telemetry_store.clone(),
+            Some(std::sync::Arc::clone(&self.gallifrey)),
+            Some(self.chronos.vortex()),
+            None, // TODO: Pass loaded model handle if available
+        );
+
+        if args[0] == "diagnose" {
+            println!("{}", screwdriver.buzz());
+            match screwdriver.diagnose().await {
+                Ok(report) => println!("{report}"),
+                Err(e) => println!("Diagnosis failed: {e}"),
+            }
+            return;
+        }
+
+        let path = std::path::Path::new(&args[args.len() - 1]);
+
+        // Check if user wants repair (e.g. "sonic repair file.json" or "fix file.json")
+        // If command is "fix", we repair.
+        // If command is "sonic" and first arg is "repair" or "fix", we repair.
+        let repair =
+            command == "fix" || (args.len() > 1 && (args[0] == "repair" || args[0] == "fix"));
+
+        let result = if repair {
+            screwdriver.repair(path)
+        } else {
+            screwdriver.inspect(path)
+        };
+
+        match result {
+            Ok(report) => println!("{report}"),
+            Err(e) => println!("Sonic Screwdriver error: {e}"),
         }
     }
 

--- a/vortex/src/tokenizer/template.rs
+++ b/vortex/src/tokenizer/template.rs
@@ -228,17 +228,20 @@ mod tests {
         let messages = vec![ChatMessage::system("You are a poet")];
 
         let result = apply_llama2_template(&messages, true);
-        assert!(result.contains("You are a poet"), "Should contain system message");
+        assert!(
+            result.contains("You are a poet"),
+            "Should contain system message"
+        );
         assert!(result.starts_with("[INST]"), "Should start with [INST]");
-        assert!(result.ends_with(" [/INST] "), "Should end with space for generation");
+        assert!(
+            result.ends_with(" [/INST] "),
+            "Should end with space for generation"
+        );
     }
 
     #[test]
     fn test_apply_llama2_template_system_assistant() {
-        let messages = vec![
-            ChatMessage::system("Sys"),
-            ChatMessage::assistant("Hi"),
-        ];
+        let messages = vec![ChatMessage::system("Sys"), ChatMessage::assistant("Hi")];
 
         let result = apply_llama2_template(&messages, true);
         assert!(result.contains("Sys"), "Should contain system message");
@@ -246,6 +249,9 @@ mod tests {
         // Structure: [INST] <<SYS>>\nSys\n<</SYS>>\n\n [/INST] Hi </s><s>
         assert!(result.contains("[INST]"), "Should contain INST block");
         assert!(result.contains(" [/INST]"), "Should contain closing INST");
-        assert!(result.ends_with(" Hi </s><s>"), "Should end with assistant response");
+        assert!(
+            result.ends_with(" Hi </s><s>"),
+            "Should end with assistant response"
+        );
     }
 }


### PR DESCRIPTION
🚮 Smell: 
- `QueryAnalyzer::analyze` had a hidden dependency on `Utc::now()`, making it impossible to test deterministically without mocking.
- `Repl::handle_builtin` was a "God Function" with a large `match` statement containing inline logic for complex commands.

✨ Solution: 
- Renamed `analyze` to `analyze_at` accepting `now: DateTime<Utc>`, and added a convenience `analyze` wrapper.
- Extracted logic for `remember`, `recall`, `dashboard`, `map`, and `sonic` into private helper methods in `Repl`.

🧼 Benefit: 
- `QueryAnalyzer` logic is now pure and testable.
- `Repl` code is flatter, easier to read, and separates dispatch from execution.

🛡️ Verification: 
- Added `test_analyze_at_deterministic` which passes.
- Ran `cargo test` and `cargo check` for `tardis-chronos` and `tardis-shell`.
- No logic changes, only refactoring.

---
*PR created automatically by Jules for task [12758667428767692284](https://jules.google.com/task/12758667428767692284) started by @madmax983*