### PR TITLE
🌟 Nova: Universal Translator

### DIFF
--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -24,11 +24,7 @@ pub struct Curiosity {
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub fn new(
-        gallifrey: Arc<Gallifrey>,
-        vortex: Arc<Vortex>,
-        model: ModelHandle,
-    ) -> Self {
+    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,
@@ -50,27 +46,35 @@ impl Curiosity {
         // Scan history to find a sparse entity
         // Heuristic: Has fewer than 3 properties and is not a "System" type
         // We stop at the first one we find for now (MVP).
-        self.gallifrey.knowledge().scan_history(|history| {
-            if target_entity.is_some() {
-                return;
-            }
-
-            // Look at the latest version of the entity
-            if let Some(latest) = history.last() {
-                if latest.properties.len() < 3
-                   && latest.entity_type != "System"
-                   && !latest.name.is_empty()
-                {
-                    target_entity = Some(latest.clone());
+        self.gallifrey
+            .knowledge()
+            .scan_history(|history| {
+                if target_entity.is_some() {
+                    return;
                 }
-            }
-        }).map_err(|e| crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+
+                // Look at the latest version of the entity
+                if let Some(latest) = history.last() {
+                    if latest.properties.len() < 3
+                        && latest.entity_type != "System"
+                        && !latest.name.is_empty()
+                    {
+                        target_entity = Some(latest.clone());
+                    }
+                }
+            })
+            .map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            })?;
 
         let Some(entity) = target_entity else {
             return Ok("I am content. My knowledge base feels complete... for now.".to_string());
         };
 
-        info!("Curiosity: Found gap in entity '{}' ({})", entity.name, entity.entity_type);
+        info!(
+            "Curiosity: Found gap in entity '{}' ({})",
+            entity.name, entity.entity_type
+        );
 
         // Construct prompt
         let prompt = format!(
@@ -88,7 +92,11 @@ impl Curiosity {
 
         let question = self.vortex.infer(self.model, &prompt, params).await?;
 
-        Ok(format!("🤔 Regarding '{}': {}", entity.name, question.trim()))
+        Ok(format!(
+            "🤔 Regarding '{}': {}",
+            entity.name,
+            question.trim()
+        ))
     }
 }
 
@@ -127,12 +135,15 @@ mod tests {
         let mock_handle = ModelHandle::new(1);
         vortex.set_mock_load_model(Box::new(move |_, _| Ok(mock_handle)));
 
-        vortex.set_mock_inference(Box::new(|_, _, _| {
-            Ok("What is inside the box?".to_string())
-        }));
+        vortex.set_mock_inference(Box::new(
+            |_, _, _| Ok("What is inside the box?".to_string()),
+        ));
 
         // Load dummy model to register handle
-        let handle = vortex.load_model("dummy", ModelLoadConfig::default()).await.unwrap();
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
 
         let curiosity = Curiosity::new(gallifrey, vortex, handle);
 
@@ -151,7 +162,10 @@ mod tests {
 
         // Register dummy model
         vortex.set_mock_load_model(Box::new(move |_, _| Ok(ModelHandle::new(1))));
-        let handle = vortex.load_model("dummy", ModelLoadConfig::default()).await.unwrap();
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
 
         let curiosity = Curiosity::new(gallifrey, vortex, handle);
 

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -22,3 +22,7 @@ pub mod doctor;
 
 #[cfg(feature = "nova")]
 pub mod curiosity;
+
+#[cfg(feature = "nova")]
+/// The Universal Translator.
+pub mod translator;

--- a/chronos/src/experimental/translator.rs
+++ b/chronos/src/experimental/translator.rs
@@ -1,0 +1,68 @@
+use crate::ChronosResult;
+use std::sync::Arc;
+use tardis_vortex::model::ModelHandle;
+use tardis_vortex::{InferenceParams, Vortex};
+
+/// The Universal Translator uses Vortex to translate text into different languages or personas.
+#[derive(Debug)]
+pub struct UniversalTranslator {
+    vortex: Arc<Vortex>,
+    model: ModelHandle,
+}
+
+impl UniversalTranslator {
+    /// Create a new translator.
+    #[must_use]
+    pub fn new(vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+        Self { vortex, model }
+    }
+
+    /// Translate text to a target language or persona.
+    ///
+    /// The target can be a real language (e.g., "French") or a fictional style (e.g., "Yoda", "Shakespeare").
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if inference fails.
+    pub async fn translate(&self, text: &str, target: &str) -> ChronosResult<String> {
+        let prompt = format!(
+            "Translate the following text to {target}. If the target is a style or persona, rewrite it in that style.\n\nText: \"{text}\"\n\nTranslation:"
+        );
+
+        let params = InferenceParams::creative()
+            .with_max_tokens(256)
+            .with_temperature(0.7);
+
+        self.vortex
+            .infer(self.model, &prompt, params)
+            .await
+            .map_err(crate::ChronosError::Vortex)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tardis_vortex::Vortex;
+
+    #[tokio::test]
+    async fn test_translator() {
+        let vortex = Arc::new(Vortex::new().unwrap());
+        let handle = ModelHandle::new(999);
+
+        // Set up mock inference
+        vortex.set_mock_inference(Box::new(|_, prompt, _| {
+            if prompt.contains("Translate the following text to Yoda") {
+                Ok("Do or do not, there is no try.".to_string())
+            } else {
+                Ok("Unknown".to_string())
+            }
+        }));
+
+        let translator = UniversalTranslator::new(vortex, handle);
+        let result = translator.translate("Try to do it", "Yoda").await.unwrap();
+
+        assert_eq!(result, "Do or do not, there is no try.");
+    }
+}

--- a/common/src/temporal.rs
+++ b/common/src/temporal.rs
@@ -161,7 +161,8 @@ impl BiTemporalInterval {
     /// to avoid repeated calls to `Utc::now()`.
     #[must_use]
     pub fn is_current_relative_to(&self, now: DateTime<Utc>) -> bool {
-        self.valid_time.is_current_relative_to(now) && self.transaction_time.is_current_relative_to(now)
+        self.valid_time.is_current_relative_to(now)
+            && self.transaction_time.is_current_relative_to(now)
     }
 
     /// Close the transaction time (mark as superseded).

--- a/gallifrey/src/error.rs
+++ b/gallifrey/src/error.rs
@@ -63,7 +63,9 @@ impl From<GallifreyError> for tardis_common::Error {
             GallifreyError::QueryParseError(msg) => Self::QueryParseError(msg),
             GallifreyError::QueryExecutionFailed(msg) => Self::QueryExecutionFailed(msg),
             GallifreyError::EntityNotFound(msg) => Self::EntityNotFound(msg),
-            GallifreyError::EntityAlreadyExists(msg) => Self::Internal(format!("Entity already exists: {}", msg)),
+            GallifreyError::EntityAlreadyExists(msg) => {
+                Self::Internal(format!("Entity already exists: {}", msg))
+            }
             GallifreyError::InvalidTemporalReference(msg) => Self::InvalidTemporalReference(msg),
             GallifreyError::TimeTravelFailed(msg) => Self::TimeTravelFailed { reason: msg },
             GallifreyError::Serialization(e) => Self::Serialization(e),

--- a/gallifrey/src/experimental/mod.rs
+++ b/gallifrey/src/experimental/mod.rs
@@ -12,7 +12,7 @@ pub mod heatmap;
 /// System entropy and stability metrics.
 pub mod entropy;
 
-/// Timeline simulation for "What-If" scenarios.
-pub mod timeline;
 /// Time Capsule for knowledge graph export/import.
 pub mod time_capsule;
+/// Timeline simulation for "What-If" scenarios.
+pub mod timeline;

--- a/gallifrey/tests/blind_insert_repro.rs
+++ b/gallifrey/tests/blind_insert_repro.rs
@@ -30,7 +30,9 @@ fn test_blind_insert_fails_if_exists() {
     };
 
     // 1. Insert first entity
-    store.insert_entity(e1).expect("First insert should succeed");
+    store
+        .insert_entity(e1)
+        .expect("First insert should succeed");
 
     // 2. Insert second entity - SHOULD FAIL with EntityAlreadyExists
     let result = store.insert_entity(e2);
@@ -38,10 +40,12 @@ fn test_blind_insert_fails_if_exists() {
     match result {
         Err(GallifreyError::EntityAlreadyExists(_)) => {
             // Success! The fix is working.
-        },
+        }
         Ok(_) => {
-            panic!("Blind insert succeeded! This creates data corruption (multiple current versions).");
-        },
+            panic!(
+                "Blind insert succeeded! This creates data corruption (multiple current versions)."
+            );
+        }
         Err(e) => {
             panic!("Unexpected error: {:?}", e);
         }
@@ -49,5 +53,9 @@ fn test_blind_insert_fails_if_exists() {
 
     // 3. Verify no corruption (still only 1 entity in history)
     let history = store.get_entity_history(id).unwrap();
-    assert_eq!(history.len(), 1, "Should only have 1 version if insert failed");
+    assert_eq!(
+        history.len(),
+        1,
+        "Should only have 1 version if insert failed"
+    );
 }

--- a/gallifrey/tests/future_entity_retrieval.rs
+++ b/gallifrey/tests/future_entity_retrieval.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    use tardis_gallifrey::{KnowledgeStore, BiTemporalInterval, TimeRange};
-    use tardis_gallifrey::domain::Entity;
-    use tardis_common::id::EntityId;
-    use chrono::{Utc, Duration};
+    use chrono::{Duration, Utc};
     use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_gallifrey::domain::Entity;
+    use tardis_gallifrey::{BiTemporalInterval, KnowledgeStore, TimeRange};
 
     #[test]
     fn get_entity_should_not_return_future_entity() {
@@ -51,6 +51,9 @@ mod tests {
         store.insert_entity(entity).expect("Insert failed");
 
         let results = store.find_by_type("FutureFact").expect("Find failed");
-        assert!(results.is_empty(), "find_by_type() returned a future entity!");
+        assert!(
+            results.is_empty(),
+            "find_by_type() returned a future entity!"
+        );
     }
 }

--- a/shell/src/experimental/biographer.rs
+++ b/shell/src/experimental/biographer.rs
@@ -6,7 +6,7 @@
 use std::fmt::Write;
 use std::sync::Arc;
 use tardis_gallifrey::Gallifrey;
-use tardis_vortex::{Vortex, ModelHandle, InferenceParams};
+use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
 
 /// The Biographer engine.
 #[derive(Debug)]
@@ -73,7 +73,11 @@ impl Biographer {
 
             // Format time range nicely
             let time_str = match valid_to {
-                Some(end) => format!("From {} to {}", valid_from.format("%Y-%m-%d %H:%M"), end.format("%Y-%m-%d %H:%M")),
+                Some(end) => format!(
+                    "From {} to {}",
+                    valid_from.format("%Y-%m-%d %H:%M"),
+                    end.format("%Y-%m-%d %H:%M")
+                ),
                 None => format!("From {} onwards", valid_from.format("%Y-%m-%d %H:%M")),
             };
 
@@ -108,10 +112,10 @@ impl Biographer {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use tardis_gallifrey::domain::Entity;
+    use std::collections::HashMap;
     use tardis_common::id::EntityId;
     use tardis_common::temporal::BiTemporalInterval;
-    use std::collections::HashMap;
+    use tardis_gallifrey::domain::Entity;
 
     #[tokio::test]
     async fn test_biography_generation() {
@@ -121,21 +125,24 @@ mod tests {
 
         // Mock inference
         vortex.set_mock_inference(Box::new(|_, prompt, _| {
-            Ok(format!("Mock biography based on prompt length: {}", prompt.len()))
+            Ok(format!(
+                "Mock biography based on prompt length: {}",
+                prompt.len()
+            ))
         }));
 
         // Mock load model to fail gracefully if we try (but we pass None for model handle)
         vortex.set_mock_load_model(Box::new(|_, _| {
-             Err(tardis_vortex::VortexError::ModelNotFound { path: "dummy".into() })
+            Err(tardis_vortex::VortexError::ModelNotFound {
+                path: "dummy".into(),
+            })
         }));
 
         let entity = Entity {
             id: EntityId::new(),
             entity_type: "Person".to_string(),
             name: "The Doctor".to_string(),
-            properties: HashMap::from([
-                ("status".to_string(), serde_json::json!("Exiled"))
-            ]),
+            properties: HashMap::from([("status".to_string(), serde_json::json!("Exiled"))]),
             embedding: None,
             temporal: BiTemporalInterval::now(),
             source: None,

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -290,10 +290,7 @@ mod tests {
 
         // Load a "dummy" model to get a valid handle in registry
         let handle = vortex
-            .load_model(
-                "/dummy/model",
-                tardis_vortex::ModelLoadConfig::default(),
-            )
+            .load_model("/dummy/model", tardis_vortex::ModelLoadConfig::default())
             .await
             .unwrap();
 
@@ -316,12 +313,8 @@ mod tests {
         telemetry.record_event(error_event).await.unwrap();
 
         // Run Sonic Screwdriver
-        let sonic = SonicScrewdriver::new(
-            Some(telemetry),
-            Some(gallifrey),
-            Some(vortex),
-            Some(handle),
-        );
+        let sonic =
+            SonicScrewdriver::new(Some(telemetry), Some(gallifrey), Some(vortex), Some(handle));
 
         let report = sonic.diagnose().await.unwrap();
 

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -13,17 +13,19 @@ use tardis_telemetry::gallifrey::TelemetryStore;
 use tracing::{error, info};
 
 #[cfg(feature = "nova")]
-use crate::experimental::chronograph::ChronoGraph;
-#[cfg(feature = "nova")]
 use crate::experimental::biographer::Biographer;
+#[cfg(feature = "nova")]
+use crate::experimental::chronograph::ChronoGraph;
 #[cfg(feature = "nova")]
 use crate::experimental::heatmap_cmd;
 #[cfg(feature = "nova")]
 use crate::experimental::sonic::SonicScrewdriver;
 #[cfg(feature = "nova")]
+use tardis_chronos::experimental::curiosity::Curiosity;
+#[cfg(feature = "nova")]
 use tardis_chronos::experimental::prophecy::Prophet;
 #[cfg(feature = "nova")]
-use tardis_chronos::experimental::curiosity::Curiosity;
+use tardis_chronos::experimental::translator::UniversalTranslator;
 #[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
 
@@ -228,12 +230,10 @@ impl Repl {
                 }
             }
             #[cfg(feature = "nova")]
-            "heatmap" => {
-                match heatmap_cmd::run(&self.gallifrey, args) {
-                    Ok(report) => println!("{report}"),
-                    Err(e) => println!("Failed to generate heatmap: {e}"),
-                }
-            }
+            "heatmap" => match heatmap_cmd::run(&self.gallifrey, args) {
+                Ok(report) => println!("{report}"),
+                Err(e) => println!("Failed to generate heatmap: {e}"),
+            },
             #[cfg(feature = "nova")]
             "biography" | "bio" => {
                 if args.is_empty() {
@@ -299,6 +299,34 @@ impl Repl {
                 match result {
                     Ok(report) => println!("{report}"),
                     Err(e) => println!("Sonic Screwdriver error: {e}"),
+                }
+            }
+            #[cfg(feature = "nova")]
+            "translate" => {
+                if args.is_empty() {
+                    println!("Usage: translate <text> [to <target>]");
+                    return;
+                }
+
+                let loaded_models = self.chronos.vortex().list_loaded_models();
+                if let Some((handle, _)) = loaded_models.first() {
+                    let text_input = args.join(" ");
+                    let (text, target) = if let Some(idx) = text_input.to_lowercase().rfind(" to ")
+                    {
+                        let (content, lang) = text_input.split_at(idx);
+                        (content, lang[4..].trim())
+                    } else {
+                        (text_input.as_str(), "Standard English")
+                    };
+
+                    let translator = UniversalTranslator::new(self.chronos.vortex(), *handle);
+
+                    match translator.translate(text, target).await {
+                        Ok(translation) => println!("\n{translation}\n"),
+                        Err(e) => println!("Translation failed: {e}"),
+                    }
+                } else {
+                    println!("Translation needs a loaded model. Use 'models load <path>'.");
                 }
             }
             #[cfg(feature = "nova")]


### PR DESCRIPTION
Implemented the Universal Translator feature as part of the Nova experimental suite.
This feature allows users to translate or rewrite text into different languages or personas using the Vortex LLM.
It is accessed via the `translate` command in the shell (e.g., `translate "Hello" to "Yoda"`).
The implementation is isolated in `chronos/src/experimental/translator.rs` and integrated into the shell REPL.
Tests verify the prompt construction and mock inference response.


---
*PR created automatically by Jules for task [12870497585852756207](https://jules.google.com/task/12870497585852756207) started by @madmax983*