### PR TITLE
⚒️ Forge: Refactor chronos analyzer and clean experimental lints

### DIFF
--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -24,7 +24,7 @@ pub struct Curiosity {
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,

--- a/chronos/src/experimental/doctor.rs
+++ b/chronos/src/experimental/doctor.rs
@@ -257,7 +257,7 @@ impl SystemDoctor {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::unchecked_time_subtraction)]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/chronos/src/experimental/fugue.rs
+++ b/chronos/src/experimental/fugue.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
+use std::fmt::Write;
 use std::sync::Arc;
 use tardis_common::id::ModelHandle;
 use tardis_gallifrey::domain::Entity;
@@ -114,12 +115,13 @@ impl Fugue {
 
         let mut context_str = String::new();
         for entity in &context_entities {
-            context_str.push_str(&format!(
-                "- {} ({}): {}\n",
+            let _ = writeln!(
+                context_str,
+                "- {} ({}): {}",
                 entity.name,
                 entity.entity_type,
                 serde_json::to_string(&entity.properties).unwrap_or_default()
-            ));
+            );
         }
 
         if context_str.is_empty() {
@@ -127,12 +129,11 @@ impl Fugue {
         }
 
         let prompt = format!(
-            "SYSTEM STATE at {}:\n{}\n\nHYPOTHETICAL SCENARIO: {}\n\nTASK: Simulate the consequences of this scenario over the next {}. \
+            "SYSTEM STATE at {divergence_time}:\n{context_str}\n\nHYPOTHETICAL SCENARIO: {counterfactual}\n\nTASK: Simulate the consequences of this scenario over the next {horizon_desc}. \
             Return a JSON object with two fields:\n\
             1. 'narrative': A short paragraph summarizing the timeline.\n\
             2. 'events': A list of objects, each having 'time_offset' (string) and 'description' (string).\n\
-            Output ONLY JSON.",
-            divergence_time, context_str, counterfactual, horizon_desc
+            Output ONLY JSON."
         );
 
         // 4. Inference
@@ -197,6 +198,7 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -130,6 +130,7 @@ impl Prophet {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -215,6 +215,7 @@ impl PsychicPaper {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/chronos/src/pipeline/analyzer.rs
+++ b/chronos/src/pipeline/analyzer.rs
@@ -9,7 +9,6 @@
 
 use crate::error::ChronosResult;
 use chrono::{DateTime, Duration, Utc};
-use std::fmt::Write;
 use tardis_common::temporal::TemporalReference;
 
 /// Analyzed query with extracted metadata.
@@ -172,30 +171,53 @@ fn classify_intent(query_lower: &str, has_question_mark: bool) -> QueryIntent {
     QueryIntent::Chat
 }
 
+#[derive(Debug, Clone, Copy)]
+enum TemporalOffset {
+    Days(i64),
+    Weeks(i64),
+    None,
+}
+
+impl TemporalOffset {
+    fn apply(&self, now: DateTime<Utc>) -> DateTime<Utc> {
+        match self {
+            TemporalOffset::Days(days) => now + Duration::days(*days),
+            TemporalOffset::Weeks(weeks) => now + Duration::weeks(*weeks),
+            TemporalOffset::None => now,
+        }
+    }
+}
+
+struct TemporalRule {
+    keyword: &'static str,
+    offset: TemporalOffset,
+}
+
+const TEMPORAL_RULES: &[TemporalRule] = &[
+    TemporalRule {
+        keyword: "yesterday",
+        offset: TemporalOffset::Days(-1),
+    },
+    TemporalRule {
+        keyword: "last week",
+        offset: TemporalOffset::Weeks(-1),
+    },
+    TemporalRule {
+        keyword: "today",
+        offset: TemporalOffset::None,
+    },
+];
+
 /// Extract temporal references from a query.
 fn extract_temporal_refs(query_lower: &str, now: DateTime<Utc>) -> Vec<TemporalReference> {
-    let mut refs = Vec::new();
-
-    if query_lower.contains("yesterday") {
-        refs.push(TemporalReference::Relative {
-            text: "yesterday".to_string(),
-            resolved: now - Duration::days(1),
-        });
-    }
-
-    if query_lower.contains("last week") {
-        refs.push(TemporalReference::Relative {
-            text: "last week".to_string(),
-            resolved: now - Duration::weeks(1),
-        });
-    }
-
-    if query_lower.contains("today") {
-        refs.push(TemporalReference::Relative {
-            text: "today".to_string(),
-            resolved: now,
-        });
-    }
+    let refs: Vec<TemporalReference> = TEMPORAL_RULES
+        .iter()
+        .filter(|rule| query_lower.contains(rule.keyword))
+        .map(|rule| TemporalReference::Relative {
+            text: rule.keyword.to_string(),
+            resolved: rule.offset.apply(now),
+        })
+        .collect();
 
     // TODO: Add more sophisticated temporal extraction
     // - NLP-based extraction
@@ -219,31 +241,23 @@ fn describe_temporal_context(refs: &[TemporalReference]) -> String {
         return "current time".to_string();
     }
 
-    let mut result = String::new();
-    for (i, r) in refs.iter().enumerate() {
-        if i > 0 {
-            result.push_str(", ");
-        }
-        match r {
+    refs.iter()
+        .map(|r| match r {
             TemporalReference::Relative { text, resolved } => {
-                let _ = write!(result, "{} ({})", text, resolved.format("%Y-%m-%d"));
+                format!("{} ({})", text, resolved.format("%Y-%m-%d"))
             }
-            TemporalReference::Absolute(resolved) => {
-                let _ = write!(result, "{}", resolved.format("%Y-%m-%d"));
-            }
+            TemporalReference::Absolute(resolved) => format!("{}", resolved.format("%Y-%m-%d")),
             TemporalReference::EventBased { event, resolved } => {
                 if let Some(res) = resolved {
-                    let _ = write!(result, "{} ({})", event, res.format("%Y-%m-%d"));
+                    format!("{} ({})", event, res.format("%Y-%m-%d"))
                 } else {
-                    result.push_str(event);
+                    event.clone()
                 }
             }
-            TemporalReference::Implicit => {
-                result.push_str("implicit");
-            }
-        }
-    }
-    result
+            TemporalReference::Implicit => "implicit".to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[cfg(test)]

--- a/shell/src/commands/mod.rs
+++ b/shell/src/commands/mod.rs
@@ -11,17 +11,17 @@
 //! - `models`: List available LLMs.
 //! - `context`: Inspect session state.
 
-/// Command traits and context.
-pub mod traits;
-/// Command registry.
-pub mod registry;
-/// System maintenance commands.
-pub mod system;
 #[cfg(feature = "nova")]
 /// Experimental commands (Nova feature).
 pub mod experimental;
 /// Knowledge management commands.
 pub mod knowledge;
+/// Command registry.
+pub mod registry;
+/// System maintenance commands.
+pub mod system;
+/// Command traits and context.
+pub mod traits;
 
 use std::sync::Arc;
 use tardis_common::SessionId;


### PR DESCRIPTION
🚮 Smell: Repetitive `if` chains in `extract_temporal_refs` and manual loop in `describe_temporal_context`. Clippy warnings in experimental modules preventing clean builds.
✨ Solution: Introduced `TEMPORAL_RULES` data-driven extraction. Rewrote `describe_temporal_context` using iterator chain. Fixed `clippy::missing_const_for_fn` and `clippy::format_push_string` in experimental modules. Added `allow` for `unwrap_used` in tests.
🧼 Benefit: Reduces cognitive load, more idiomatic Rust, ensures clean CI pipeline.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [715686677173400065](https://jules.google.com/task/715686677173400065) started by @madmax983*