### PR TITLE
🔒 Warden: Fix DoS vulnerability in Sonic Screwdriver (capped reader)

### DIFF
--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -24,7 +24,7 @@ pub struct Curiosity {
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub fn new(
+    pub const fn new(
         gallifrey: Arc<Gallifrey>,
         vortex: Arc<Vortex>,
         model: ModelHandle,

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -155,7 +155,7 @@ pub struct Chronos {
 impl Chronos {
     /// Create a new Chronos instance.
     #[must_use]
-    pub fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
         Self {
             vortex,
             gallifrey,

--- a/gallifrey/src/error.rs
+++ b/gallifrey/src/error.rs
@@ -63,7 +63,7 @@ impl From<GallifreyError> for tardis_common::Error {
             GallifreyError::QueryParseError(msg) => Self::QueryParseError(msg),
             GallifreyError::QueryExecutionFailed(msg) => Self::QueryExecutionFailed(msg),
             GallifreyError::EntityNotFound(msg) => Self::EntityNotFound(msg),
-            GallifreyError::EntityAlreadyExists(msg) => Self::Internal(format!("Entity already exists: {}", msg)),
+            GallifreyError::EntityAlreadyExists(msg) => Self::Internal(format!("Entity already exists: {msg}")),
             GallifreyError::InvalidTemporalReference(msg) => Self::InvalidTemporalReference(msg),
             GallifreyError::TimeTravelFailed(msg) => Self::TimeTravelFailed { reason: msg },
             GallifreyError::Serialization(e) => Self::Serialization(e),

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use serde_json::Value;
 use std::fmt::Write as _;
 use std::fs;
+use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
 use tardis_chronos::experimental::doctor::{HealthStatus, SystemDoctor};
@@ -16,6 +17,8 @@ use tardis_chronos::experimental::psychic_paper::{Intent, PsychicPaper};
 use tardis_gallifrey::Gallifrey;
 use tardis_telemetry::gallifrey::TelemetryStore;
 use tardis_vortex::{ModelHandle, Vortex};
+
+const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 
 /// The Sonic Screwdriver.
 #[derive(Debug, Default)]
@@ -117,14 +120,32 @@ impl SonicScrewdriver {
         "🔊 *Whirrrrrr-buzz-click-whirrrrrr*".to_string()
     }
 
+    fn read_file_capped(path: &Path) -> Result<String> {
+        let file = fs::File::open(path)
+            .with_context(|| format!("Failed to open file: {}", path.display()))?;
+
+        let mut content = String::new();
+        // Read limit + 1 to detect truncation
+        let limit = MAX_FILE_SIZE;
+        let mut handle = file.take(limit + 1);
+        handle
+            .read_to_string(&mut content)
+            .with_context(|| format!("Failed to read file: {}", path.display()))?;
+
+        if content.len() as u64 > limit {
+            anyhow::bail!("File too large (limit: {limit} bytes)");
+        }
+
+        Ok(content)
+    }
+
     /// Inspect a file and return a diagnosis.
     ///
     /// # Errors
     ///
     /// Returns an error if the file cannot be read.
     pub fn inspect(&self, path: &Path) -> Result<String> {
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("Failed to read file: {}", path.display()))?;
+        let content = Self::read_file_capped(path)?;
 
         let size = content.len();
         let lines = content.lines().count();
@@ -176,8 +197,7 @@ impl SonicScrewdriver {
     ///
     /// Returns an error if the file cannot be read or written.
     pub fn repair(&self, path: &Path) -> Result<String> {
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("Failed to read file: {}", path.display()))?;
+        let content = Self::read_file_capped(path)?;
 
         // Create backup
         let backup_path = path.with_extension("bak");
@@ -328,5 +348,37 @@ mod tests {
         // Verify report contains AI diagnosis
         assert!(report.contains("AI Diagnosis: Capacitor fluxing"));
         assert!(report.contains("Status: DEGRADED"));
+    }
+
+    #[test]
+    fn test_file_too_large() {
+        // Create a file slightly larger than 10MB
+        let limit = 10 * 1024 * 1024;
+        let size = limit + 10;
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("sonic_large_{}.tmp", nanos));
+
+        // Create sparse file
+        {
+            let file = File::create(&path).unwrap();
+            file.set_len(size as u64).unwrap();
+        }
+
+        let sonic = SonicScrewdriver::new(None, None, None, None);
+
+        // Attempt to inspect
+        let result = sonic.inspect(&path);
+
+        // Clean up
+        let _ = fs::remove_file(&path);
+
+        // Should fail due to size limit
+        assert!(result.is_err(), "Should return error for large file");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("File too large"), "Error should mention file size. Got: {}", err);
     }
 }


### PR DESCRIPTION
🔒 Warden: Fix potential DoS vulnerability in Sonic Screwdriver

🦠 Threat: The `inspect` and `repair` methods in `SonicScrewdriver` used `fs::read_to_string` on user-provided paths without size limits. This allowed a malicious or accidental input of a massive file (e.g., `/dev/zero` or a large log) to exhaust system memory (OOM), crashing the shell.

🛡️ Defense: Implemented a "Capped Reader" pattern using `File::take(MAX_FILE_SIZE)` where `MAX_FILE_SIZE` is 10MB. If a file exceeds this limit, the operation is aborted with a clear error message. This prevents unbounded memory allocation.

💥 Severity: High (DoS vector in a user-facing tool).

🧪 Verification: Added `test_file_too_large` in `shell/src/experimental/sonic.rs` which creates a >10MB file and asserts that `inspect` returns an error. The test passes.

Also addressed minor clippy lints in `gallifrey` (format string) and `chronos` (const fn).

---
*PR created automatically by Jules for task [15406271969617844956](https://jules.google.com/task/15406271969617844956) started by @madmax983*