### PR TITLE
⚒️ Forge: Refactor Repl::handle_builtin

### DIFF
--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -24,11 +24,7 @@ pub struct Curiosity {
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub fn new(
-        gallifrey: Arc<Gallifrey>,
-        vortex: Arc<Vortex>,
-        model: ModelHandle,
-    ) -> Self {
+    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,
@@ -50,27 +46,35 @@ impl Curiosity {
         // Scan history to find a sparse entity
         // Heuristic: Has fewer than 3 properties and is not a "System" type
         // We stop at the first one we find for now (MVP).
-        self.gallifrey.knowledge().scan_history(|history| {
-            if target_entity.is_some() {
-                return;
-            }
-
-            // Look at the latest version of the entity
-            if let Some(latest) = history.last() {
-                if latest.properties.len() < 3
-                   && latest.entity_type != "System"
-                   && !latest.name.is_empty()
-                {
-                    target_entity = Some(latest.clone());
+        self.gallifrey
+            .knowledge()
+            .scan_history(|history| {
+                if target_entity.is_some() {
+                    return;
                 }
-            }
-        }).map_err(|e| crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+
+                // Look at the latest version of the entity
+                if let Some(latest) = history.last() {
+                    if latest.properties.len() < 3
+                        && latest.entity_type != "System"
+                        && !latest.name.is_empty()
+                    {
+                        target_entity = Some(latest.clone());
+                    }
+                }
+            })
+            .map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            })?;
 
         let Some(entity) = target_entity else {
             return Ok("I am content. My knowledge base feels complete... for now.".to_string());
         };
 
-        info!("Curiosity: Found gap in entity '{}' ({})", entity.name, entity.entity_type);
+        info!(
+            "Curiosity: Found gap in entity '{}' ({})",
+            entity.name, entity.entity_type
+        );
 
         // Construct prompt
         let prompt = format!(
@@ -88,7 +92,11 @@ impl Curiosity {
 
         let question = self.vortex.infer(self.model, &prompt, params).await?;
 
-        Ok(format!("🤔 Regarding '{}': {}", entity.name, question.trim()))
+        Ok(format!(
+            "🤔 Regarding '{}': {}",
+            entity.name,
+            question.trim()
+        ))
     }
 }
 
@@ -127,12 +135,15 @@ mod tests {
         let mock_handle = ModelHandle::new(1);
         vortex.set_mock_load_model(Box::new(move |_, _| Ok(mock_handle)));
 
-        vortex.set_mock_inference(Box::new(|_, _, _| {
-            Ok("What is inside the box?".to_string())
-        }));
+        vortex.set_mock_inference(Box::new(
+            |_, _, _| Ok("What is inside the box?".to_string()),
+        ));
 
         // Load dummy model to register handle
-        let handle = vortex.load_model("dummy", ModelLoadConfig::default()).await.unwrap();
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
 
         let curiosity = Curiosity::new(gallifrey, vortex, handle);
 
@@ -151,7 +162,10 @@ mod tests {
 
         // Register dummy model
         vortex.set_mock_load_model(Box::new(move |_, _| Ok(ModelHandle::new(1))));
-        let handle = vortex.load_model("dummy", ModelLoadConfig::default()).await.unwrap();
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
 
         let curiosity = Curiosity::new(gallifrey, vortex, handle);
 

--- a/common/src/temporal.rs
+++ b/common/src/temporal.rs
@@ -161,7 +161,8 @@ impl BiTemporalInterval {
     /// to avoid repeated calls to `Utc::now()`.
     #[must_use]
     pub fn is_current_relative_to(&self, now: DateTime<Utc>) -> bool {
-        self.valid_time.is_current_relative_to(now) && self.transaction_time.is_current_relative_to(now)
+        self.valid_time.is_current_relative_to(now)
+            && self.transaction_time.is_current_relative_to(now)
     }
 
     /// Close the transaction time (mark as superseded).

--- a/gallifrey/src/error.rs
+++ b/gallifrey/src/error.rs
@@ -63,7 +63,9 @@ impl From<GallifreyError> for tardis_common::Error {
             GallifreyError::QueryParseError(msg) => Self::QueryParseError(msg),
             GallifreyError::QueryExecutionFailed(msg) => Self::QueryExecutionFailed(msg),
             GallifreyError::EntityNotFound(msg) => Self::EntityNotFound(msg),
-            GallifreyError::EntityAlreadyExists(msg) => Self::Internal(format!("Entity already exists: {}", msg)),
+            GallifreyError::EntityAlreadyExists(msg) => {
+                Self::Internal(format!("Entity already exists: {}", msg))
+            }
             GallifreyError::InvalidTemporalReference(msg) => Self::InvalidTemporalReference(msg),
             GallifreyError::TimeTravelFailed(msg) => Self::TimeTravelFailed { reason: msg },
             GallifreyError::Serialization(e) => Self::Serialization(e),

--- a/gallifrey/src/experimental/mod.rs
+++ b/gallifrey/src/experimental/mod.rs
@@ -12,7 +12,7 @@ pub mod heatmap;
 /// System entropy and stability metrics.
 pub mod entropy;
 
-/// Timeline simulation for "What-If" scenarios.
-pub mod timeline;
 /// Time Capsule for knowledge graph export/import.
 pub mod time_capsule;
+/// Timeline simulation for "What-If" scenarios.
+pub mod timeline;

--- a/gallifrey/tests/blind_insert_repro.rs
+++ b/gallifrey/tests/blind_insert_repro.rs
@@ -30,7 +30,9 @@ fn test_blind_insert_fails_if_exists() {
     };
 
     // 1. Insert first entity
-    store.insert_entity(e1).expect("First insert should succeed");
+    store
+        .insert_entity(e1)
+        .expect("First insert should succeed");
 
     // 2. Insert second entity - SHOULD FAIL with EntityAlreadyExists
     let result = store.insert_entity(e2);
@@ -38,10 +40,12 @@ fn test_blind_insert_fails_if_exists() {
     match result {
         Err(GallifreyError::EntityAlreadyExists(_)) => {
             // Success! The fix is working.
-        },
+        }
         Ok(_) => {
-            panic!("Blind insert succeeded! This creates data corruption (multiple current versions).");
-        },
+            panic!(
+                "Blind insert succeeded! This creates data corruption (multiple current versions)."
+            );
+        }
         Err(e) => {
             panic!("Unexpected error: {:?}", e);
         }
@@ -49,5 +53,9 @@ fn test_blind_insert_fails_if_exists() {
 
     // 3. Verify no corruption (still only 1 entity in history)
     let history = store.get_entity_history(id).unwrap();
-    assert_eq!(history.len(), 1, "Should only have 1 version if insert failed");
+    assert_eq!(
+        history.len(),
+        1,
+        "Should only have 1 version if insert failed"
+    );
 }

--- a/gallifrey/tests/future_entity_retrieval.rs
+++ b/gallifrey/tests/future_entity_retrieval.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    use tardis_gallifrey::{KnowledgeStore, BiTemporalInterval, TimeRange};
-    use tardis_gallifrey::domain::Entity;
-    use tardis_common::id::EntityId;
-    use chrono::{Utc, Duration};
+    use chrono::{Duration, Utc};
     use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_gallifrey::domain::Entity;
+    use tardis_gallifrey::{BiTemporalInterval, KnowledgeStore, TimeRange};
 
     #[test]
     fn get_entity_should_not_return_future_entity() {
@@ -51,6 +51,9 @@ mod tests {
         store.insert_entity(entity).expect("Insert failed");
 
         let results = store.find_by_type("FutureFact").expect("Find failed");
-        assert!(results.is_empty(), "find_by_type() returned a future entity!");
+        assert!(
+            results.is_empty(),
+            "find_by_type() returned a future entity!"
+        );
     }
 }

--- a/shell/src/experimental/biographer.rs
+++ b/shell/src/experimental/biographer.rs
@@ -6,7 +6,7 @@
 use std::fmt::Write;
 use std::sync::Arc;
 use tardis_gallifrey::Gallifrey;
-use tardis_vortex::{Vortex, ModelHandle, InferenceParams};
+use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
 
 /// The Biographer engine.
 #[derive(Debug)]
@@ -73,7 +73,11 @@ impl Biographer {
 
             // Format time range nicely
             let time_str = match valid_to {
-                Some(end) => format!("From {} to {}", valid_from.format("%Y-%m-%d %H:%M"), end.format("%Y-%m-%d %H:%M")),
+                Some(end) => format!(
+                    "From {} to {}",
+                    valid_from.format("%Y-%m-%d %H:%M"),
+                    end.format("%Y-%m-%d %H:%M")
+                ),
                 None => format!("From {} onwards", valid_from.format("%Y-%m-%d %H:%M")),
             };
 
@@ -108,10 +112,10 @@ impl Biographer {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use tardis_gallifrey::domain::Entity;
+    use std::collections::HashMap;
     use tardis_common::id::EntityId;
     use tardis_common::temporal::BiTemporalInterval;
-    use std::collections::HashMap;
+    use tardis_gallifrey::domain::Entity;
 
     #[tokio::test]
     async fn test_biography_generation() {
@@ -121,21 +125,24 @@ mod tests {
 
         // Mock inference
         vortex.set_mock_inference(Box::new(|_, prompt, _| {
-            Ok(format!("Mock biography based on prompt length: {}", prompt.len()))
+            Ok(format!(
+                "Mock biography based on prompt length: {}",
+                prompt.len()
+            ))
         }));
 
         // Mock load model to fail gracefully if we try (but we pass None for model handle)
         vortex.set_mock_load_model(Box::new(|_, _| {
-             Err(tardis_vortex::VortexError::ModelNotFound { path: "dummy".into() })
+            Err(tardis_vortex::VortexError::ModelNotFound {
+                path: "dummy".into(),
+            })
         }));
 
         let entity = Entity {
             id: EntityId::new(),
             entity_type: "Person".to_string(),
             name: "The Doctor".to_string(),
-            properties: HashMap::from([
-                ("status".to_string(), serde_json::json!("Exiled"))
-            ]),
+            properties: HashMap::from([("status".to_string(), serde_json::json!("Exiled"))]),
             embedding: None,
             temporal: BiTemporalInterval::now(),
             source: None,

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -290,10 +290,7 @@ mod tests {
 
         // Load a "dummy" model to get a valid handle in registry
         let handle = vortex
-            .load_model(
-                "/dummy/model",
-                tardis_vortex::ModelLoadConfig::default(),
-            )
+            .load_model("/dummy/model", tardis_vortex::ModelLoadConfig::default())
             .await
             .unwrap();
 
@@ -316,12 +313,8 @@ mod tests {
         telemetry.record_event(error_event).await.unwrap();
 
         // Run Sonic Screwdriver
-        let sonic = SonicScrewdriver::new(
-            Some(telemetry),
-            Some(gallifrey),
-            Some(vortex),
-            Some(handle),
-        );
+        let sonic =
+            SonicScrewdriver::new(Some(telemetry), Some(gallifrey), Some(vortex), Some(handle));
 
         let report = sonic.diagnose().await.unwrap();
 

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -13,17 +13,17 @@ use tardis_telemetry::gallifrey::TelemetryStore;
 use tracing::{error, info};
 
 #[cfg(feature = "nova")]
-use crate::experimental::chronograph::ChronoGraph;
-#[cfg(feature = "nova")]
 use crate::experimental::biographer::Biographer;
+#[cfg(feature = "nova")]
+use crate::experimental::chronograph::ChronoGraph;
 #[cfg(feature = "nova")]
 use crate::experimental::heatmap_cmd;
 #[cfg(feature = "nova")]
 use crate::experimental::sonic::SonicScrewdriver;
 #[cfg(feature = "nova")]
-use tardis_chronos::experimental::prophecy::Prophet;
-#[cfg(feature = "nova")]
 use tardis_chronos::experimental::curiosity::Curiosity;
+#[cfg(feature = "nova")]
+use tardis_chronos::experimental::prophecy::Prophet;
 #[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
 
@@ -147,7 +147,6 @@ impl Repl {
     }
 
     /// Handle a built-in command.
-    #[allow(clippy::too_many_lines)]
     async fn handle_builtin(&mut self, command: &str, args: &[String]) {
         match command {
             "help" => commands::help(args),
@@ -155,222 +154,30 @@ impl Repl {
                 println!("Goodbye!");
                 self.running = false;
             }
-            "history" => commands::history(&self.gallifrey, self.session_id),
-            "remember" => {
-                let content = args.join(" ");
-                match self
-                    .chronos
-                    .remember(&content, tardis_chronos::MemoryCategory::Knowledge)
-                    .await
-                {
-                    Ok(id) => println!("Remembered: {id}"),
-                    Err(e) => println!("Failed to remember: {e}"),
-                }
-            }
-            "recall" => {
-                let query = args.join(" ");
-                match self.chronos.recall(&query, 5).await {
-                    Ok(results) => {
-                        for result in results {
-                            println!("- {}", result.content);
-                        }
-                    }
-                    Err(e) => println!("Failed to recall: {e}"),
-                }
-            }
-            "models" => commands::list_models(),
-            "context" => commands::show_context(self.session_id),
+            "history" => self.handle_history(),
+            "remember" => self.handle_remember(args).await,
+            "recall" => self.handle_recall(args).await,
+            "models" => self.handle_models(),
+            "context" => self.handle_context(),
             "clear" => {
                 print!("\x1B[2J\x1B[1;1H");
             }
             #[cfg(feature = "nova")]
-            "dashboard" => {
-                match crate::dashboard::tui::Dashboard::new(
-                    std::sync::Arc::clone(&self.gallifrey),
-                    self.telemetry_store.clone(),
-                    self.prophet.clone(),
-                ) {
-                    Ok(mut dashboard) => {
-                        if let Err(e) = dashboard.run() {
-                            println!("Dashboard failed: {e}");
-                        }
-                    }
-                    Err(e) => println!("Failed to initialize dashboard: {e}"),
-                }
-            }
+            "dashboard" => self.handle_dashboard(),
             #[cfg(feature = "nova")]
-            "timeline" => {
-                if args.is_empty() {
-                    println!("Usage: timeline <entity_name>");
-                    return;
-                }
-                let entity_name = &args[0];
-
-                let graph = ChronoGraph::new(self.gallifrey.clone());
-                match graph.generate_timeline(entity_name) {
-                    Ok(timeline) => println!("{timeline}"),
-                    Err(e) => println!("Failed to generate timeline: {e}"),
-                }
-            }
+            "timeline" => self.handle_timeline(args),
             #[cfg(feature = "nova")]
-            "map" => {
-                if args.is_empty() {
-                    println!("Usage: map <entity_name> [depth]");
-                    return;
-                }
-                let entity_name = &args[0];
-                let depth = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2);
-
-                let graph = ChronoGraph::new(self.gallifrey.clone());
-                match graph.generate_map(entity_name, depth, None) {
-                    Ok(map) => println!("{map}"),
-                    Err(e) => println!("Failed to generate map: {e}"),
-                }
-            }
+            "map" => self.handle_map(args),
             #[cfg(feature = "nova")]
-            "heatmap" => {
-                match heatmap_cmd::run(&self.gallifrey, args) {
-                    Ok(report) => println!("{report}"),
-                    Err(e) => println!("Failed to generate heatmap: {e}"),
-                }
-            }
+            "heatmap" => self.handle_heatmap(args),
             #[cfg(feature = "nova")]
-            "biography" | "bio" => {
-                if args.is_empty() {
-                    println!("Usage: biography <entity_name>");
-                    return;
-                }
-                let entity_name = args.join(" ");
-
-                let loaded_models = self.chronos.vortex().list_loaded_models();
-                let model_handle = loaded_models.first().map(|(h, _)| *h);
-
-                let biographer = Biographer::new(
-                    std::sync::Arc::clone(&self.gallifrey),
-                    self.chronos.vortex(),
-                    model_handle,
-                );
-
-                match biographer.biography(&entity_name).await {
-                    Ok(bio) => println!("\n{bio}\n"),
-                    Err(e) => println!("Failed to generate biography: {e}"),
-                }
-            }
+            "biography" | "bio" => self.handle_biography(args).await,
             #[cfg(feature = "nova")]
-            "sonic" | "fix" => {
-                if args.is_empty() {
-                    println!("Usage: sonic <file> | sonic repair <file> | sonic diagnose");
-                    return;
-                }
-
-                let loaded_models = self.chronos.vortex().list_loaded_models();
-                let model_handle = loaded_models.first().map(|(h, _)| *h);
-
-                let screwdriver = SonicScrewdriver::new(
-                    self.telemetry_store.clone(),
-                    Some(std::sync::Arc::clone(&self.gallifrey)),
-                    Some(self.chronos.vortex()),
-                    model_handle,
-                );
-
-                if args[0] == "diagnose" {
-                    println!("{}", screwdriver.buzz());
-                    match screwdriver.diagnose().await {
-                        Ok(report) => println!("{report}"),
-                        Err(e) => println!("Diagnosis failed: {e}"),
-                    }
-                    return;
-                }
-
-                let path = std::path::Path::new(&args[args.len() - 1]);
-
-                // Check if user wants repair (e.g. "sonic repair file.json" or "fix file.json")
-                // If command is "fix", we repair.
-                // If command is "sonic" and first arg is "repair" or "fix", we repair.
-                let repair = command == "fix"
-                    || (args.len() > 1 && (args[0] == "repair" || args[0] == "fix"));
-
-                let result = if repair {
-                    screwdriver.repair(path)
-                } else {
-                    screwdriver.inspect(path)
-                };
-
-                match result {
-                    Ok(report) => println!("{report}"),
-                    Err(e) => println!("Sonic Screwdriver error: {e}"),
-                }
-            }
+            "sonic" | "fix" => self.handle_sonic(command, args).await,
             #[cfg(feature = "nova")]
-            "ask" | "curiosity" => {
-                let loaded_models = self.chronos.vortex().list_loaded_models();
-                if let Some((handle, _)) = loaded_models.first() {
-                    let curiosity = Curiosity::new(
-                        std::sync::Arc::clone(&self.gallifrey),
-                        self.chronos.vortex(),
-                        *handle,
-                    );
-
-                    println!("🤔 Curiosity is scanning...");
-                    match curiosity.ask().await {
-                        Ok(question) => println!("{question}"),
-                        Err(e) => println!("Curiosity failed: {e}"),
-                    }
-                } else {
-                    println!("Curiosity needs a loaded model. Use 'models load <path>'.");
-                }
-            }
+            "ask" | "curiosity" => self.handle_curiosity().await,
             #[cfg(feature = "nova")]
-            "capsule" => {
-                if args.len() < 2 {
-                    println!(
-                        "Usage: capsule capture <entity> <file> [depth] | capsule restore <file>"
-                    );
-                    return;
-                }
-
-                let subcommand = &args[0];
-                match subcommand.as_str() {
-                    "capture" => {
-                        if args.len() < 3 {
-                            println!("Usage: capsule capture <entity> <file> [depth]");
-                            return;
-                        }
-                        let entity_name = &args[1];
-                        let file_path = &args[2];
-                        let depth = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1);
-
-                        match TimeCapsule::capture(&self.gallifrey, entity_name, depth) {
-                            Ok(capsule) => match capsule.save_to_file(file_path) {
-                                Ok(()) => println!(
-                                    "Captured {} entities and {} relationships to {}",
-                                    capsule.entities.len(),
-                                    capsule.relationships.len(),
-                                    file_path
-                                ),
-                                Err(e) => println!("Failed to save capsule: {e}"),
-                            },
-                            Err(e) => println!("Failed to capture capsule: {e}"),
-                        }
-                    }
-                    "restore" => {
-                        let file_path = &args[1];
-                        match TimeCapsule::load_from_file(file_path) {
-                            Ok(capsule) => {
-                                let count = capsule.entities.len();
-                                match capsule.restore(&self.gallifrey).await {
-                                    Ok(()) => {
-                                        println!("Restored {count} entities from {file_path}");
-                                    }
-                                    Err(e) => println!("Failed to restore capsule: {e}"),
-                                }
-                            }
-                            Err(e) => println!("Failed to load capsule: {e}"),
-                        }
-                    }
-                    _ => println!("Unknown capsule command: {subcommand}"),
-                }
-            }
+            "capsule" => self.handle_capsule(args).await,
             _ => println!("Unknown command: {command}. Type 'help' for available commands."),
         }
     }
@@ -417,5 +224,232 @@ impl Repl {
     async fn handle_direct_query(&self, query: &str) {
         println!("[Direct query: {query}]");
         println!("Direct queries not yet implemented.");
+    }
+
+    fn handle_history(&self) {
+        commands::history(&self.gallifrey, self.session_id);
+    }
+
+    async fn handle_remember(&self, args: &[String]) {
+        let content = args.join(" ");
+        match self
+            .chronos
+            .remember(&content, tardis_chronos::MemoryCategory::Knowledge)
+            .await
+        {
+            Ok(id) => println!("Remembered: {id}"),
+            Err(e) => println!("Failed to remember: {e}"),
+        }
+    }
+
+    async fn handle_recall(&self, args: &[String]) {
+        let query = args.join(" ");
+        match self.chronos.recall(&query, 5).await {
+            Ok(results) => {
+                for result in results {
+                    println!("- {}", result.content);
+                }
+            }
+            Err(e) => println!("Failed to recall: {e}"),
+        }
+    }
+
+    fn handle_models(&self) {
+        commands::list_models();
+    }
+
+    fn handle_context(&self) {
+        commands::show_context(self.session_id);
+    }
+
+    #[cfg(feature = "nova")]
+    fn handle_dashboard(&self) {
+        match crate::dashboard::tui::Dashboard::new(
+            std::sync::Arc::clone(&self.gallifrey),
+            self.telemetry_store.clone(),
+            self.prophet.clone(),
+        ) {
+            Ok(mut dashboard) => {
+                if let Err(e) = dashboard.run() {
+                    println!("Dashboard failed: {e}");
+                }
+            }
+            Err(e) => println!("Failed to initialize dashboard: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    fn handle_timeline(&self, args: &[String]) {
+        if args.is_empty() {
+            println!("Usage: timeline <entity_name>");
+            return;
+        }
+        let entity_name = &args[0];
+
+        let graph = ChronoGraph::new(self.gallifrey.clone());
+        match graph.generate_timeline(entity_name) {
+            Ok(timeline) => println!("{timeline}"),
+            Err(e) => println!("Failed to generate timeline: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    fn handle_map(&self, args: &[String]) {
+        if args.is_empty() {
+            println!("Usage: map <entity_name> [depth]");
+            return;
+        }
+        let entity_name = &args[0];
+        let depth = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(2);
+
+        let graph = ChronoGraph::new(self.gallifrey.clone());
+        match graph.generate_map(entity_name, depth, None) {
+            Ok(map) => println!("{map}"),
+            Err(e) => println!("Failed to generate map: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    fn handle_heatmap(&self, args: &[String]) {
+        match heatmap_cmd::run(&self.gallifrey, args) {
+            Ok(report) => println!("{report}"),
+            Err(e) => println!("Failed to generate heatmap: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    async fn handle_biography(&self, args: &[String]) {
+        if args.is_empty() {
+            println!("Usage: biography <entity_name>");
+            return;
+        }
+        let entity_name = args.join(" ");
+
+        let loaded_models = self.chronos.vortex().list_loaded_models();
+        let model_handle = loaded_models.first().map(|(h, _)| *h);
+
+        let biographer = Biographer::new(
+            std::sync::Arc::clone(&self.gallifrey),
+            self.chronos.vortex(),
+            model_handle,
+        );
+
+        match biographer.biography(&entity_name).await {
+            Ok(bio) => println!("\n{bio}\n"),
+            Err(e) => println!("Failed to generate biography: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    async fn handle_sonic(&self, command: &str, args: &[String]) {
+        if args.is_empty() {
+            println!("Usage: sonic <file> | sonic repair <file> | sonic diagnose");
+            return;
+        }
+
+        let loaded_models = self.chronos.vortex().list_loaded_models();
+        let model_handle = loaded_models.first().map(|(h, _)| *h);
+
+        let screwdriver = SonicScrewdriver::new(
+            self.telemetry_store.clone(),
+            Some(std::sync::Arc::clone(&self.gallifrey)),
+            Some(self.chronos.vortex()),
+            model_handle,
+        );
+
+        if args[0] == "diagnose" {
+            println!("{}", screwdriver.buzz());
+            match screwdriver.diagnose().await {
+                Ok(report) => println!("{report}"),
+                Err(e) => println!("Diagnosis failed: {e}"),
+            }
+            return;
+        }
+
+        let path = std::path::Path::new(&args[args.len() - 1]);
+
+        let repair =
+            command == "fix" || (args.len() > 1 && (args[0] == "repair" || args[0] == "fix"));
+
+        let result = if repair {
+            screwdriver.repair(path)
+        } else {
+            screwdriver.inspect(path)
+        };
+
+        match result {
+            Ok(report) => println!("{report}"),
+            Err(e) => println!("Sonic Screwdriver error: {e}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    async fn handle_curiosity(&self) {
+        let loaded_models = self.chronos.vortex().list_loaded_models();
+        if let Some((handle, _)) = loaded_models.first() {
+            let curiosity = Curiosity::new(
+                std::sync::Arc::clone(&self.gallifrey),
+                self.chronos.vortex(),
+                *handle,
+            );
+
+            println!("🤔 Curiosity is scanning...");
+            match curiosity.ask().await {
+                Ok(question) => println!("{question}"),
+                Err(e) => println!("Curiosity failed: {e}"),
+            }
+        } else {
+            println!("Curiosity needs a loaded model. Use 'models load <path>'.");
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    async fn handle_capsule(&self, args: &[String]) {
+        if args.len() < 2 {
+            println!("Usage: capsule capture <entity> <file> [depth] | capsule restore <file>");
+            return;
+        }
+
+        let subcommand = &args[0];
+        match subcommand.as_str() {
+            "capture" => {
+                if args.len() < 3 {
+                    println!("Usage: capsule capture <entity> <file> [depth]");
+                    return;
+                }
+                let entity_name = &args[1];
+                let file_path = &args[2];
+                let depth = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1);
+
+                match TimeCapsule::capture(&self.gallifrey, entity_name, depth) {
+                    Ok(capsule) => match capsule.save_to_file(file_path) {
+                        Ok(()) => println!(
+                            "Captured {} entities and {} relationships to {}",
+                            capsule.entities.len(),
+                            capsule.relationships.len(),
+                            file_path
+                        ),
+                        Err(e) => println!("Failed to save capsule: {e}"),
+                    },
+                    Err(e) => println!("Failed to capture capsule: {e}"),
+                }
+            }
+            "restore" => {
+                let file_path = &args[1];
+                match TimeCapsule::load_from_file(file_path) {
+                    Ok(capsule) => {
+                        let count = capsule.entities.len();
+                        match capsule.restore(&self.gallifrey).await {
+                            Ok(()) => {
+                                println!("Restored {count} entities from {file_path}");
+                            }
+                            Err(e) => println!("Failed to restore capsule: {e}"),
+                        }
+                    }
+                    Err(e) => println!("Failed to load capsule: {e}"),
+                }
+            }
+            _ => println!("Unknown capsule command: {subcommand}"),
+        }
     }
 }


### PR DESCRIPTION
🚮 Smell: `handle_builtin` in `shell/src/repl.rs` was a "God Function" with a large `match` statement handling many commands, leading to `#[allow(clippy::too_many_lines)]`.
✨ Solution: Extracted command handling logic into private helper methods (e.g., `handle_history`, `handle_sonic`, `handle_capsule`).
🧼 Benefit: Reduces cognitive load, improves readability, and makes the code more modular. Removes the need for the clippy suppression.
🛡️ Verification: `cargo check` and `cargo test -p tardis-shell` passed. No logic changes.

---
*PR created automatically by Jules for task [6842259146040412134](https://jules.google.com/task/6842259146040412134) started by @madmax983*