### PR TITLE
🔒 Warden: Harden TimeCapsule and SonicScrewdriver

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -33,3 +33,7 @@
 **2025-06-05 - Supply Chain Attack**
 **Threat:** `serde_json` v1.0.149 introduced a malicious dependency `zmij` v1.0.19. Additionally, `zip` v7.4.0 (a typosquatted/hijacked crate version) was pulled in by `candle-core` v0.9.2. These compromised versions posed a critical risk of arbitrary code execution.
 **Defense:** Pinned `serde_json` to known safe version `=1.0.128`. Downgraded `candle-core` to `0.9.1` and patched the dependency to use the official Git repository, forcing dependency resolution to safe versions (e.g., `zip` v1.1.4). Removed compromised crate versions from `Cargo.lock`.
+
+**2025-06-06 - Path Traversal & DoS in Experimental Tools**
+**Threat:** `TimeCapsule` and `SonicScrewdriver` (CLI tools) allowed arbitrary file paths, including those with `..` components. This created a Path Traversal vulnerability, potentially allowing attackers to read sensitive files or overwrite system files via the `repair` or `capture` commands. Additionally, `TimeCapsule::load_from_file` read files without a size limit, creating a Denial of Service (DoS) vector via memory exhaustion.
+**Defense:** Implemented `validate_path` to strictly reject paths containing `ParentDir` (`..`) components. Enforced `MAX_CAPSULE_SIZE` (50MB) using `take()` on file readers. Updated `TimeCapsule::save_to_file` to use `OpenOptions::create_new(true)` to prevent accidental or malicious overwriting of existing files.

--- a/gallifrey/src/experimental/time_capsule.rs
+++ b/gallifrey/src/experimental/time_capsule.rs
@@ -11,8 +11,26 @@ use crate::Gallifrey;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashSet, VecDeque};
 use std::fs::File;
-use std::io::{BufReader, BufWriter};
+use std::io::{BufReader, BufWriter, Read};
 use std::path::Path;
+
+/// Maximum size of a time capsule file (50 MB).
+const MAX_CAPSULE_SIZE: u64 = 50 * 1024 * 1024;
+
+/// Validates that a path is safe for file operations.
+///
+/// Rejects paths containing parent directory components ("..").
+fn validate_path(path: &Path) -> GallifreyResult<()> {
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(crate::error::GallifreyError::StorageError(
+            "Path traversal detected: path contains '..' components".to_string(),
+        ));
+    }
+    Ok(())
+}
 
 /// A portable container for a knowledge subgraph.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -154,9 +172,16 @@ impl TimeCapsule {
     ///
     /// Returns an error if file creation or serialization fails.
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> GallifreyResult<()> {
-        let file = File::create(path).map_err(|e| {
-            crate::error::GallifreyError::StorageError(format!("Failed to create file: {e}"))
-        })?;
+        let path = path.as_ref();
+        validate_path(path)?;
+
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .map_err(|e| {
+                crate::error::GallifreyError::StorageError(format!("Failed to create file: {e}"))
+            })?;
         let writer = BufWriter::new(file);
         serde_json::to_writer_pretty(writer, self).map_err(|e| {
             crate::error::GallifreyError::StorageError(format!("Failed to serialize capsule: {e}"))
@@ -170,10 +195,16 @@ impl TimeCapsule {
     ///
     /// Returns an error if file reading or deserialization fails.
     pub fn load_from_file<P: AsRef<Path>>(path: P) -> GallifreyResult<Self> {
+        let path = path.as_ref();
+        validate_path(path)?;
+
         let file = File::open(path).map_err(|e| {
             crate::error::GallifreyError::StorageError(format!("Failed to open file: {e}"))
         })?;
         let reader = BufReader::new(file);
+        // Limit reader to prevent DoS
+        let reader = reader.take(MAX_CAPSULE_SIZE);
+
         let capsule = serde_json::from_reader(reader).map_err(|e| {
             crate::error::GallifreyError::StorageError(format!(
                 "Failed to deserialize capsule: {e}"

--- a/gallifrey/tests/security_capsule.rs
+++ b/gallifrey/tests/security_capsule.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "nova")]
+#![allow(missing_docs)]
+
+use std::fs::File;
+use std::io::Write;
+use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
+
+#[test]
+fn test_path_traversal_save() {
+    let capsule = TimeCapsule::new();
+    // Attempt to save with ".." in path
+    // This should fail with "Path traversal detected" or similar error
+    let result = capsule.save_to_file("../traversal_test.json");
+
+    match result {
+        Ok(_) => {
+            let _ = std::fs::remove_file("../traversal_test.json");
+            panic!("TimeCapsule::save_to_file should reject paths with '..'");
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("Path traversal"),
+                "Expected 'Path traversal' error, got: '{}'",
+                msg
+            );
+        }
+    }
+}
+
+#[test]
+fn test_overwrite_protection() {
+    let path = "overwrite_test.json";
+
+    // Create an existing file
+    {
+        let mut file = File::create(path).unwrap();
+        writeln!(file, "original content").unwrap();
+    }
+
+    let capsule = TimeCapsule::new();
+    // Attempt to overwrite
+    let result = capsule.save_to_file(path);
+
+    // Verify original content is still there
+    let content = std::fs::read_to_string(path).unwrap();
+    let _ = std::fs::remove_file(path);
+
+    if result.is_ok() {
+        panic!("TimeCapsule::save_to_file should fail if file exists");
+    }
+
+    assert_eq!(content.trim(), "original content", "File content was overwritten!");
+}
+
+#[test]
+fn test_path_traversal_load() {
+    // Attempt to load from ".." path
+    // We don't need the file to exist, the path validation should happen first
+    let result = TimeCapsule::load_from_file("../passwd");
+
+    if let Err(e) = result {
+        let msg = e.to_string();
+        assert!(
+            msg.contains("Path traversal"),
+            "Expected 'Path traversal' error, got: '{}'",
+            msg
+        );
+    } else {
+        panic!("TimeCapsule::load_from_file should reject paths with '..'");
+    }
+}

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -214,8 +214,20 @@ impl SonicScrewdriver {
     }
 }
 
+/// Validates that a path is safe.
+fn validate_path(path: &Path) -> Result<()> {
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        anyhow::bail!("Path traversal detected: path contains '..' components");
+    }
+    Ok(())
+}
+
 /// Reads a file with a size limit to prevent DoS.
 fn read_file_with_limit(path: &Path, limit: u64) -> Result<String> {
+    validate_path(path)?;
     let file =
         fs::File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
     let mut content = String::new();
@@ -272,6 +284,15 @@ mod tests {
 
         cleanup();
         Ok(())
+    }
+
+    #[test]
+    fn test_inspect_traversal() {
+        let sonic = SonicScrewdriver::new(None, None, None, None);
+        let path = std::path::Path::new("../passwd");
+        let result = sonic.inspect(path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Path traversal"));
     }
 
     #[test]


### PR DESCRIPTION
Harden TimeCapsule and SonicScrewdriver against Path Traversal and DoS vulnerabilities.

- **Threat:** Path Traversal via `..` in file paths.
- **Defense:** Added `validate_path` to reject such paths.
- **Threat:** DoS via large file loading in `TimeCapsule`.
- **Defense:** Added `take(limit)` to file readers.
- **Threat:** Arbitrary File Overwrite.
- **Defense:** Used `create_new(true)` for file creation.

Verified with new security tests.


---
*PR created automatically by Jules for task [6185125050756958855](https://jules.google.com/task/6185125050756958855) started by @madmax983*