### PR TITLE
docs: Enhance shell and RAG documentation

### DIFF
--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -37,6 +37,15 @@ use std::fmt::Write;
 
 /// Augment a prompt with retrieved context.
 ///
+/// # Silent Truncation
+///
+/// This function enforces the token budget defined in `config.max_context_tokens`.
+/// If the context exceeds this limit:
+/// 1. Sources are processed in order.
+/// 2. If a source partially fits, it is **silently truncated** to fill the remaining space.
+/// 3. Subsequent sources are **dropped entirely**.
+/// 4. A summary note (e.g., "... (N more sources truncated)") is appended.
+///
 /// # Examples
 ///
 /// ```

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -105,7 +105,7 @@ impl Default for RagConfig {
 ///
 /// Represents a piece of information retrieved to answer a query.
 ///
-/// **Note:** The `content` of a source may be truncated by the [`ContextAugmenter`]
+/// **Note:** The `content` of a source may be truncated by the [`augment`] function
 /// if it exceeds the remaining token budget.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextSource {

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -1,6 +1,15 @@
 //! Experimental commands for the Tardis shell.
 //!
 //! These commands are only available when the `nova` feature is enabled.
+//!
+//! # Features
+//!
+//! - **Sonic Screwdriver**: System diagnosis and repair.
+//! - **Biographer**: Narrative generation.
+//! - **Chronograph**: Timeline visualization.
+//! - **Heatmap**: Temporal activity analysis.
+//! - **Curiosity**: Active learning.
+//! - **Time Capsule**: Backup and restore entity subgraphs.
 
 use crate::commands::traits::{CommandContext, CommandResult, ShellCommand};
 use anyhow::Result;
@@ -17,6 +26,16 @@ use tardis_chronos::experimental::curiosity::Curiosity;
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
 
 /// Sonic Screwdriver tool command.
+///
+/// Provides system diagnostics and automated repair capabilities.
+///
+/// # Usage
+///
+/// ```text
+/// sonic diagnose          # Run system diagnostics
+/// sonic <file>            # Inspect a file for issues
+/// sonic repair <file>     # Attempt to repair a file
+/// ```
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct SonicCommand;
@@ -75,6 +94,14 @@ impl ShellCommand for SonicCommand {
 }
 
 /// Repair command (alias for sonic repair).
+///
+/// A shortcut for `sonic repair`.
+///
+/// # Usage
+///
+/// ```text
+/// fix <file>
+/// ```
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct FixCommand;
@@ -116,6 +143,14 @@ impl ShellCommand for FixCommand {
 }
 
 /// Dashboard command.
+///
+/// Launches a TUI (Text User Interface) dashboard to monitor system status.
+///
+/// # Usage
+///
+/// ```text
+/// dashboard
+/// ```
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct DashboardCommand;
@@ -149,6 +184,14 @@ impl ShellCommand for DashboardCommand {
 }
 
 /// Timeline command.
+///
+/// Visualizes the history of changes to a specific entity.
+///
+/// # Usage
+///
+/// ```text
+/// timeline <entity_name>
+/// ```
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct TimelineCommand;
@@ -181,6 +224,16 @@ impl ShellCommand for TimelineCommand {
 }
 
 /// Entity map command.
+///
+/// Generates a text-based map of an entity's relationships.
+///
+/// # Usage
+///
+/// ```text
+/// map <entity_name> [depth]
+/// ```
+///
+/// - `depth`: How many levels of relationships to traverse (default: 2).
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct MapCommand;
@@ -214,6 +267,14 @@ impl ShellCommand for MapCommand {
 }
 
 /// Heatmap command.
+///
+/// Generates a temporal heatmap showing activity density for an entity.
+///
+/// # Usage
+///
+/// ```text
+/// heatmap <entity_name>
+/// ```
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct HeatmapCommand;
@@ -239,6 +300,18 @@ impl ShellCommand for HeatmapCommand {
 }
 
 /// Biography command.
+///
+/// Generates a narrative biography for an entity using the LLM.
+///
+/// # Usage
+///
+/// ```text
+/// biography <entity_name>
+/// ```
+///
+/// # Prerequisites
+///
+/// - Requires a loaded LLM model.
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct BiographerCommand;
@@ -279,6 +352,18 @@ impl ShellCommand for BiographerCommand {
 }
 
 /// Curiosity command.
+///
+/// Triggers the Curiosity Engine to actively scan for knowledge gaps and ask questions.
+///
+/// # Usage
+///
+/// ```text
+/// curiosity
+/// ```
+///
+/// # Prerequisites
+///
+/// - Requires a loaded LLM model.
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct CuriosityCommand;
@@ -316,6 +401,15 @@ impl ShellCommand for CuriosityCommand {
 }
 
 /// Time Capsule command.
+///
+/// Manages "Time Capsules" - portable snapshots of entity subgraphs.
+///
+/// # Usage
+///
+/// ```text
+/// capsule capture <entity> <file> [depth]   # Save entity subgraph to file
+/// capsule restore <file>                    # Restore subgraph from file
+/// ```
 #[cfg(feature = "nova")]
 #[derive(Debug)]
 pub struct CapsuleCommand;

--- a/shell/src/commands/mod.rs
+++ b/shell/src/commands/mod.rs
@@ -71,6 +71,18 @@ fn general_help() {
     println!("    @<time> <query>   Time-travel query (e.g., @yesterday what did we discuss)");
     println!("    ?<query>          Direct LLM query (no RAG)");
     println!();
+    #[cfg(feature = "nova")]
+    {
+        println!("  EXPERIMENTAL COMMANDS (Nova):");
+        println!("    sonic <file>      System diagnosis and repair");
+        println!("    biography <name>  Generate entity biography");
+        println!("    map <name>        Show entity relationship map");
+        println!("    heatmap <name>    Show temporal activity");
+        println!("    curiosity         Active learning scan");
+        println!("    capsule           Manage time capsules");
+        println!("    dashboard         System TUI dashboard");
+        println!();
+    }
     println!("  EXAMPLES:");
     println!("    > What did we discuss about Rust?");
     println!("    > remember that the API uses JWT tokens");


### PR DESCRIPTION
This PR improves the documentation for the Tardis shell and Chronos RAG pipeline.

### 📖 Documentation Updates
- **Shell Commands**: Added detailed doc comments and usage examples for all experimental commands in `shell/src/commands/experimental.rs`. These commands are now also listed in the `help` output when the `nova` feature is active.
- **RAG Pipeline**: Clarified the "Silent Truncation" behavior in `chronos::pipeline::augmenter::augment`, explaining how context sources are dropped when the token budget is exceeded.
- **Fixes**: Resolved a broken intra-doc link to the removed `ContextAugmenter` struct.

### 🧪 Verification
- Ran `cargo test` on `shell` (with `nova`) and `chronos`.
- Verified `cargo doc` output for correctness and warning-free builds.

---
*PR created automatically by Jules for task [2326947131126841499](https://jules.google.com/task/2326947131126841499) started by @madmax983*