### PR TITLE
🌟 Nova: Chameleon Command (System Persona)

### DIFF
--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -95,7 +95,12 @@ pub fn augment(
     let mut augmented = String::with_capacity(capacity);
 
     // System context
-    write_system_context(&mut augmented, analysis);
+    #[cfg(feature = "nova")]
+    let persona = config.persona.as_deref();
+    #[cfg(not(feature = "nova"))]
+    let persona = None;
+
+    write_system_context(&mut augmented, analysis, persona);
 
     // Retrieved context
     if !context.is_empty() {
@@ -115,8 +120,16 @@ pub fn augment(
 }
 
 /// Write system context header to buffer.
-fn write_system_context(buffer: &mut String, analysis: &AnalyzedQuery) {
-    buffer.push_str("# Tardis AI Assistant\n\n");
+fn write_system_context(
+    buffer: &mut String,
+    analysis: &AnalyzedQuery,
+    persona: Option<&str>,
+) {
+    if let Some(p) = persona {
+        let _ = writeln!(buffer, "# {p}\n");
+    } else {
+        buffer.push_str("# Tardis AI Assistant\n\n");
+    }
     // Bolt: Optimized format string usage
     let _ = writeln!(
         buffer,
@@ -429,5 +442,20 @@ mod tests {
             result.contains("15 more sources truncated"),
             "Should report 15 dropped sources"
         );
+    }
+
+    #[cfg(feature = "nova")]
+    #[test]
+    fn test_augment_with_persona() {
+        let config = RagConfig {
+            persona: Some("You are a Dalek.".to_string()),
+            ..RagConfig::default()
+        };
+        let analysis = create_mock_analysis();
+
+        let result = augment("query", &[], &analysis, &config).unwrap();
+
+        assert!(result.contains("# You are a Dalek."));
+        assert!(!result.contains("# Tardis AI Assistant"));
     }
 }

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -86,6 +86,9 @@ pub struct RagConfig {
     pub session_id: Option<SessionId>,
     /// Maximum number of tokens for context.
     pub max_context_tokens: usize,
+    /// System persona description (optional).
+    #[cfg(feature = "nova")]
+    pub persona: Option<String>,
 }
 
 impl Default for RagConfig {
@@ -97,6 +100,8 @@ impl Default for RagConfig {
             include_system_state: false,
             session_id: None,
             max_context_tokens: 4096,
+            #[cfg(feature = "nova")]
+            persona: None,
         }
     }
 }

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -16,6 +16,38 @@ use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
 
+/// Chameleon command (System Persona).
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct ChameleonCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for ChameleonCommand {
+    fn name(&self) -> &str {
+        "chameleon"
+    }
+
+    fn description(&self) -> &str {
+        "Set the system persona"
+    }
+
+    async fn execute(&self, args: &[String], _context: &CommandContext) -> Result<CommandResult> {
+        if args.is_empty() {
+            println!("Usage: chameleon <persona> | chameleon off | chameleon reset");
+            return Ok(CommandResult::Continue);
+        }
+
+        let input = args.join(" ");
+        let persona = match input.to_lowercase().as_str() {
+            "off" | "reset" | "default" | "none" => None,
+            _ => Some(input),
+        };
+
+        Ok(CommandResult::SetPersona(persona))
+    }
+}
+
 /// Sonic Screwdriver tool command.
 #[cfg(feature = "nova")]
 #[derive(Debug)]

--- a/shell/src/commands/traits.rs
+++ b/shell/src/commands/traits.rs
@@ -37,12 +37,15 @@ impl fmt::Debug for CommandContext {
 }
 
 /// Result of a command execution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandResult {
     /// Continue the shell loop.
     Continue,
     /// Exit the shell loop.
     Quit,
+    /// Set the system persona.
+    #[cfg(feature = "nova")]
+    SetPersona(Option<String>),
 }
 
 /// A shell command.

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -40,6 +40,9 @@ pub struct Repl {
     session_id: SessionId,
     /// Whether to continue running.
     running: bool,
+    /// System persona.
+    #[cfg(feature = "nova")]
+    persona: Option<String>,
 }
 
 impl Repl {
@@ -74,6 +77,8 @@ impl Repl {
             prophet,
             session_id,
             running: true,
+            #[cfg(feature = "nova")]
+            persona: None,
         })
     }
 
@@ -95,6 +100,7 @@ impl Repl {
         // Experimental
         #[cfg(feature = "nova")]
         {
+            registry.register(Box::new(commands::experimental::ChameleonCommand));
             registry.register(Box::new(commands::experimental::SonicCommand));
             registry.register(Box::new(commands::experimental::FixCommand));
             registry.register(Box::new(commands::experimental::DashboardCommand));
@@ -189,6 +195,15 @@ impl Repl {
                 Ok(CommandResult::Quit) => {
                     self.running = false;
                 }
+                #[cfg(feature = "nova")]
+                Ok(CommandResult::SetPersona(persona)) => {
+                    self.persona = persona.clone();
+                    if let Some(p) = persona {
+                        println!("System persona set to: {}", p);
+                    } else {
+                        println!("System persona reset to default.");
+                    }
+                }
                 Err(e) => println!("Command failed: {e}"),
             }
         } else {
@@ -205,10 +220,16 @@ impl Repl {
 
     /// Handle a Chronos RAG query.
     async fn handle_chronos_query(&self, query: &str) {
-        let config = RagConfig {
+        #[allow(unused_mut)]
+        let mut config = RagConfig {
             session_id: Some(self.session_id),
             ..RagConfig::default()
         };
+
+        #[cfg(feature = "nova")]
+        {
+            config.persona = self.persona.clone();
+        }
 
         match self.chronos.query(query, config).await {
             Ok(response) => {


### PR DESCRIPTION
💡 **The Spark:** "Why does the AI always sound the same? I want it to talk like a Pirate or be super concise when I'm debugging."
🚀 **The Feature:** Implemented `ChameleonCommand` (`chameleon <persona>`).
🔮 **The Potential:** Enables role-playing, specialized expert modes (e.g., "SQL Expert", "Rust Compiler"), or just fun interactions.
⚠️ **Risk:** Low. Isolated behind `#[cfg(feature = "nova")]`. Modifies `CommandResult` to be `Clone` instead of `Copy`, which is a minor refactor.


---
*PR created automatically by Jules for task [11714941974213663008](https://jules.google.com/task/11714941974213663008) started by @madmax983*