### PR TITLE
feat(chronos): add The Weaver experimental module

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -34,7 +34,13 @@
 **Concept:** A CLI command `heatmap <entity>` that renders the Temporal Heatmap in the terminal.
 **Fate:** Merged
 **Lesson:** ASCII art is surprisingly effective for communicating complex 2D time data.
+
 ## The Simulator (Timeline)
 **Concept:** A copy-on-write overlay that allows "What-If" scenarios on the Knowledge Graph without corrupting the main timeline.
 **Fate:** Merged (Experimental)
 **Lesson:** Bi-temporal data is great for history, but for hypothetical futures, we need a lightweight branching mechanism that doesn't persist until committed.
+
+## The Weaver
+**Concept:** A narrative engine that generates creative connections between two entities and stores them as "NARRATIVE_LINK" relationships.
+**Fate:** Merged (Experimental)
+**Lesson:** Innovation is connecting two existing modules (Gallifrey + Vortex) that haven't met yet.

--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -24,7 +24,7 @@ pub struct Curiosity {
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,

--- a/chronos/src/experimental/fugue.rs
+++ b/chronos/src/experimental/fugue.rs
@@ -8,6 +8,7 @@
 use crate::error::{ChronosError, ChronosResult};
 use crate::experimental::psychic_paper::{Intent, PsychicPaper};
 use chrono::{DateTime, Duration, Utc};
+use std::fmt::Write;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
@@ -109,8 +110,13 @@ impl Fugue {
 
         let mut context_str = String::new();
         for entity in &context_entities {
-            context_str.push_str(&format!("- {} ({}): {}\n", entity.name, entity.entity_type,
-                serde_json::to_string(&entity.properties).unwrap_or_default()));
+            let _ = writeln!(
+                &mut context_str,
+                "- {} ({}): {}",
+                entity.name,
+                entity.entity_type,
+                serde_json::to_string(&entity.properties).unwrap_or_default()
+            );
         }
 
         if context_str.is_empty() {
@@ -118,12 +124,11 @@ impl Fugue {
         }
 
         let prompt = format!(
-            "SYSTEM STATE at {}:\n{}\n\nHYPOTHETICAL SCENARIO: {}\n\nTASK: Simulate the consequences of this scenario over the next {}. \
+            "SYSTEM STATE at {divergence_time}:\n{context_str}\n\nHYPOTHETICAL SCENARIO: {counterfactual}\n\nTASK: Simulate the consequences of this scenario over the next {horizon_desc}. \
             Return a JSON object with two fields:\n\
             1. 'narrative': A short paragraph summarizing the timeline.\n\
             2. 'events': A list of objects, each having 'time_offset' (string) and 'description' (string).\n\
-            Output ONLY JSON.",
-            divergence_time, context_str, counterfactual, horizon_desc
+            Output ONLY JSON."
         );
 
         // 4. Inference

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -16,3 +16,6 @@ pub mod curiosity;
 
 #[cfg(feature = "nova")]
 pub mod fugue;
+
+#[cfg(feature = "nova")]
+pub mod weaver;

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -1,0 +1,223 @@
+//! The Weaver: Narrative Connection Engine.
+//!
+//! "We are all stories in the end."
+//!
+//! This module uses `Vortex` to generate narrative connections between two entities
+//! in the `Gallifrey` knowledge graph, "weaving" them together into a coherent story.
+//!
+//! If a connection is successfully generated, it is stored as a `Relationship`
+//! of type "`NARRATIVE_LINK`".
+
+use crate::error::ChronosResult;
+use std::fmt::Write;
+use std::sync::Arc;
+use tardis_common::id::EntityId;
+use tardis_common::temporal::BiTemporalInterval;
+use tardis_gallifrey::domain::{Entity, Relationship};
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+use tracing::{info, instrument};
+
+/// The Weaver engine.
+#[derive(Debug)]
+pub struct Weaver {
+    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<Vortex>,
+    model: ModelHandle,
+}
+
+impl Weaver {
+    /// Create a new Weaver engine.
+    #[must_use]
+    pub const fn new(
+        gallifrey: Arc<Gallifrey>,
+        vortex: Arc<Vortex>,
+        model: ModelHandle,
+    ) -> Self {
+        Self {
+            gallifrey,
+            vortex,
+            model,
+        }
+    }
+
+    /// Weave a narrative connection between two entities.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if entities are not found or inference fails.
+    #[instrument(skip(self))]
+    pub async fn weave(&self, name_a: &str, name_b: &str) -> ChronosResult<String> {
+        info!("Weaving narrative between '{name_a}' and '{name_b}'");
+
+        let entity_a = self.find_entity(name_a)?;
+        let entity_b = self.find_entity(name_b)?;
+
+        // Construct prompt
+        let mut prompt = String::new();
+        let _ = writeln!(&mut prompt, "You are a creative historian. Your task is to find a plausible or creative connection between two entities in the Tardis OS universe.");
+        let _ = writeln!(&mut prompt, "\nEntity A:");
+        let _ = writeln!(&mut prompt, "Name: {}", entity_a.name);
+        let _ = writeln!(&mut prompt, "Type: {}", entity_a.entity_type);
+        let _ = writeln!(&mut prompt, "Properties: {:?}", entity_a.properties);
+
+        let _ = writeln!(&mut prompt, "\nEntity B:");
+        let _ = writeln!(&mut prompt, "Name: {}", entity_b.name);
+        let _ = writeln!(&mut prompt, "Type: {}", entity_b.entity_type);
+        let _ = writeln!(&mut prompt, "Properties: {:?}", entity_b.properties);
+
+        let _ = writeln!(&mut prompt, "\nTask: Write a short paragraph explaining how these two entities might be connected. If no obvious connection exists, invent a scenario where they interact.");
+        let _ = writeln!(&mut prompt, "Narrative Connection:");
+
+        // Ask Vortex
+        let params = InferenceParams::default()
+            .with_temperature(0.8) // High creativity
+            .with_max_tokens(256);
+
+        let story = self.vortex.infer(self.model, &prompt, params).await?;
+
+        // Store the connection in Gallifrey
+        self.store_connection(&entity_a, &entity_b, &story)?;
+
+        Ok(story)
+    }
+
+    fn find_entity(&self, name: &str) -> ChronosResult<Entity> {
+        let mut found = None;
+
+        // Scan history to find the entity
+        // We use the latest version of the first match
+        self.gallifrey
+            .knowledge()
+            .scan_history(|history| {
+                if found.is_some() {
+                    return;
+                }
+                if let Some(latest) = history.last() {
+                    if latest.name.eq_ignore_ascii_case(name) {
+                        found = Some(latest.clone());
+                    }
+                }
+            })
+            .map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            })?;
+
+        found.ok_or_else(|| {
+            crate::error::ChronosError::Common(tardis_common::Error::EntityNotFound(format!(
+                "Entity '{name}' not found"
+            )))
+        })
+    }
+
+    fn store_connection(
+        &self,
+        source: &Entity,
+        target: &Entity,
+        story: &str,
+    ) -> ChronosResult<()> {
+        let relationship = Relationship {
+            id: EntityId::new(),
+            relationship_type: "NARRATIVE_LINK".to_string(),
+            source: source.id,
+            target: target.id,
+            properties: std::collections::HashMap::from([(
+                "narrative".to_string(),
+                serde_json::Value::String(story.to_string()),
+            )]),
+            temporal: BiTemporalInterval::now(),
+        };
+
+        self.gallifrey
+            .knowledge()
+            .insert_relationship(relationship)
+            .map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tardis_vortex::ModelLoadConfig;
+
+    fn create_entity(name: &str) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            entity_type: "Test".to_string(),
+            name: name.to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval::now(),
+            source: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_weaver_connects_entities() {
+        // Setup
+        let gallifrey = Arc::new(Gallifrey::new());
+        let vortex = Arc::new(Vortex::new().unwrap());
+
+        // Insert entities
+        let e1 = create_entity("Doctor");
+        let e2 = create_entity("Dalek");
+        gallifrey.insert(e1.clone()).await.unwrap();
+        gallifrey.insert(e2.clone()).await.unwrap();
+
+        // Mock Vortex
+        vortex.set_mock_inference(Box::new(|_, _, _| {
+            Ok("The Doctor and the Dalek are eternal enemies.".to_string())
+        }));
+
+        vortex.set_mock_load_model(Box::new(move |_, _| Ok(ModelHandle::new(1))));
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
+
+        let weaver = Weaver::new(gallifrey.clone(), vortex, handle);
+
+        // Test
+        let story = weaver.weave("Doctor", "Dalek").await.unwrap();
+
+        assert!(story.contains("eternal enemies"));
+
+        // Verify relationship created
+        let mut found_rel = false;
+        gallifrey
+            .knowledge()
+            .scan_relationships(|rels| {
+                for rel in rels {
+                    if rel.source == e1.id && rel.target == e2.id && rel.relationship_type == "NARRATIVE_LINK" {
+                        found_rel = true;
+                    }
+                }
+            })
+            .unwrap();
+
+        assert!(found_rel, "Relationship should be created");
+    }
+
+    #[tokio::test]
+    async fn test_weaver_entity_not_found() {
+        let gallifrey = Arc::new(Gallifrey::new());
+        let vortex = Arc::new(Vortex::new().unwrap());
+
+        vortex.set_mock_load_model(Box::new(move |_, _| Ok(ModelHandle::new(1))));
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
+
+        let weaver = Weaver::new(gallifrey, vortex, handle);
+
+        let result = weaver.weave("Ghost", "Shadow").await;
+        assert!(result.is_err());
+    }
+}

--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -179,16 +179,16 @@ pub fn analyze_at(query: &str, now: DateTime<Utc>) -> ChronosResult<AnalyzedQuer
         // Use a case-insensitive scan instead.
         let check_contains = |k: &str| contains_ignore_ascii_case(query, k);
         (
-            classify_intent(&check_contains, query.ends_with('?')),
-            extract_temporal_refs(&check_contains, now),
+            classify_intent(check_contains, query.ends_with('?')),
+            extract_temporal_refs(check_contains, now),
         )
     } else {
         // Optimization: Hoist to_lowercase() to avoid repeating it in helper methods
         let query_lower = query.to_lowercase();
         let check_contains = |k: &str| query_lower.contains(k);
         (
-            classify_intent(&check_contains, query_lower.ends_with('?')),
-            extract_temporal_refs(&check_contains, now),
+            classify_intent(check_contains, query_lower.ends_with('?')),
+            extract_temporal_refs(check_contains, now),
         )
     };
 
@@ -650,8 +650,9 @@ mod sentry_tests {
         ];
 
         for (input, expected) in cases {
+            let input_lower = input.to_lowercase();
             assert_eq!(
-                classify_intent(&input.to_lowercase()),
+                classify_intent(|k| input_lower.contains(k), input.ends_with('?')),
                 expected,
                 "Failed for input: '{}'", input
             );
@@ -667,7 +668,9 @@ mod sentry_tests {
         // "yesterday" matches first (rule order).
         // "today" matches next.
         // Result order: yesterday, today.
-        let refs = extract_temporal_refs("today yesterday", now);
+        let input = "today yesterday";
+        let input_lower = input.to_lowercase();
+        let refs = extract_temporal_refs(|k| input_lower.contains(k), now);
         assert_eq!(refs.len(), 2);
         match &refs[0] {
             TemporalReference::Relative { text, .. } => assert_eq!(text, "yesterday"),

--- a/gallifrey/src/error.rs
+++ b/gallifrey/src/error.rs
@@ -64,7 +64,7 @@ impl From<GallifreyError> for tardis_common::Error {
             GallifreyError::QueryExecutionFailed(msg) => Self::QueryExecutionFailed(msg),
             GallifreyError::EntityNotFound(msg) => Self::EntityNotFound(msg),
             GallifreyError::EntityAlreadyExists(msg) => {
-                Self::Internal(format!("Entity already exists: {}", msg))
+                Self::Internal(format!("Entity already exists: {msg}"))
             }
             GallifreyError::InvalidTemporalReference(msg) => Self::InvalidTemporalReference(msg),
             GallifreyError::TimeTravelFailed(msg) => Self::TimeTravelFailed { reason: msg },

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -25,6 +25,8 @@ use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::prophecy::Prophet;
 #[cfg(feature = "nova")]
+use tardis_chronos::experimental::weaver::Weaver;
+#[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
 
 /// The main REPL for Tardis shell.
@@ -178,6 +180,8 @@ impl Repl {
             "ask" | "curiosity" => self.handle_curiosity().await,
             #[cfg(feature = "nova")]
             "capsule" => self.handle_capsule(args).await,
+            #[cfg(feature = "nova")]
+            "weave" => self.handle_weave(args).await,
             _ => println!("Unknown command: {command}. Type 'help' for available commands."),
         }
     }
@@ -254,6 +258,7 @@ impl Repl {
         }
     }
 
+    #[allow(clippy::unused_self)]
     fn handle_models(&self) {
         commands::list_models();
     }
@@ -450,6 +455,37 @@ impl Repl {
                 }
             }
             _ => println!("Unknown capsule command: {subcommand}"),
+        }
+    }
+
+    #[cfg(feature = "nova")]
+    async fn handle_weave(&self, args: &[String]) {
+        if args.len() < 2 {
+            println!("Usage: weave <entity_a> <entity_b>");
+            return;
+        }
+
+        let entity_a = &args[0];
+        let entity_b = &args[1];
+
+        let loaded_models = self.chronos.vortex().list_loaded_models();
+        if let Some((handle, _)) = loaded_models.first() {
+            let weaver = Weaver::new(
+                std::sync::Arc::clone(&self.gallifrey),
+                self.chronos.vortex(),
+                *handle,
+            );
+
+            println!("🧶 Weaving narrative between '{entity_a}' and '{entity_b}'...");
+            match weaver.weave(entity_a, entity_b).await {
+                Ok(story) => {
+                    println!("\n{story}\n");
+                    println!("(A new connection has been added to the Knowledge Graph)");
+                }
+                Err(e) => println!("Weaving failed: {e}"),
+            }
+        } else {
+            println!("Weaver needs a loaded model. Use 'models load <path>'.");
         }
     }
 }

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -86,6 +86,8 @@ impl Router {
                 "sonic",
                 #[cfg(feature = "nova")]
                 "fix",
+                #[cfg(feature = "nova")]
+                "weave",
             ],
         }
     }


### PR DESCRIPTION
This PR introduces "The Weaver", an experimental feature for the Timey Wimey OS.

**Concept:**
The Weaver connects two entities in the Gallifrey knowledge graph by generating a narrative link between them using the Vortex LLM. If a connection is generated, it is stored as a `Relationship` of type `NARRATIVE_LINK`.

**Changes:**
1.  **Backend (`chronos`):**
    *   Added `Weaver` struct in `src/experimental/weaver.rs`.
    *   Implemented `weave` method that prompts the LLM to connect two entities.
    *   Added tests for `Weaver` using mocked `Vortex`.
    *   Fixed existing broken tests in `pipeline/analyzer.rs` found during verification.
    *   Fixed clippy warnings in `fugue.rs` and `curiosity.rs`.

2.  **Frontend (`shell`):**
    *   Added `weave <entity_a> <entity_b>` command.
    *   Updated `Router` to recognize `weave`.
    *   Updated `Repl` to handle `weave`.

**Why is this cool?**
It embodies the "innovation is connecting existing modules" philosophy. It allows the system to creatively fill in the gaps between isolated facts, effectively "dreaming" connections that can then be explored or refuted.


---
*PR created automatically by Jules for task [13358671021416188156](https://jules.google.com/task/13358671021416188156) started by @madmax983*