### PR TITLE
🛡️ Sentry: Fix future entity retrieval bug

### DIFF
--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -94,7 +94,7 @@ impl KnowledgeStore {
         let now = Utc::now();
         Ok(entities
             .get(&id)
-            .and_then(|versions| versions.iter().find(|e| e.temporal.is_current_relative_to(now)))
+            .and_then(|versions| versions.iter().find(|e| e.temporal.active_at(now, now)))
             .cloned())
     }
 
@@ -296,7 +296,7 @@ impl KnowledgeStore {
         Ok(entities
             .values()
             .flat_map(|versions| versions.iter())
-            .filter(|e| e.temporal.is_current_relative_to(now) && e.entity_type == entity_type)
+            .filter(|e| e.temporal.active_at(now, now) && e.entity_type == entity_type)
             .cloned()
             .collect())
     }
@@ -322,7 +322,7 @@ impl KnowledgeStore {
         Ok(entities
             .values()
             .flat_map(|versions| versions.iter())
-            .filter(|e| e.temporal.is_current_relative_to(now) && e.embedding.is_some())
+            .filter(|e| e.temporal.active_at(now, now) && e.embedding.is_some())
             .take(limit)
             .cloned()
             .collect())

--- a/gallifrey/tests/future_entity_retrieval.rs
+++ b/gallifrey/tests/future_entity_retrieval.rs
@@ -1,0 +1,56 @@
+#[cfg(test)]
+mod tests {
+    use tardis_gallifrey::{KnowledgeStore, BiTemporalInterval, TimeRange};
+    use tardis_gallifrey::domain::Entity;
+    use tardis_common::id::EntityId;
+    use chrono::{Utc, Duration};
+    use std::collections::HashMap;
+
+    #[test]
+    fn get_entity_should_not_return_future_entity() {
+        let store = KnowledgeStore::new();
+        let now = Utc::now();
+        let future_time = now + Duration::hours(1);
+
+        let entity = Entity {
+            id: EntityId::new(),
+            entity_type: "FutureFact".to_string(),
+            name: "Will happen".to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            // Valid ONLY in the future
+            temporal: BiTemporalInterval::with_valid_time(TimeRange::starting_at(future_time)),
+            source: None,
+        };
+
+        let id = entity.id;
+        store.insert_entity(entity).expect("Insert failed");
+
+        // This should return None because the entity is not valid YET.
+        let retrieved = store.get_entity(id).expect("Get entity failed");
+
+        assert!(retrieved.is_none(), "get_entity() returned a future entity! It should only return currently valid entities.");
+    }
+
+    #[test]
+    fn find_by_type_should_not_return_future_entity() {
+        let store = KnowledgeStore::new();
+        let now = Utc::now();
+        let future_time = now + Duration::hours(1);
+
+        let entity = Entity {
+            id: EntityId::new(),
+            entity_type: "FutureFact".to_string(),
+            name: "Will happen".to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval::with_valid_time(TimeRange::starting_at(future_time)),
+            source: None,
+        };
+
+        store.insert_entity(entity).expect("Insert failed");
+
+        let results = store.find_by_type("FutureFact").expect("Find failed");
+        assert!(results.is_empty(), "find_by_type() returned a future entity!");
+    }
+}


### PR DESCRIPTION
**Target:** `gallifrey/src/stores/knowledge.rs`
**Risk:** High. `get_entity` was returning entities that are not yet valid (future facts), potentially causing applications to act on premature information.
**Strategy:** Changed the temporal filter from "is open-ended" (`is_current`) to "is active at timestamp" (`active_at`), which checks both start and end bounds of Valid Time.
**Verification:** Added `gallifrey/tests/future_entity_retrieval.rs` which confirms that future-dated entities are no longer returned by `get_entity` or `find_by_type`. Ran full `tardis-gallifrey` test suite to ensure no regressions.

---
*PR created automatically by Jules for task [756304705671759742](https://jules.google.com/task/756304705671759742) started by @madmax983*