### PR TITLE
🛡️ Sentry: Improve test coverage for Chronos augmenter and Vortex templates

### DIFF
--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -431,3 +431,85 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+mod sentry_tests {
+    use super::*;
+    use crate::pipeline::analyzer::{AnalyzedQuery, QueryIntent};
+    use crate::pipeline::{ContextSource, ContextSourceType};
+
+    fn create_mock_analysis(intent: QueryIntent) -> AnalyzedQuery {
+        AnalyzedQuery {
+            text: "test".to_string(),
+            intent,
+            temporal_refs: vec![],
+            temporal_description: None,
+            entities: vec![],
+        }
+    }
+
+    fn create_mock_source(content: &str) -> ContextSource {
+        ContextSource {
+            source_type: ContextSourceType::Knowledge,
+            content: content.to_string(),
+            relevance: 1.0,
+            entity_id: None,
+        }
+    }
+
+    #[test]
+    fn test_write_instructions_intent_coverage() {
+        let config = RagConfig::default();
+        let intents = vec![
+            (QueryIntent::Recall, "Focus on accurately recalling"),
+            (QueryIntent::TemporalDiff, "Compare the states"),
+            (QueryIntent::SystemQuery, "Provide accurate system state"),
+            (QueryIntent::Chat, "Be helpful and concise"),
+            (QueryIntent::Question, "Be helpful and concise"),
+            (QueryIntent::Remember, "Be helpful and concise"),
+        ];
+
+        for (intent, expected_phrase) in intents {
+            let analysis = create_mock_analysis(intent.clone());
+            let result = augment("query", &[], &analysis, &config).unwrap();
+
+            assert!(
+                result.contains(expected_phrase),
+                "Instructions for {:?} should contain '{}'",
+                intent,
+                expected_phrase
+            );
+        }
+    }
+
+    #[test]
+    fn test_augment_truncation_boundary_conditions() {
+        let config = RagConfig {
+            max_context_tokens: 10, // 40 chars
+            ..RagConfig::default()
+        };
+
+        // Source 1: 39 chars. 10 tokens (39/4 ceil = 10).
+        // Remaining budget: 10 - 10 = 0 tokens.
+        let s1 = create_mock_source(&"a".repeat(39));
+
+        // Source 2: 1 char. Should be dropped.
+        let s2 = create_mock_source("SHOULD_NOT_APPEAR");
+
+        let analysis = create_mock_analysis(QueryIntent::Question);
+
+        let result = augment("query", &[s1, s2], &analysis, &config).unwrap();
+
+        assert!(result.contains(&"a".repeat(39)), "Should contain s1");
+        assert!(
+            !result.contains("SHOULD_NOT_APPEAR"),
+            "Should not contain s2"
+        );
+        assert!(
+            result.contains("1 more sources truncated"),
+            "Should report s2 dropped"
+        );
+    }
+}

--- a/shell/src/commands/mod.rs
+++ b/shell/src/commands/mod.rs
@@ -11,17 +11,17 @@
 //! - `models`: List available LLMs.
 //! - `context`: Inspect session state.
 
-/// Command traits and context.
-pub mod traits;
-/// Command registry.
-pub mod registry;
-/// System maintenance commands.
-pub mod system;
 #[cfg(feature = "nova")]
 /// Experimental commands (Nova feature).
 pub mod experimental;
 /// Knowledge management commands.
 pub mod knowledge;
+/// Command registry.
+pub mod registry;
+/// System maintenance commands.
+pub mod system;
+/// Command traits and context.
+pub mod traits;
 
 use std::sync::Arc;
 use tardis_common::SessionId;

--- a/vortex/src/tokenizer/template.rs
+++ b/vortex/src/tokenizer/template.rs
@@ -255,3 +255,70 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod sentry_tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_jinja_template_dispatch() {
+        let messages = vec![ChatMessage::user("Hi")];
+
+        // ChatML pattern
+        let res_chatml = apply_jinja_template("... <|im_start|> ...", &messages, true);
+        assert!(
+            res_chatml.contains("<|im_start|>user"),
+            "Should dispatch to ChatML"
+        );
+
+        // Llama 2 pattern
+        let res_llama2 = apply_jinja_template("... [INST] ...", &messages, true);
+        assert!(res_llama2.contains("[INST]"), "Should dispatch to Llama 2");
+
+        // Llama 3 pattern
+        let res_llama3 = apply_jinja_template("... <|start_header_id|> ...", &messages, true);
+        assert!(
+            res_llama3.contains("<|start_header_id|>"),
+            "Should dispatch to Llama 3"
+        );
+
+        // Fallback
+        let res_simple = apply_jinja_template("unknown template", &messages, true);
+        assert!(res_simple.contains("user: Hi"), "Should fallback to simple");
+    }
+
+    #[test]
+    fn test_apply_llama2_template_multiple_systems() {
+        let messages = vec![
+            ChatMessage::system("Sys1"),
+            ChatMessage::user("Hi"),
+            ChatMessage::system("Sys2"), // Should be ignored
+            ChatMessage::user("Bye"),
+        ];
+
+        let result = apply_llama2_template(&messages, true);
+
+        assert!(
+            result.contains("Sys1"),
+            "Should contain first system message"
+        );
+        assert!(
+            !result.contains("Sys2"),
+            "Should ignore subsequent system messages"
+        );
+    }
+
+    #[test]
+    fn test_apply_llama2_template_system_only_no_user() {
+        // This is similar to existing test_apply_llama2_template_system_only but verifies logic explicitly
+        let messages = vec![ChatMessage::system("Sys1")];
+        let result = apply_llama2_template(&messages, true);
+
+        assert!(result.contains("Sys1"));
+        assert!(result.contains("<<SYS>>"));
+        assert!(
+            result.ends_with(" [/INST] "),
+            "Should end ready for assistant generation"
+        );
+    }
+}


### PR DESCRIPTION
Implemented additional unit tests for `chronos` and `vortex` crates to improve code coverage and verify edge cases.

Changes:
- In `chronos/src/pipeline/augmenter.rs`:
  - Added `sentry_tests` module.
  - Added `test_write_instructions_intent_coverage` to verify `write_instructions` output for all `QueryIntent` variants.
  - Added `test_augment_truncation_boundary_conditions` to test the truncation logic when the token budget is exhausted.

- In `vortex/src/tokenizer/template.rs`:
  - Added `sentry_tests` module.
  - Added `test_apply_jinja_template_dispatch` to test the dispatch logic for different chat templates (`ChatML`, `Llama2`, `Llama3`).
  - Added `test_apply_llama2_template_multiple_systems` to verify that Llama 2 template correctly ignores subsequent system messages.
  - Added `test_apply_llama2_template_system_only_no_user` to verify Llama 2 template generation with only a system message.

Verification:
- Ran `cargo test -p tardis-chronos` - Passed.
- Ran `cargo test -p tardis-vortex` - Passed.
- Ran `cargo clippy` - Passed.

---
*PR created automatically by Jules for task [9447265381923427381](https://jules.google.com/task/9447265381923427381) started by @madmax983*