### PR TITLE
⚒️ Forge: Refactor `chronos` analyzer and `TemporalReference` formatting

### DIFF
--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -9,7 +9,6 @@
 
 use crate::error::ChronosResult;
 use chrono::{DateTime, Duration, Utc};
-use std::fmt::Write;
 use tardis_common::temporal::TemporalReference;
 
 /// Analyzed query with extracted metadata.
@@ -194,40 +193,33 @@ pub fn analyze_at(query: &str, now: DateTime<Utc>) -> ChronosResult<AnalyzedQuer
 
 /// Classify the intent of a query.
 fn classify_intent(query_lower: &str) -> QueryIntent {
-    for rule in INTENT_RULES {
-        if rule.matches(query_lower) {
-            return rule.intent.clone();
-        }
-    }
-
-    if query_lower.ends_with('?') {
-        return QueryIntent::Question;
-    }
-
-    QueryIntent::Chat
+    INTENT_RULES.iter().find(|rule| rule.matches(query_lower)).map_or_else(
+        || {
+            if query_lower.ends_with('?') {
+                QueryIntent::Question
+            } else {
+                QueryIntent::Chat
+            }
+        },
+        |rule| rule.intent.clone(),
+    )
 }
 
 /// Extract temporal references from a query.
 fn extract_temporal_refs(query_lower: &str, now: DateTime<Utc>) -> Vec<TemporalReference> {
-    let mut refs = Vec::new();
-
-    for rule in TEMPORAL_RULES {
-        if query_lower.contains(rule.keyword) {
-            let resolved = rule.resolve(now);
-
-            refs.push(TemporalReference::Relative {
-                text: rule.keyword.to_string(),
-                resolved,
-            });
-        }
-    }
-
     // TODO: Add more sophisticated temporal extraction
     // - NLP-based extraction
     // - Absolute date parsing
     // - Event-based references
 
-    refs
+    TEMPORAL_RULES
+        .iter()
+        .filter(|rule| query_lower.contains(rule.keyword))
+        .map(|rule| TemporalReference::Relative {
+            text: rule.keyword.to_string(),
+            resolved: rule.resolve(now),
+        })
+        .collect()
 }
 
 /// Extract entity mentions from a query.
@@ -244,31 +236,10 @@ fn describe_temporal_context(refs: &[TemporalReference]) -> String {
         return "current time".to_string();
     }
 
-    let mut result = String::new();
-    for (i, r) in refs.iter().enumerate() {
-        if i > 0 {
-            result.push_str(", ");
-        }
-        match r {
-            TemporalReference::Relative { text, resolved } => {
-                let _ = write!(result, "{} ({})", text, resolved.format("%Y-%m-%d"));
-            }
-            TemporalReference::Absolute(resolved) => {
-                let _ = write!(result, "{}", resolved.format("%Y-%m-%d"));
-            }
-            TemporalReference::EventBased { event, resolved } => {
-                if let Some(res) = resolved {
-                    let _ = write!(result, "{} ({})", event, res.format("%Y-%m-%d"));
-                } else {
-                    result.push_str(event);
-                }
-            }
-            TemporalReference::Implicit => {
-                result.push_str("implicit");
-            }
-        }
-    }
-    result
+    refs.iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[cfg(test)]

--- a/common/src/temporal.rs
+++ b/common/src/temporal.rs
@@ -342,6 +342,27 @@ impl TemporalReference {
     }
 }
 
+impl std::fmt::Display for TemporalReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Relative { text, resolved } => {
+                write!(f, "{} ({})", text, resolved.format("%Y-%m-%d"))
+            }
+            Self::Absolute(resolved) => {
+                write!(f, "{}", resolved.format("%Y-%m-%d"))
+            }
+            Self::EventBased { event, resolved } => {
+                if let Some(res) = resolved {
+                    write!(f, "{} ({})", event, res.format("%Y-%m-%d"))
+                } else {
+                    write!(f, "{event}")
+                }
+            }
+            Self::Implicit => write!(f, "implicit"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -466,6 +487,37 @@ mod tests {
 
         // Implicit returns current time, so we just check it returns Some
         assert!(TemporalReference::Implicit.resolved().is_some());
+    }
+
+    #[test]
+    fn temporal_reference_display() {
+        let now = DateTime::parse_from_rfc3339("2024-03-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let rel = TemporalReference::Relative {
+            text: "yesterday".into(),
+            resolved: now,
+        };
+        assert_eq!(rel.to_string(), "yesterday (2024-03-15)");
+
+        let abs = TemporalReference::Absolute(now);
+        assert_eq!(abs.to_string(), "2024-03-15");
+
+        let event = TemporalReference::EventBased {
+            event: "launch".into(),
+            resolved: Some(now),
+        };
+        assert_eq!(event.to_string(), "launch (2024-03-15)");
+
+        let event_unresolved = TemporalReference::EventBased {
+            event: "launch".into(),
+            resolved: None,
+        };
+        assert_eq!(event_unresolved.to_string(), "launch");
+
+        let implicit = TemporalReference::Implicit;
+        assert_eq!(implicit.to_string(), "implicit");
     }
 
     #[test]


### PR DESCRIPTION
This PR refactors `chronos::pipeline::analyzer` and `tardis-common::temporal` to improve readability and idiomatic Rust usage.

**Changes:**
1.  **`tardis-common`**: Implemented `std::fmt::Display` for `TemporalReference`. This moves the string representation logic from the consumer (`chronos`) to the type definition, adhering to the principle "Types are documentation".
2.  **`tardis-chronos`**:
    *   Replaced the manual `for` loop in `classify_intent` with a functional iterator chain using `find` and `map_or_else`.
    *   Replaced the manual `for` loop in `extract_temporal_refs` with a functional iterator chain (`filter`, `map`, `collect`).
    *   Simplified `describe_temporal_context` to leverage the new `Display` implementation and `join`, removing the need for `std::fmt::Write`.

**Verification:**
*   `cargo test -p tardis-chronos -p tardis-common` passed.
*   `cargo clippy -p tardis-chronos -p tardis-common` passed.
*   No logic changes; strict refactor.

---
*PR created automatically by Jules for task [16902124205153950936](https://jules.google.com/task/16902124205153950936) started by @madmax983*