### PR TITLE
🗺️ Atlas: Decouple Chronos from concrete Services

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -64,3 +64,11 @@
 2. Moved `common::llm` to `vortex::config` (the Inference Engine).
 3. Updated `common` to only contain shared primitives (`id`, `error`, `temporal`).
 **Stability:** Enforced strict domain boundaries. `common` is now truly common.
+
+**[Architect] Completing the Great Decoupling**
+**Tangle:** `Chronos` was still coupled to concrete `Vortex` and `Gallifrey` structs, preventing true decoupling and mocking. The previous journal entry claiming this was done was premature or referred to a different branch.
+**Blueprint:**
+1. Defined `GallifreyService` trait in `gallifrey` and implemented it for `Gallifrey`.
+2. Defined `VortexService` trait in `vortex` and implemented it for `Vortex`.
+3. Refactored `Chronos`, `Retriever`, `SystemDoctor`, `Prophet`, and `SonicScrewdriver` to use `Arc<dyn Service>`.
+**Stability:** Enforced Dependency Inversion Principle. `Chronos` core logic is now strictly decoupled from infrastructure implementations.

--- a/chronos/src/experimental/doctor.rs
+++ b/chronos/src/experimental/doctor.rs
@@ -6,10 +6,10 @@
 use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tardis_telemetry::gallifrey::TelemetryStore;
 use tardis_telemetry::types::Level;
-use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+use tardis_vortex::{InferenceParams, ModelHandle, VortexService};
 
 /// Vital signs of the system.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,15 +59,15 @@ pub struct Prescription {
 #[derive(Debug)]
 pub struct SystemDoctor {
     telemetry: Arc<TelemetryStore>,
-    gallifrey: Arc<Gallifrey>,
-    vortex: Option<Arc<Vortex>>,
+    gallifrey: Arc<dyn GallifreyService>,
+    vortex: Option<Arc<dyn VortexService>>,
     model_handle: Option<ModelHandle>,
 }
 
 impl SystemDoctor {
     /// Create a new System Doctor.
     #[must_use]
-    pub const fn new(telemetry: Arc<TelemetryStore>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(telemetry: Arc<TelemetryStore>, gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self {
             telemetry,
             gallifrey,
@@ -78,7 +78,7 @@ impl SystemDoctor {
 
     /// Attach Vortex AI engine.
     #[must_use]
-    pub fn with_vortex(mut self, vortex: Arc<Vortex>) -> Self {
+    pub fn with_vortex(mut self, vortex: Arc<dyn VortexService>) -> Self {
         self.vortex = Some(vortex);
         self
     }
@@ -174,7 +174,7 @@ impl SystemDoctor {
         let window = Duration::minutes(5);
         let from = now - window;
 
-        if let Ok(changes) = self.gallifrey.system_state().get_changes(from, now) {
+        if let Ok(changes) = self.gallifrey.get_system_changes(from, now).await {
             for change in changes {
                 changes_desc.push(format!(
                     "Change to {} at {} ({:?})",

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -13,20 +13,20 @@ use tardis_common::id::{EntityId, ModelHandle};
 use tardis_common::temporal::{BiTemporalInterval, TimeRange};
 use tardis_gallifrey::domain::Entity;
 use tardis_vortex::InferenceParams;
-use tardis_vortex::Vortex;
+use tardis_vortex::VortexService;
 use tracing::{info, instrument};
 
 /// The Prophet engine.
 #[derive(Debug)]
 pub struct Prophet {
-    vortex: Arc<Vortex>,
+    vortex: Arc<dyn VortexService>,
     paper: PsychicPaper,
 }
 
 impl Prophet {
     /// Create a new Prophet.
     #[must_use]
-    pub const fn new(vortex: Arc<Vortex>) -> Self {
+    pub fn new(vortex: Arc<dyn VortexService>) -> Self {
         Self {
             vortex,
             paper: PsychicPaper::new(),

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -43,10 +43,10 @@ use crate::error::{ChronosError, ChronosResult};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tardis_common::{EntityId, SessionId};
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 #[cfg(feature = "telemetry")]
 use tardis_telemetry::gallifrey::TelemetryStore;
-use tardis_vortex::Vortex;
+use tardis_vortex::VortexService;
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -143,8 +143,8 @@ pub struct RagResponse {
 /// The main Chronos RAG engine.
 #[derive(Debug)]
 pub struct Chronos {
-    vortex: Arc<Vortex>,
-    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<dyn VortexService>,
+    gallifrey: Arc<dyn GallifreyService>,
     #[cfg(feature = "telemetry")]
     telemetry: Option<Arc<TelemetryStore>>,
     analyzer: QueryAnalyzer,
@@ -155,7 +155,7 @@ pub struct Chronos {
 impl Chronos {
     /// Create a new Chronos instance.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(vortex: Arc<dyn VortexService>, gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self {
             vortex,
             gallifrey: Arc::clone(&gallifrey),
@@ -177,7 +177,7 @@ impl Chronos {
 
     /// Get access to the underlying Vortex engine.
     #[must_use]
-    pub fn vortex(&self) -> Arc<Vortex> {
+    pub fn vortex(&self) -> Arc<dyn VortexService> {
         Arc::clone(&self.vortex)
     }
 

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -4,19 +4,19 @@ use super::{ContextSource, ContextSourceType, RagConfig};
 use crate::error::{ChronosError, ChronosResult};
 use crate::pipeline::analyzer::AnalyzedQuery;
 use std::sync::Arc;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tracing::info;
 
 /// Multi-source retriever.
 #[derive(Debug)]
 pub struct Retriever {
-    gallifrey: Arc<Gallifrey>,
+    gallifrey: Arc<dyn GallifreyService>,
 }
 
 impl Retriever {
     /// Create a new retriever.
     #[must_use]
-    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self { gallifrey }
     }
 

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -91,6 +91,76 @@ use tardis_common::id::{EntityId, SessionId};
 use tardis_common::temporal::TemporalQuery;
 
 use crate::query::QueryResult;
+use async_trait::async_trait;
+
+use std::fmt::Debug;
+
+/// Core service trait for Gallifrey.
+#[async_trait]
+pub trait GallifreyService: Send + Sync + Debug {
+    /// Execute a query with optional temporal parameters.
+    async fn query(
+        &self,
+        query: &str,
+        temporal: TemporalQuery,
+    ) -> tardis_common::Result<QueryResult>;
+
+    /// Insert a node into the knowledge graph.
+    async fn insert(&self, node: Entity) -> tardis_common::Result<EntityId>;
+
+    /// Update an existing node.
+    async fn update(
+        &self,
+        id: EntityId,
+        properties: serde_json::Value,
+    ) -> tardis_common::Result<()>;
+
+    /// Get the history of an entity.
+    async fn get_history(&self, id: EntityId) -> tardis_common::Result<Vec<Entity>>;
+
+    /// Travel to a point in time and get a snapshot.
+    async fn time_travel(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<QueryResult>;
+
+    /// Semantic search for entities.
+    async fn search_knowledge(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Entity>>;
+
+    /// Get recent messages from a session.
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Message>>;
+
+    /// Semantic search for messages.
+    async fn search_conversation(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Message>>;
+
+    /// Find a system snapshot at a specific time.
+    async fn find_snapshot(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Option<Snapshot>>;
+
+    /// Record a system change.
+    async fn record_change(&self, change: Change) -> tardis_common::Result<()>;
+
+    /// Get changes between two timestamps.
+    async fn get_system_changes(
+        &self,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Vec<Change>>;
+}
 
 /// The main Gallifrey database instance.
 ///
@@ -308,6 +378,99 @@ impl Gallifrey {
         self.system_state
             .record_change(change)
             .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    /// Get changes between two timestamps.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if changes cannot be retrieved.
+    #[allow(clippy::unused_async)]
+    pub async fn get_system_changes(
+        &self,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Vec<Change>> {
+        self.system_state
+            .get_changes(from, to)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+}
+
+#[async_trait]
+impl GallifreyService for Gallifrey {
+    async fn query(
+        &self,
+        query: &str,
+        temporal: TemporalQuery,
+    ) -> tardis_common::Result<QueryResult> {
+        self.query(query, temporal).await
+    }
+
+    async fn insert(&self, node: Entity) -> tardis_common::Result<EntityId> {
+        self.insert(node).await
+    }
+
+    async fn update(
+        &self,
+        id: EntityId,
+        properties: serde_json::Value,
+    ) -> tardis_common::Result<()> {
+        self.update(id, properties).await
+    }
+
+    async fn get_history(&self, id: EntityId) -> tardis_common::Result<Vec<Entity>> {
+        self.get_history(id).await
+    }
+
+    async fn time_travel(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<QueryResult> {
+        self.time_travel(timestamp).await
+    }
+
+    async fn search_knowledge(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Entity>> {
+        self.search_knowledge(embedding, limit).await
+    }
+
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Message>> {
+        self.get_recent_messages(session_id, limit).await
+    }
+
+    async fn search_conversation(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> tardis_common::Result<Vec<Message>> {
+        self.search_conversation(embedding, limit).await
+    }
+
+    async fn find_snapshot(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Option<Snapshot>> {
+        self.find_snapshot(timestamp).await
+    }
+
+    async fn record_change(&self, change: Change) -> tardis_common::Result<()> {
+        self.record_change(change).await
+    }
+
+    async fn get_system_changes(
+        &self,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Vec<Change>> {
+        self.get_system_changes(from, to).await
     }
 }
 

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -13,27 +13,27 @@ use std::path::Path;
 use std::sync::Arc;
 use tardis_chronos::experimental::doctor::{HealthStatus, SystemDoctor};
 use tardis_chronos::experimental::psychic_paper::{Intent, PsychicPaper};
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tardis_telemetry::gallifrey::TelemetryStore;
-use tardis_vortex::{ModelHandle, Vortex};
+use tardis_vortex::{ModelHandle, VortexService};
 
 /// The Sonic Screwdriver.
 #[derive(Debug, Default)]
 pub struct SonicScrewdriver {
     paper: PsychicPaper,
     telemetry: Option<Arc<TelemetryStore>>,
-    gallifrey: Option<Arc<Gallifrey>>,
-    vortex: Option<Arc<Vortex>>,
+    gallifrey: Option<Arc<dyn GallifreyService>>,
+    vortex: Option<Arc<dyn VortexService>>,
     model_handle: Option<ModelHandle>,
 }
 
 impl SonicScrewdriver {
     /// Create a new Sonic Screwdriver.
     #[must_use]
-    pub const fn new(
+    pub fn new(
         telemetry: Option<Arc<TelemetryStore>>,
-        gallifrey: Option<Arc<Gallifrey>>,
-        vortex: Option<Arc<Vortex>>,
+        gallifrey: Option<Arc<dyn GallifreyService>>,
+        vortex: Option<Arc<dyn VortexService>>,
         model_handle: Option<ModelHandle>,
     ) -> Self {
         Self {

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -56,3 +56,109 @@ pub use inference::Vortex;
 pub use loader::ModelPreset;
 pub use model::{ModelHandle, ModelInfo, ModelRegistry};
 pub use tokenizer::TokenizerService;
+
+use async_trait::async_trait;
+use std::fmt::Debug;
+
+/// Core service trait for Vortex.
+#[async_trait]
+pub trait VortexService: Send + Sync + Debug {
+    /// Load a model from disk.
+    async fn load_model(
+        &self,
+        path: &str,
+        config: ModelLoadConfig,
+    ) -> VortexResult<ModelHandle>;
+
+    /// Load a preset model.
+    async fn load_preset(
+        &self,
+        preset: ModelPreset,
+        device: Option<&str>,
+    ) -> VortexResult<ModelHandle>;
+
+    /// Load the default test model.
+    async fn load_default_test_model(&self) -> VortexResult<ModelHandle>;
+
+    /// Unload a model.
+    async fn unload_model(&self, handle: ModelHandle) -> VortexResult<()>;
+
+    /// Run inference on a model.
+    async fn infer(
+        &self,
+        handle: ModelHandle,
+        prompt: &str,
+        params: InferenceParams,
+    ) -> VortexResult<String>;
+
+    /// Generate embeddings for text.
+    async fn embed(&self, handle: ModelHandle, text: &str) -> VortexResult<Vec<f32>>;
+
+    /// List available models.
+    fn list_models(&self) -> Vec<ModelInfo>;
+
+    /// List loaded models and their handles.
+    fn list_loaded_models(&self) -> Vec<(ModelHandle, ModelInfo)>;
+
+    /// Get information about a specific model.
+    fn model_info(&self, handle: ModelHandle) -> Option<ModelInfo>;
+
+    /// Check if a model is loaded.
+    fn is_model_loaded(&self, handle: ModelHandle) -> bool;
+}
+
+#[async_trait]
+impl VortexService for Vortex {
+    async fn load_model(
+        &self,
+        path: &str,
+        config: ModelLoadConfig,
+    ) -> VortexResult<ModelHandle> {
+        self.load_model(path, config).await
+    }
+
+    async fn load_preset(
+        &self,
+        preset: ModelPreset,
+        device: Option<&str>,
+    ) -> VortexResult<ModelHandle> {
+        self.load_preset(preset, device).await
+    }
+
+    async fn load_default_test_model(&self) -> VortexResult<ModelHandle> {
+        self.load_default_test_model().await
+    }
+
+    async fn unload_model(&self, handle: ModelHandle) -> VortexResult<()> {
+        self.unload_model(handle).await
+    }
+
+    async fn infer(
+        &self,
+        handle: ModelHandle,
+        prompt: &str,
+        params: InferenceParams,
+    ) -> VortexResult<String> {
+        self.infer(handle, prompt, params).await
+    }
+
+    async fn embed(&self, handle: ModelHandle, text: &str) -> VortexResult<Vec<f32>> {
+        self.embed(handle, text).await
+    }
+
+    fn list_models(&self) -> Vec<ModelInfo> {
+        self.list_models()
+    }
+
+    fn list_loaded_models(&self) -> Vec<(ModelHandle, ModelInfo)> {
+        self.list_loaded_models()
+    }
+
+    fn model_info(&self, handle: ModelHandle) -> Option<ModelInfo> {
+        self.model_info(handle)
+    }
+
+    fn is_model_loaded(&self, handle: ModelHandle) -> bool {
+        self.is_model_loaded(handle)
+    }
+}


### PR DESCRIPTION
- Defined `GallifreyService` trait in `tardis-gallifrey` and implemented it for `Gallifrey`.
- Defined `VortexService` trait in `tardis-vortex` and implemented it for `Vortex`.
- Updated `Chronos` pipeline to use trait objects.
- Updated `SystemDoctor` and `Prophet` experimental modules to use trait objects.
- Updated `SonicScrewdriver` to use trait objects.
- Verified system integrity with `cargo check` and `cargo test`.
- Documented changes in `.jules/atlas.md`.

---
*PR created automatically by Jules for task [12570992477028048612](https://jules.google.com/task/12570992477028048612) started by @madmax983*