### PR TITLE
feat: The Weaver - Narrative Connection Generator

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -38,3 +38,8 @@
 **Concept:** A copy-on-write overlay that allows "What-If" scenarios on the Knowledge Graph without corrupting the main timeline.
 **Fate:** Merged (Experimental)
 **Lesson:** Bi-temporal data is great for history, but for hypothetical futures, we need a lightweight branching mechanism that doesn't persist until committed.
+
+## The Weaver
+**Concept:** A generative module that finds and fabricates narrative connections between two disconnected entities using LLM hallucination.
+**Fate:** In Progress (Experimental)
+**Lesson:** Sometimes the most valuable insights come from forcing connections where none exist. It mimics "lateral thinking."

--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -24,7 +24,7 @@ pub struct Curiosity {
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,

--- a/chronos/src/experimental/fugue.rs
+++ b/chronos/src/experimental/fugue.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
+use std::fmt::Write;
 use std::sync::Arc;
 use tardis_common::id::ModelHandle;
 use tardis_gallifrey::domain::Entity;
@@ -109,8 +110,13 @@ impl Fugue {
 
         let mut context_str = String::new();
         for entity in &context_entities {
-            context_str.push_str(&format!("- {} ({}): {}\n", entity.name, entity.entity_type,
-                serde_json::to_string(&entity.properties).unwrap_or_default()));
+            let _ = writeln!(
+                context_str,
+                "- {} ({}): {}",
+                entity.name,
+                entity.entity_type,
+                serde_json::to_string(&entity.properties).unwrap_or_default()
+            );
         }
 
         if context_str.is_empty() {
@@ -118,12 +124,11 @@ impl Fugue {
         }
 
         let prompt = format!(
-            "SYSTEM STATE at {}:\n{}\n\nHYPOTHETICAL SCENARIO: {}\n\nTASK: Simulate the consequences of this scenario over the next {}. \
+            "SYSTEM STATE at {divergence_time}:\n{context_str}\n\nHYPOTHETICAL SCENARIO: {counterfactual}\n\nTASK: Simulate the consequences of this scenario over the next {horizon_desc}. \
             Return a JSON object with two fields:\n\
             1. 'narrative': A short paragraph summarizing the timeline.\n\
             2. 'events': A list of objects, each having 'time_offset' (string) and 'description' (string).\n\
-            Output ONLY JSON.",
-            divergence_time, context_str, counterfactual, horizon_desc
+            Output ONLY JSON."
         );
 
         // 4. Inference

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -16,3 +16,6 @@ pub mod curiosity;
 
 #[cfg(feature = "nova")]
 pub mod fugue;
+
+#[cfg(feature = "nova")]
+pub mod weaver;

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -1,0 +1,277 @@
+//! The Weaver: A Narrative Connection Generator.
+//!
+//! "We are all connected. Sometimes you just have to look hard enough."
+//!
+//! This module uses Vortex inference to hallucinate plausible narrative connections
+//! between two arbitrary entities in the knowledge graph.
+
+use crate::error::{ChronosError, ChronosResult};
+use crate::experimental::psychic_paper::{Intent, PsychicPaper};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+use tardis_common::id::ModelHandle;
+use tardis_gallifrey::domain::Entity;
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::{InferenceParams, Vortex};
+use tracing::{info, instrument};
+
+/// A step in the woven narrative.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WeaveStep {
+    /// Description of the connection step.
+    pub description: String,
+    /// Name of an entity involved in this step (existing or hypothetical).
+    pub entity_name: Option<String>,
+    /// Type of relationship implied (e.g., "created", "met", "destroyed").
+    pub relationship: Option<String>,
+}
+
+/// The result of a Weave operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WeaveResult {
+    /// A coherent story connecting the two entities.
+    pub narrative: String,
+    /// Structured steps of the connection.
+    pub steps: Vec<WeaveStep>,
+}
+
+/// The Weaver engine.
+#[derive(Debug)]
+pub struct Weaver {
+    vortex: Arc<Vortex>,
+    gallifrey: Arc<Gallifrey>,
+    paper: PsychicPaper,
+}
+
+impl Weaver {
+    /// Create a new Weaver engine.
+    #[must_use]
+    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+        Self {
+            vortex,
+            gallifrey,
+            paper: PsychicPaper::new(),
+        }
+    }
+
+    /// Find an entity by name (case-insensitive, exact match).
+    ///
+    /// This performs a linear scan of the knowledge base, which is inefficient
+    /// but acceptable for this experimental feature.
+    fn find_entity_by_name(&self, name: &str) -> Option<Entity> {
+        let name_lower = name.to_lowercase();
+        let result = std::sync::Mutex::new(None);
+        let now = Utc::now();
+
+        // We accept the inefficiency for the sake of "The Spark"
+        let _ = self.gallifrey.knowledge().scan_history(|history| {
+            // Check if we already found it
+            if let Ok(guard) = result.lock() {
+                if guard.is_some() {
+                    return;
+                }
+            }
+
+            // Find the currently active version of the entity
+            if let Some(entity) = history
+                .iter()
+                .find(|e| e.temporal.active_at(now, now))
+            {
+                if entity.name.to_lowercase() == name_lower {
+                    if let Ok(mut guard) = result.lock() {
+                        *guard = Some(entity.clone());
+                    }
+                }
+            }
+        });
+
+        result.into_inner().unwrap_or(None)
+    }
+
+    /// Weave a narrative connection between two entities.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if entities are not found or inference fails.
+    #[instrument(skip(self))]
+    pub async fn weave(
+        &self,
+        source_name: &str,
+        target_name: &str,
+        model: ModelHandle,
+    ) -> ChronosResult<WeaveResult> {
+        info!("Weaving connection between '{}' and '{}'", source_name, target_name);
+
+        let source = self
+            .find_entity_by_name(source_name)
+            .ok_or_else(|| {
+                ChronosError::Common(tardis_common::Error::EntityNotFound(format!(
+                    "Entity '{source_name}'"
+                )))
+            })?;
+
+        let target = self
+            .find_entity_by_name(target_name)
+            .ok_or_else(|| {
+                ChronosError::Common(tardis_common::Error::EntityNotFound(format!(
+                    "Entity '{target_name}'"
+                )))
+            })?;
+
+        // Construct context strings
+        let source_desc = format!(
+            "Name: {}\nType: {}\nProperties: {}",
+            source.name,
+            source.entity_type,
+            serde_json::to_string(&source.properties).unwrap_or_default()
+        );
+
+        let target_desc = format!(
+            "Name: {}\nType: {}\nProperties: {}",
+            target.name,
+            target.entity_type,
+            serde_json::to_string(&target.properties).unwrap_or_default()
+        );
+
+        let prompt = format!(
+            "TASK: Create a plausible, creative narrative connection between two seemingly unrelated entities in the system.\n\n\
+            ENTITY A:\n{source_desc}\n\n\
+            ENTITY B:\n{target_desc}\n\n\
+            INSTRUCTIONS:\n\
+            1. Invent a chain of events, shared history, or causal link that connects A to B.\n\
+            2. You may hypothesize intermediate entities or events.\n\
+            3. Be creative but logical within the context of the entity types.\n\
+            4. Return a JSON object with:\n\
+               - 'narrative': A short paragraph telling the story of the connection.\n\
+               - 'steps': A list of objects with 'description', 'entity_name' (optional), and 'relationship' (optional).\n\
+            Output ONLY JSON."
+        );
+
+        let response = self
+            .vortex
+            .infer(
+                model,
+                &prompt,
+                InferenceParams {
+                    max_tokens: 1024,
+                    temperature: 0.8, // High creativity
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+
+        let parsed = self
+            .paper
+            .interpret(&response, Intent::Json)
+            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e)))?;
+
+        let narrative = parsed
+            .get("narrative")
+            .and_then(Value::as_str)
+            .unwrap_or("The threads are tangled. No clear path found.")
+            .to_string();
+
+        let mut steps = Vec::new();
+        if let Some(arr) = parsed.get("steps").and_then(Value::as_array) {
+            for item in arr {
+                let description = item
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Unknown step")
+                    .to_string();
+                let entity_name = item.get("entity_name").and_then(Value::as_str).map(String::from);
+                let relationship = item.get("relationship").and_then(Value::as_str).map(String::from);
+                steps.push(WeaveStep {
+                    description,
+                    entity_name,
+                    relationship,
+                });
+            }
+        }
+
+        Ok(WeaveResult { narrative, steps })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::BiTemporalInterval;
+
+    #[tokio::test]
+    async fn test_weaver_connection() {
+        let vortex = Arc::new(Vortex::new().unwrap());
+
+        // Mock Inference
+        vortex.set_mock_inference(Box::new(|_, _, _| {
+            let response = json!({
+                "narrative": "The Doctor used the Sonic Screwdriver to fix the TARDIS.",
+                "steps": [
+                    {
+                        "description": "Doctor activates device",
+                        "entity_name": "Sonic Screwdriver",
+                        "relationship": "USES"
+                    },
+                    {
+                        "description": "Device repairs ship",
+                        "entity_name": "TARDIS",
+                        "relationship": "REPAIRS"
+                    }
+                ]
+            });
+            Ok(response.to_string())
+        }));
+
+        let gallifrey = Arc::new(Gallifrey::new());
+
+        // Insert Source
+        let source = Entity {
+            id: EntityId::new(),
+            entity_type: "Person".to_string(),
+            name: "The Doctor".to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval::now(),
+            source: None,
+        };
+        gallifrey.knowledge().insert_entity(source).unwrap();
+
+        // Insert Target
+        let target = Entity {
+            id: EntityId::new(),
+            entity_type: "Ship".to_string(),
+            name: "TARDIS".to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval::now(),
+            source: None,
+        };
+        gallifrey.knowledge().insert_entity(target).unwrap();
+
+        let weaver = Weaver::new(vortex, gallifrey);
+        let model = ModelHandle::new(1); // Dummy handle
+
+        let result = weaver.weave("The Doctor", "TARDIS", model).await.unwrap();
+
+        assert_eq!(result.narrative, "The Doctor used the Sonic Screwdriver to fix the TARDIS.");
+        assert_eq!(result.steps.len(), 2);
+        assert_eq!(result.steps[0].entity_name.as_deref(), Some("Sonic Screwdriver"));
+    }
+
+    #[tokio::test]
+    async fn test_weaver_missing_entity() {
+        let vortex = Arc::new(Vortex::new().unwrap());
+        let gallifrey = Arc::new(Gallifrey::new());
+        let weaver = Weaver::new(vortex, gallifrey);
+        let model = ModelHandle::new(1);
+
+        let result = weaver.weave("Ghost", "Shadow", model).await;
+        assert!(result.is_err());
+    }
+}

--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -179,16 +179,16 @@ pub fn analyze_at(query: &str, now: DateTime<Utc>) -> ChronosResult<AnalyzedQuer
         // Use a case-insensitive scan instead.
         let check_contains = |k: &str| contains_ignore_ascii_case(query, k);
         (
-            classify_intent(&check_contains, query.ends_with('?')),
-            extract_temporal_refs(&check_contains, now),
+            classify_intent(check_contains, query.ends_with('?')),
+            extract_temporal_refs(check_contains, now),
         )
     } else {
         // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
         let query_lower = query.to_lowercase();
         let check_contains = |k: &str| query_lower.contains(k);
         (
-            classify_intent(&check_contains, query_lower.ends_with('?')),
-            extract_temporal_refs(&check_contains, now),
+            classify_intent(check_contains, query_lower.ends_with('?')),
+            extract_temporal_refs(check_contains, now),
         )
     };
 
@@ -650,10 +650,12 @@ mod sentry_tests {
         ];
 
         for (input, expected) in cases {
+            let input_lower = input.to_lowercase();
             assert_eq!(
-                classify_intent(&input.to_lowercase()),
+                classify_intent(|k| input_lower.contains(k), input.ends_with('?')),
                 expected,
-                "Failed for input: '{}'", input
+                "Failed for input: '{}'",
+                input
             );
         }
     }
@@ -667,7 +669,7 @@ mod sentry_tests {
         // "yesterday" matches first (rule order).
         // "today" matches next.
         // Result order: yesterday, today.
-        let refs = extract_temporal_refs("today yesterday", now);
+        let refs = extract_temporal_refs(|k| "today yesterday".contains(k), now);
         assert_eq!(refs.len(), 2);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "yesterday"),

--- a/gallifrey/src/error.rs
+++ b/gallifrey/src/error.rs
@@ -64,7 +64,7 @@ impl From<GallifreyError> for tardis_common::Error {
             GallifreyError::QueryExecutionFailed(msg) => Self::QueryExecutionFailed(msg),
             GallifreyError::EntityNotFound(msg) => Self::EntityNotFound(msg),
             GallifreyError::EntityAlreadyExists(msg) => {
-                Self::Internal(format!("Entity already exists: {}", msg))
+                Self::Internal(format!("Entity already exists: {msg}"))
             }
             GallifreyError::InvalidTemporalReference(msg) => Self::InvalidTemporalReference(msg),
             GallifreyError::TimeTravelFailed(msg) => Self::TimeTravelFailed { reason: msg },

--- a/shell/src/experimental/mod.rs
+++ b/shell/src/experimental/mod.rs
@@ -5,3 +5,5 @@ pub mod chronograph;
 #[cfg(feature = "nova")]
 pub mod heatmap_cmd;
 pub mod sonic;
+#[cfg(feature = "nova")]
+pub mod weaver_cmd;

--- a/shell/src/experimental/weaver_cmd.rs
+++ b/shell/src/experimental/weaver_cmd.rs
@@ -1,0 +1,72 @@
+//! Shell command for The Weaver.
+//!
+//! Usage: `weave <source> to <target>` or `weave <source>, <target>`
+
+use anyhow::{Context, Result};
+use std::fmt::Write;
+use std::sync::Arc;
+use tardis_chronos::experimental::weaver::Weaver;
+use tardis_chronos::Chronos;
+use tardis_gallifrey::Gallifrey;
+
+/// Run the `weave` command.
+///
+/// # Errors
+///
+/// Returns an error if the connection fails or arguments are invalid.
+pub async fn run(
+    gallifrey: Arc<Gallifrey>,
+    chronos: Arc<Chronos>,
+    args: &[String],
+) -> Result<String> {
+    if args.is_empty() {
+        return Ok("Usage: weave <source> to <target> OR weave <source>, <target>".to_string());
+    }
+
+    let full_args = args.join(" ");
+    let (source, target) = if full_args.contains(" to ") {
+        let parts: Vec<&str> = full_args.splitn(2, " to ").collect();
+        (parts[0].trim().to_string(), parts[1].trim().to_string())
+    } else if full_args.contains(',') {
+        let parts: Vec<&str> = full_args.splitn(2, ',').collect();
+        (parts[0].trim().to_string(), parts[1].trim().to_string())
+    } else if args.len() == 2 {
+        (args[0].clone(), args[1].clone())
+    } else {
+        return Ok("Usage: weave <source> to <target> OR weave <source>, <target>".to_string());
+    };
+
+    let vortex = chronos.vortex();
+    let loaded_models = vortex.list_loaded_models();
+
+    // Check if we have a model, otherwise hint to load one
+    let (model, _) = loaded_models
+        .first()
+        .context("No models loaded. Use 'models load <path>' first.")?;
+
+    let weaver = Weaver::new(Arc::clone(&vortex), Arc::clone(&gallifrey));
+
+    println!("🧶 Weaving connection between '{source}' and '{target}'...");
+
+    let result = weaver.weave(&source, &target, *model).await?;
+
+    let mut output = String::new();
+    let _ = write!(
+        output,
+        "\n✨ THE CONNECTION ✨\n\n{}\n\n",
+        result.narrative
+    );
+    output.push_str("📜 THE PATH:\n");
+
+    for (i, step) in result.steps.iter().enumerate() {
+        let _ = writeln!(output, "{}. {}", i + 1, step.description);
+        if let Some(entity) = &step.entity_name {
+            let _ = writeln!(output, "   (Entity: {entity})");
+        }
+        if let Some(rel) = &step.relationship {
+            let _ = writeln!(output, "   (Relation: {rel})");
+        }
+    }
+
+    Ok(output)
+}

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -26,6 +26,8 @@ use tardis_chronos::experimental::curiosity::Curiosity;
 use tardis_chronos::experimental::prophecy::Prophet;
 #[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
+#[cfg(feature = "nova")]
+use crate::experimental::weaver_cmd;
 
 /// The main REPL for Tardis shell.
 #[derive(Debug)]
@@ -178,6 +180,8 @@ impl Repl {
             "ask" | "curiosity" => self.handle_curiosity().await,
             #[cfg(feature = "nova")]
             "capsule" => self.handle_capsule(args).await,
+            #[cfg(feature = "nova")]
+            "weave" => self.handle_weave(args).await,
             _ => println!("Unknown command: {command}. Type 'help' for available commands."),
         }
     }
@@ -254,6 +258,7 @@ impl Repl {
         }
     }
 
+    #[allow(clippy::unused_self)]
     fn handle_models(&self) {
         commands::list_models();
     }
@@ -450,6 +455,20 @@ impl Repl {
                 }
             }
             _ => println!("Unknown capsule command: {subcommand}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    async fn handle_weave(&self, args: &[String]) {
+        match weaver_cmd::run(
+            std::sync::Arc::clone(&self.gallifrey),
+            std::sync::Arc::clone(&self.chronos),
+            args,
+        )
+        .await
+        {
+            Ok(output) => println!("{output}"),
+            Err(e) => println!("Weave failed: {e}"),
         }
     }
 }

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -86,6 +86,8 @@ impl Router {
                 "sonic",
                 #[cfg(feature = "nova")]
                 "fix",
+                #[cfg(feature = "nova")]
+                "weave",
             ],
         }
     }


### PR DESCRIPTION
This PR introduces "The Weaver", an experimental feature for the Timey Wimey OS.

**The Spark:**
Connecting disparate entities in the knowledge graph is often difficult. "The Weaver" uses Generative AI (Vortex) to hallucinate/infer a plausible narrative path between any two entities.

**The Feature:**
- `Weaver` struct in `chronos`: Takes two entity names, finds them in `Gallifrey` (via linear scan), and prompts `Vortex` to create a connection story and a list of steps.
- `weave` command in `shell`: Usage `weave <source> to <target>` or `weave <source>, <target>`. Displays the narrative and the steps.

**The Potential:**
This enables "lateral thinking" for the OS, allowing it to find or invent relationships that aren't explicitly defined, useful for brainstorming, storytelling, or investigative scenarios.

**Verification:**
- Added unit tests for `Weaver`.
- Verified `weave` command integration.
- Fixed existing broken tests in `chronos`.
- Fixed clippy warnings in `chronos`, `shell`, and `gallifrey`.

**Risk:**
Low. Isolated behind `#[cfg(feature = "nova")]`. The entity lookup is O(N) but acceptable for experimental mode.

---
*PR created automatically by Jules for task [12653022952628090575](https://jules.google.com/task/12653022952628090575) started by @madmax983*