### PR TITLE
🔒 Warden: Prevent DoS in SonicScrewdriver via capped reader

### DIFF
--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -139,7 +139,7 @@ impl Gallifrey {
     /// # ⚠️ Experimental
     ///
     /// This method is currently a stub. It parses the query but returns an empty result set.
-    /// Full implementation is pending the GallifreyDB query engine integration.
+    /// Full implementation is pending the `GallifreyDB` query engine integration.
     ///
     /// # Errors
     ///

--- a/shell/src/experimental/chronograph.rs
+++ b/shell/src/experimental/chronograph.rs
@@ -1,4 +1,4 @@
-//! ChronoGraph 🗺️
+//! `ChronoGraph` 🗺️
 //!
 //! A visualizer for the bi-temporal knowledge graph.
 //!
@@ -14,16 +14,16 @@ use tardis_common::id::EntityId;
 use tardis_gallifrey::domain::Entity;
 use tardis_gallifrey::Gallifrey;
 
-/// The ChronoGraph visualizer.
+/// The `ChronoGraph` visualizer.
 #[derive(Debug)]
 pub struct ChronoGraph {
     gallifrey: Arc<Gallifrey>,
 }
 
 impl ChronoGraph {
-    /// Create a new ChronoGraph.
+    /// Create a new `ChronoGraph`.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
         Self { gallifrey }
     }
 
@@ -42,9 +42,9 @@ impl ChronoGraph {
         let mut visited = HashSet::new();
         let mut map = String::new();
 
-        writeln!(map, "🗺️  Time Map: {} (Depth: {})", entity_name, depth)?;
+        writeln!(map, "🗺️  Time Map: {entity_name} (Depth: {depth})")?;
         if let Some(t) = time {
-            writeln!(map, "🕒  Time: {}", t)?;
+            writeln!(map, "🕒  Time: {t}")?;
         } else {
             writeln!(map, "🕒  Time: NOW (Current Valid)")?;
         }
@@ -80,7 +80,7 @@ impl ChronoGraph {
             }
         })?;
 
-        found.ok_or_else(|| anyhow!("Entity '{}' not found", name))
+        found.ok_or_else(|| anyhow!("Entity '{name}' not found"))
     }
 
     fn traverse(
@@ -98,8 +98,8 @@ impl ChronoGraph {
         // Print the node
         write!(
             output,
-            "{}{}{} ({})",
-            indent, prefix, entity.name, entity.entity_type
+            "{indent}{prefix}{} ({})",
+            entity.name, entity.entity_type
         )?;
 
         // Cycle detection / Already visited in this traversal
@@ -126,8 +126,8 @@ impl ChronoGraph {
             let indent_rel = "  ".repeat(current_depth + 1);
             writeln!(
                 output,
-                "{}|--[{}]-->",
-                indent_rel, rel.relationship_type
+                "{indent_rel}|--[{}]-->",
+                rel.relationship_type
             )?;
 
             if let Some(target) = self.resolve_entity(rel.target, time)? {
@@ -140,7 +140,7 @@ impl ChronoGraph {
                     output,
                 )?;
             } else {
-                writeln!(output, "{}(Unknown Entity)", indent_rel)?;
+                writeln!(output, "{indent_rel}(Unknown Entity)")?;
             }
         }
 

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use serde_json::Value;
 use std::fmt::Write as _;
 use std::fs;
+use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
 use tardis_chronos::experimental::doctor::{HealthStatus, SystemDoctor};
@@ -16,6 +17,9 @@ use tardis_chronos::experimental::psychic_paper::{Intent, PsychicPaper};
 use tardis_gallifrey::Gallifrey;
 use tardis_telemetry::gallifrey::TelemetryStore;
 use tardis_vortex::{ModelHandle, Vortex};
+
+/// Maximum file size supported for inspection/repair (10MB).
+const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 
 /// The Sonic Screwdriver.
 #[derive(Debug, Default)]
@@ -28,6 +32,43 @@ pub struct SonicScrewdriver {
 }
 
 impl SonicScrewdriver {
+    /// Safely read a file with a size limit.
+    fn read_file_capped(path: &Path) -> Result<String> {
+        let file = fs::File::open(path)
+            .with_context(|| format!("Failed to open file: {}", path.display()))?;
+
+        let metadata = file.metadata()?;
+        if !metadata.is_file() {
+            return Err(anyhow::anyhow!("Not a regular file: {}", path.display()));
+        }
+
+        // Fast path check
+        if metadata.len() > MAX_FILE_SIZE {
+            return Err(anyhow::anyhow!(
+                "File too large (exceeds {}MB limit): {}",
+                MAX_FILE_SIZE / 1024 / 1024,
+                path.display()
+            ));
+        }
+
+        // Read with limit (plus 1 byte to detect truncation/growth)
+        let mut reader = file.take(MAX_FILE_SIZE + 1);
+        let mut content = String::new();
+        reader
+            .read_to_string(&mut content)
+            .with_context(|| format!("Failed to read file: {}", path.display()))?;
+
+        if content.len() as u64 > MAX_FILE_SIZE {
+            return Err(anyhow::anyhow!(
+                "File too large (exceeds {}MB limit): {}",
+                MAX_FILE_SIZE / 1024 / 1024,
+                path.display()
+            ));
+        }
+
+        Ok(content)
+    }
+
     /// Create a new Sonic Screwdriver.
     #[must_use]
     pub const fn new(
@@ -121,11 +162,9 @@ impl SonicScrewdriver {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file cannot be read.
+    /// Returns an error if the file cannot be read, is not a regular file, or exceeds the size limit.
     pub fn inspect(&self, path: &Path) -> Result<String> {
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("Failed to read file: {}", path.display()))?;
-
+        let content = Self::read_file_capped(path)?;
         let size = content.len();
         let lines = content.lines().count();
 
@@ -174,10 +213,9 @@ impl SonicScrewdriver {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file cannot be read or written.
+    /// Returns an error if the file cannot be read, written, or exceeds the size limit.
     pub fn repair(&self, path: &Path) -> Result<String> {
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("Failed to read file: {}", path.display()))?;
+        let content = Self::read_file_capped(path)?;
 
         // Create backup
         let backup_path = path.with_extension("bak");

--- a/shell/tests/sonic_dos.rs
+++ b/shell/tests/sonic_dos.rs
@@ -1,0 +1,94 @@
+#[cfg(feature = "nova")]
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tardis_shell::experimental::sonic::SonicScrewdriver;
+
+    fn create_large_file(path: &PathBuf, size_mb: usize) -> std::io::Result<()> {
+        let mut file = File::create(path)?;
+        let chunk = vec![0u8; 1024 * 1024]; // 1MB chunk
+        for _ in 0..size_mb {
+            file.write_all(&chunk)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_inspect_rejects_large_file() {
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join("large_file.txt");
+
+        // Create 11MB file
+        create_large_file(&file_path, 11).expect("Failed to create large file");
+
+        let sonic = SonicScrewdriver::new(None, None, None, None);
+        let result = sonic.inspect(&file_path);
+
+        // Cleanup first to avoid disk usage
+        let _ = std::fs::remove_file(&file_path);
+
+        assert!(result.is_err(), "Inspect should fail for large file");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("File too large") || err.to_string().contains("exceeds limit"),
+            "Error should be about file size, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_inspect_rejects_directory() {
+        let temp_dir = std::env::temp_dir();
+        // Use temp_dir itself as the directory to test
+        let sonic = SonicScrewdriver::new(None, None, None, None);
+        let result = sonic.inspect(&temp_dir);
+
+        assert!(result.is_err(), "Inspect should fail for directory");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("Not a regular file"),
+            "Error should be about file type, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_inspect_accepts_small_file() {
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join("small_file.txt");
+        let mut file = File::create(&file_path).expect("Failed to create file");
+        writeln!(file, r#"{{"key": "value"}}"#).expect("Failed to write file");
+
+        let sonic = SonicScrewdriver::new(None, None, None, None);
+        let result = sonic.inspect(&file_path);
+
+        let _ = std::fs::remove_file(&file_path);
+
+        assert!(result.is_ok(), "Inspect should pass for small file");
+    }
+
+    #[test]
+    fn test_repair_rejects_large_file() {
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join("large_file_repair.txt");
+
+        // Create 11MB file
+        create_large_file(&file_path, 11).expect("Failed to create large file");
+
+        let sonic = SonicScrewdriver::new(None, None, None, None);
+        let result = sonic.repair(&file_path);
+
+        // Cleanup
+        let _ = std::fs::remove_file(&file_path);
+
+        assert!(result.is_err(), "Repair should fail for large file");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("File too large") || err.to_string().contains("exceeds limit"),
+            "Error should be about file size, got: {}",
+            err
+        );
+    }
+}


### PR DESCRIPTION
Hardened `SonicScrewdriver` against Denial of Service (DoS) attacks by enforcing a strict file size limit and using capped readers.
Added comprehensive tests to verify rejection of large files and directories.
Fixed minor documentation and clippy issues in related modules to ensure build stability.


---
*PR created automatically by Jules for task [4527809122498078640](https://jules.google.com/task/4527809122498078640) started by @madmax983*