### PR TITLE
Prevent blind entity overwrite in KnowledgeStore

### DIFF
--- a/chronos/src/experimental/historian.rs
+++ b/chronos/src/experimental/historian.rs
@@ -198,7 +198,7 @@ mod tests {
                 },
                 transaction_time: TimeRange {
                     start: ten_mins_ago,
-                    end: None,
+                    end: Some(now),
                 },
             },
             source: None,

--- a/gallifrey/src/error.rs
+++ b/gallifrey/src/error.rs
@@ -17,6 +17,10 @@ pub enum GallifreyError {
     #[error("entity not found: {0}")]
     EntityNotFound(String),
 
+    /// Entity already exists (current version).
+    #[error("entity already exists: {0}")]
+    EntityAlreadyExists(String),
+
     /// Relationship not found.
     #[error("relationship not found: {0}")]
     RelationshipNotFound(String),
@@ -59,6 +63,7 @@ impl From<GallifreyError> for tardis_common::Error {
             GallifreyError::QueryParseError(msg) => Self::QueryParseError(msg),
             GallifreyError::QueryExecutionFailed(msg) => Self::QueryExecutionFailed(msg),
             GallifreyError::EntityNotFound(msg) => Self::EntityNotFound(msg),
+            GallifreyError::EntityAlreadyExists(msg) => Self::Internal(format!("Entity already exists: {}", msg)),
             GallifreyError::InvalidTemporalReference(msg) => Self::InvalidTemporalReference(msg),
             GallifreyError::TimeTravelFailed(msg) => Self::TimeTravelFailed { reason: msg },
             GallifreyError::Serialization(e) => Self::Serialization(e),

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -75,6 +75,16 @@ impl KnowledgeStore {
             .write()
             .map_err(|_| GallifreyError::StorageError("lock poisoned".to_string()))?;
 
+        if let Some(versions) = entities.get(&id) {
+            let now = Utc::now();
+            if versions
+                .iter()
+                .any(|e| e.temporal.transaction_time.is_current_relative_to(now))
+            {
+                return Err(GallifreyError::EntityAlreadyExists(id.to_string()));
+            }
+        }
+
         entities.entry(id).or_default().push(entity);
 
         Ok(id)

--- a/gallifrey/tests/blind_insert_repro.rs
+++ b/gallifrey/tests/blind_insert_repro.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+use tardis_common::id::EntityId;
+use tardis_common::temporal::BiTemporalInterval;
+use tardis_gallifrey::stores::{Entity, KnowledgeStore};
+use tardis_gallifrey::GallifreyError;
+
+#[test]
+fn test_blind_insert_fails_if_exists() {
+    let store = KnowledgeStore::new();
+    let id = EntityId::new();
+
+    let e1 = Entity {
+        id,
+        entity_type: "Test".to_string(),
+        name: "Entity 1".to_string(),
+        properties: HashMap::new(),
+        embedding: None,
+        temporal: BiTemporalInterval::now(),
+        source: None,
+    };
+
+    let e2 = Entity {
+        id,
+        entity_type: "Test".to_string(),
+        name: "Entity 2".to_string(),
+        properties: HashMap::new(),
+        embedding: None,
+        temporal: BiTemporalInterval::now(),
+        source: None,
+    };
+
+    // 1. Insert first entity
+    store.insert_entity(e1).expect("First insert should succeed");
+
+    // 2. Insert second entity - SHOULD FAIL with EntityAlreadyExists
+    let result = store.insert_entity(e2);
+
+    match result {
+        Err(GallifreyError::EntityAlreadyExists(_)) => {
+            // Success! The fix is working.
+        },
+        Ok(_) => {
+            panic!("Blind insert succeeded! This creates data corruption (multiple current versions).");
+        },
+        Err(e) => {
+            panic!("Unexpected error: {:?}", e);
+        }
+    }
+
+    // 3. Verify no corruption (still only 1 entity in history)
+    let history = store.get_entity_history(id).unwrap();
+    assert_eq!(history.len(), 1, "Should only have 1 version if insert failed");
+}


### PR DESCRIPTION
Prevents `KnowledgeStore::insert_entity` from creating multiple "current" versions of the same entity, which would lead to ambiguous state. Added `EntityAlreadyExists` error variant and updated consumers.

---
*PR created automatically by Jules for task [4525067195855431849](https://jules.google.com/task/4525067195855431849) started by @madmax983*