### PR TITLE
Add READMEs for core crates and update shell docs

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,47 @@
+# Tardis Common 🔧
+
+> "It's the sonic screwdriver of the operating system. It does... things."
+
+**Common** is the shared utility crate for Tardis OS. It provides the core types, traits, and error handling mechanisms used by all other subsystems (`chronos`, `gallifrey`, `vortex`, `shell`).
+
+## 📦 Modules
+
+-   **`error`**: Defines the unified `Error` type and `Result` alias for cross-crate compatibility.
+-   **`id`**: Strongly-typed identifiers for system entities:
+    -   `EntityId`: Unique ID for knowledge graph nodes (UUID v4).
+    -   `SessionId`: ID for user sessions.
+    -   `SnapshotId`: ID for system state snapshots.
+    -   `ModelHandle`: Lightweight handle for loaded LLM models.
+-   **`temporal`**: Primitives for bi-temporal data management.
+
+## ⏳ Bi-Temporal Primitives
+
+The crown jewel of this crate is the **`BiTemporalInterval`**, which enables `Gallifrey` to track history accurately.
+
+```rust
+use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+use chrono::{Utc, TimeZone};
+
+// Create an interval representing "Now" in both dimensions
+let interval = BiTemporalInterval::now();
+
+// Create a historical interval
+// Valid: 2020-2022
+// Transaction: Recorded today
+let historical = BiTemporalInterval {
+    valid_time: TimeRange::closed(
+        Utc.ymd(2020, 1, 1).and_hms(0, 0, 0),
+        Utc.ymd(2022, 1, 1).and_hms(0, 0, 0),
+    ),
+    transaction_time: TimeRange::open_from(Utc::now()),
+};
+```
+
+## 🤝 Usage
+
+This crate is a workspace dependency.
+
+```toml
+[dependencies]
+tardis-common = { path = "../common" }
+```

--- a/gallifrey/README.md
+++ b/gallifrey/README.md
@@ -1,0 +1,98 @@
+# Tardis Gallifrey 🕰️
+
+> "People assume that time is a strict progression of cause to effect, but *actually* from a non-linear, non-subjective viewpoint - it's more like a big ball of wibbly wobbly... time-y wimey... stuff."
+
+**Gallifrey** is the temporal knowledge store for Tardis OS. Unlike traditional databases that only store the *current* state of the world, Gallifrey tracks history across two dimensions of time, allowing the system to remember not just *what* is true, but *when* it was true and *when* we learned it.
+
+## 🏗️ The Three Stores
+
+Gallifrey manages three specialized storage engines:
+
+1.  **Knowledge Store (`KnowledgeStore`)**:
+    -   A graph database for long-term semantic memory.
+    -   Stores entities (people, places, concepts) and their relationships.
+    -   Supports vector embeddings for semantic search.
+
+2.  **Conversation Store (`ConversationStore`)**:
+    -   An append-only log of all interactions with the user.
+    -   Maintains context across sessions (`SessionId`).
+    -   Enables the system to "remember" past conversations.
+
+3.  **System State Store (`SystemStateStore`)**:
+    -   Records snapshots of the OS state (files, processes, configuration).
+    -   Enables time-travel debugging and "undo" functionality.
+
+## ⏳ Bi-Temporality Explained
+
+Gallifrey implements **Bi-Temporal Modeling**, tracking two time axes for every piece of data:
+
+1.  **Valid Time**: The time period when a fact was true in the real world.
+    -   *Example:* "I lived in London from 2010 to 2015."
+2.  **Transaction Time**: The time period when the fact was present in the database.
+    -   *Example:* "I told the system about living in London on 2023-10-27."
+
+This allows powerful queries like:
+-   *"What is the user's address now?"* (Current Valid, Current Transaction)
+-   *"What did we think the user's address was yesterday?"* (Past Transaction, Current Valid)
+-   *"What was the user's address in 2010 (according to what we know now)?"* (Past Valid, Current Transaction)
+
+### Append-Only Architecture
+
+To support this, Gallifrey uses an **Append-Only** model. Updates do not overwrite data; they:
+1.  Close the `transaction_time` of the old version (making it historical).
+2.  Insert a new version with the current `transaction_time`.
+
+## 🚀 Getting Started
+
+```rust,no_run
+use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::domain::Entity;
+use tardis_common::id::EntityId;
+use tardis_common::temporal::BiTemporalInterval;
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Initialize the store
+    let gallifrey = Gallifrey::new();
+
+    // 2. Create an entity representing a fact
+    let entity = Entity {
+        id: EntityId::new(),
+        entity_type: "Fact".to_string(),
+        name: "The Sky".to_string(),
+        properties: HashMap::from([
+            ("color".to_string(), serde_json::json!("blue"))
+        ]),
+        embedding: None,
+        temporal: BiTemporalInterval::now(),
+        source: Some("User Observation".to_string()),
+    };
+
+    // 3. Insert it into the Knowledge Store
+    let id = gallifrey.insert(entity).await?;
+
+    // 4. Update it (creates a new version, preserving history)
+    gallifrey.update(id, serde_json::json!({"color": "dark_blue"})).await?;
+
+    // 5. Retrieve history to see both versions
+    let history = gallifrey.get_history(id).await?;
+    assert_eq!(history.len(), 2);
+
+    Ok(())
+}
+```
+
+## 🧪 Experimental Features (Nova)
+
+When compiled with the `nova` feature, Gallifrey exposes experimental modules:
+
+-   **`TimeCapsule`**: For bulk import/export of knowledge subgraphs.
+-   **`Timeline`**: Advanced visualization of entity history.
+
+To enable these features:
+
+```toml
+[dependencies]
+tardis-gallifrey = { version = "0.1.0", features = ["nova"] }
+```

--- a/shell/README.md
+++ b/shell/README.md
@@ -23,10 +23,17 @@ tardis>
 ## ✨ Features
 
 - **Natural Language Understanding**: Ask questions like "What is the system status?" or "Why did the build fail?".
-- **Temporal Awareness**: Use `@time` syntax to query the past or future.
 - **Context Retention**: The shell remembers your conversation history and current task.
 - **RAG Integration**: Seamlessly retrieves knowledge from **Gallifrey** (the memory store) to answer queries.
 - **Built-in Commands**: Traditional commands for system management.
+
+## ⚠️ Experimental Features
+
+The following features are currently in active development or partially implemented:
+
+- **Temporal Awareness (`@time`)**: Syntax for querying the past is parsed but not fully integrated.
+- **Direct LLM (`?`)**: Bypassing RAG to talk to the raw model is a work in progress.
+- **System Commands (`!`)**: Execution of host OS commands is currently disabled for safety.
 
 ## 🎮 Usage
 
@@ -38,31 +45,7 @@ tardis> How do I add a new user?
 [Chronos] To add a new user, you can use the `useradd` command...
 ```
 
-### 2. Time Travel (`@time`)
-Prefix your query with `@` to shift the temporal context.
-
-```text
-tardis> @yesterday Who logged in?
-[Time Travel] Querying history for 2023-10-26...
-```
-
-### 3. Direct LLM (`?`)
-Bypass RAG and talk directly to the model.
-
-```text
-tardis> ?Write a poem about Rust.
-[Vortex] Rust, the iron oxide red...
-```
-
-### 4. System Commands (`!`)
-Execute standard shell commands (not fully implemented yet).
-
-```text
-tardis> !ls -la
-```
-
-## 🛠️ Built-in Commands
-
+### 2. Built-in Commands
 The shell includes several built-in commands for managing the AI system.
 
 | Command | Description | Example |
@@ -74,12 +57,24 @@ The shell includes several built-in commands for managing the AI system.
 | `recall` | Search long-term memory. | `recall "preferences"` |
 | `models` | List available LLM models. | `models` |
 | `context` | Show current session context. | `context` |
-| `snapshot` | Save system state snapshot. | `snapshot "pre-deploy"` |
-| `restore` | Restore a saved snapshot. | `restore "pre-deploy"` |
-| `timeline` | Show history of an entity. | `timeline "config.toml"` |
-| `forget` | Remove a memory. | `forget "old-password"` |
-| `export` | Export session data. | `export "session.json"` |
 | `exit` / `quit` | Exit the shell. | `exit` |
+
+## 🌟 Nova Features (Experimental)
+
+When compiled with the `nova` feature, the shell gains advanced TUI visualization and system repair tools.
+
+```bash
+cargo run --bin tardis --features nova
+```
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `dashboard` | Interactive system monitor TUI. | `dashboard` |
+| `timeline` | Visualize an entity's history. | `timeline "config.toml"` |
+| `map` | View knowledge graph relationships. | `map "User" 2` |
+| `heatmap` | Bi-temporal activity visualization. | `heatmap` |
+| `sonic` | "Sonic Screwdriver" - Inspect/Fix files. | `sonic fix config.json` |
+| `capsule` | Import/Export time capsules. | `capsule capture "ProjectX" backup.json` |
 
 ## 🏗️ Architecture
 

--- a/shell/src/lib.rs
+++ b/shell/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! 1.  **REPL Loop**: The [`Repl`](crate::repl::Repl) manages the user session, history, and terminal I/O using `rustyline`.
 //! 2.  **Intent Classification**: The [`Router`](crate::router::Router) analyzes input to determine if it is:
-//!     -   A **Built-in Command** (e.g., `help`, `history`) -> Handled by [`CommandHandler`](crate::commands::CommandHandler).
+//!     -   A **Built-in Command** (e.g., `help`, `history`) -> Handled by the [`commands`] module.
 //!     -   A **Chronos Query** (e.g., "What is the status?") -> Sent to the RAG engine.
 //!     -   A **Time Travel Request** (e.g., `@yesterday ...`) -> Modifies temporal context.
 //!     -   A **Direct LLM Query** (e.g., `?Write a poem`) -> Bypasses RAG.

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,0 +1,69 @@
+# Tardis Telemetry 📡
+
+> "I can see everything. All that is, all that was, all that ever could be."
+
+**Telemetry** provides full-stack observability for Tardis OS, from the kernel ring buffer up to user-space application metrics. It unifies logging, tracing, and metrics collection into a single, cohesive system.
+
+## 🏗️ Architecture
+
+The telemetry stack is designed to work in both `no_std` (Kernel) and `std` (Userspace) environments.
+
+```text
+┌─────────────────────────────────────────┐
+│           External Tools                │
+│    Jaeger / Grafana / Prometheus        │
+└─────────────────▲───────────────────────┘
+                  │ OTLP (gRPC)
+┌─────────────────┴───────────────────────┐
+│          tardis-telemetry               │
+│  [Userspace]                            │
+│  • Tracing Subscriber (Logs/Spans)      │
+│  • Metrics Registry (Counters/Gauges)   │
+│  • Gallifrey Store (Historical Logs)    │
+└─────────────────▲───────────────────────┘
+                  │ Ring Buffer
+┌─────────────────┴───────────────────────┐
+│              Kernel                     │
+│  [Kernel Space]                         │
+│  • KernelLogger (printk)                │
+│  • Serial Port Output                   │
+└─────────────────────────────────────────┘
+```
+
+## 🚀 Usage
+
+### Initialization
+```rust
+use tardis_telemetry::{init, TelemetryConfig};
+
+fn main() -> anyhow::Result<()> {
+    // Initialize tracing subscriber and metrics exporter
+    let _handle = init(TelemetryConfig::default())?;
+
+    tracing::info!("Telemetry initialized!");
+    Ok(())
+}
+```
+
+### Metrics
+We provide convenient macros for recording metrics:
+
+```rust
+use tardis_telemetry::{counter, gauge, histogram};
+
+fn process_request() {
+    // Increment a counter
+    counter!("requests_total", "service" => "api").inc();
+
+    // Record latency
+    let start = std::time::Instant::now();
+    // ... work ...
+    histogram!("request_duration_ms").record(start.elapsed().as_millis() as f64);
+}
+```
+
+## 🚩 Feature Flags
+
+-   **`std`** *(Default)*: Enables userspace features (tracing-subscriber, Tokio runtime).
+-   **`kernel`**: Enables `no_std` support for the OS kernel.
+-   **`otlp`**: Enables OpenTelemetry Protocol (OTLP) exporters for integration with external observability platforms.

--- a/vortex/README.md
+++ b/vortex/README.md
@@ -1,0 +1,72 @@
+# Tardis Vortex 🌪️
+
+> "The Vortex is a funnel of psychic energy... a door to another dimension."
+
+**Vortex** is the Large Language Model (LLM) inference engine for Tardis OS. It is built on top of [Candle](https://github.com/huggingface/candle), a minimalist ML framework for Rust, enabling high-performance, GPU-accelerated inference directly within the OS.
+
+## ✨ Features
+
+-   **Native Rust Inference**: No Python dependencies or external API calls required.
+-   **Multi-Architecture Support**: Supports popular architectures including:
+    -   Llama (CodeLlama, Llama 2/3)
+    -   Mistral / Mixtral
+    -   Phi (2/3)
+    -   Gemma
+-   **Quantization**: Supports loading quantized models (GGUF, Q4, Q8) for memory efficiency.
+-   **State Management**: Manages KV-caches and model states efficiently.
+-   **Token Streaming**: Supports real-time token generation for responsive UIs.
+
+## 🚀 Usage
+
+Vortex handles the complexity of loading weights, tokenizing input, and sampling tokens.
+
+```rust,no_run
+use tardis_vortex::{Vortex, ModelLoadConfig, InferenceParams};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // 1. Initialize the engine
+    // This detects available hardware (CUDA, Metal, CPU)
+    let vortex = Vortex::new()?;
+
+    // 2. Load a model
+    // You can load from a local directory containing .safetensors and config.json
+    let handle = vortex.load_model(
+        "/path/to/models/phi-3-mini",
+        ModelLoadConfig {
+            quantized: true, // Use quantization if available
+            ..Default::default()
+        },
+    ).await?;
+
+    // 3. Run inference
+    let response = vortex.infer(
+        handle,
+        "Explain the theory of relativity in 5 words.",
+        InferenceParams {
+            temperature: 0.7,
+            max_tokens: 50,
+            ..Default::default()
+        },
+    ).await?;
+
+    println!("Response: {}", response);
+    Ok(())
+}
+```
+
+## 🏗️ Architecture
+
+Vortex is composed of several modules:
+
+-   **`loader`**: Handles parsing `config.json` and loading SafeTensors/GGUF weights.
+-   **`model`**: Defines architecture implementations (e.g., `LlamaModel`, `PhiModel`).
+-   **`inference`**: Manages the inference loop, KV-cache updates, and sampling.
+-   **`tokenizer`**: Wraps the Hugging Face `tokenizers` library for text encoding/decoding.
+
+## ⚠️ Requirements
+
+Vortex relies on `candle-core`. To enable GPU support:
+
+-   **NVIDIA**: Ensure CUDA toolkit is installed. The `cuda` feature is enabled by default in the workspace.
+-   **macOS**: Metal support is automatically enabled on Apple Silicon.


### PR DESCRIPTION
This PR adds comprehensive `README.md` files to the `gallifrey`, `vortex`, `common`, and `telemetry` crates, which were previously undocumented at the crate level. 

It also updates `shell/README.md` to accurately reflect the current implementation status of commands (marking some as experimental) and documents the `nova` feature flag for TUI capabilities.

Finally, it fixes a broken intra-doc link in `shell/src/lib.rs` that was causing documentation build warnings.

---
*PR created automatically by Jules for task [7061359839301566545](https://jules.google.com/task/7061359839301566545) started by @madmax983*