### PR TITLE
🗺️ Atlas: Service Trait Abstraction

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -64,3 +64,12 @@
 2. Moved `common::llm` to `vortex::config` (the Inference Engine).
 3. Updated `common` to only contain shared primitives (`id`, `error`, `temporal`).
 **Stability:** Enforced strict domain boundaries. `common` is now truly common.
+
+**[Architect] Service Trait Abstraction**
+**Tangle:** `Chronos` and `Shell` depended on concrete `Gallifrey` and `Vortex` structs, making testing difficult and violating Dependency Inversion Principle. `Gallifrey` leaked internal store implementations (`.knowledge()`, `.conversation()`).
+**Blueprint:**
+1. Defined `VortexService` trait in `vortex` and `GallifreyService` trait in `gallifrey`.
+2. Updated `Gallifrey` to be a true Facade, exposing all necessary methods (including `scan_history`, `create_session`) directly.
+3. Refactored `Chronos` to depend on `Arc<dyn VortexService>` and `Arc<dyn GallifreyService>`.
+4. Updated `Shell` and experimental tools to use the traits, handling object-safety for closures via `Box<dyn FnMut + Send>` and `Arc<Mutex>`.
+**Stability:** Decoupled core logic from implementations. Enabled easier mocking and substitution.

--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -8,23 +8,27 @@
 use crate::error::ChronosResult;
 use std::sync::Arc;
 use tardis_gallifrey::domain::Entity;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tardis_vortex::config::InferenceParams;
-use tardis_vortex::{ModelHandle, Vortex};
+use tardis_vortex::{ModelHandle, VortexService};
 use tracing::{info, instrument};
 
 /// The Curiosity engine.
 #[derive(Debug)]
 pub struct Curiosity {
-    gallifrey: Arc<Gallifrey>,
-    vortex: Arc<Vortex>,
+    gallifrey: Arc<dyn GallifreyService>,
+    vortex: Arc<dyn VortexService>,
     model: ModelHandle,
 }
 
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub fn new(
+        gallifrey: Arc<dyn GallifreyService>,
+        vortex: Arc<dyn VortexService>,
+        model: ModelHandle,
+    ) -> Self {
         Self {
             gallifrey,
             vortex,
@@ -41,33 +45,41 @@ impl Curiosity {
     pub async fn ask(&self) -> ChronosResult<String> {
         info!("Curiosity: Scanning for knowledge gaps...");
 
-        let mut target_entity: Option<Entity> = None;
+        // We use Arc<Mutex> because the trait object requires 'static lifetime for the closure
+        let target_entity = Arc::new(std::sync::Mutex::new(None));
+        let target_clone = target_entity.clone();
 
         // Scan history to find a sparse entity
         // Heuristic: Has fewer than 3 properties and is not a "System" type
         // We stop at the first one we find for now (MVP).
         self.gallifrey
-            .knowledge()
-            .scan_history(|history| {
-                if target_entity.is_some() {
-                    return;
-                }
+            .scan_history(Box::new(move |history| {
+                if let Ok(mut guard) = target_clone.lock() {
+                    if guard.is_some() {
+                        return;
+                    }
 
-                // Look at the latest version of the entity
-                if let Some(latest) = history.last() {
-                    if latest.properties.len() < 3
-                        && latest.entity_type != "System"
-                        && !latest.name.is_empty()
-                    {
-                        target_entity = Some(latest.clone());
+                    // Look at the latest version of the entity
+                    if let Some(latest) = history.last() {
+                        if latest.properties.len() < 3
+                            && latest.entity_type != "System"
+                            && !latest.name.is_empty()
+                        {
+                            *guard = Some(latest.clone());
+                        }
                     }
                 }
-            })
-            .map_err(|e| {
-                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
-            })?;
+            }))
+            .map_err(|e| crate::error::ChronosError::Common(e))?;
 
-        let Some(entity) = target_entity else {
+        let entity = {
+            let mut guard = target_entity
+                .lock()
+                .map_err(|e| crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            guard.take()
+        };
+
+        let Some(entity) = entity else {
             return Ok("I am content. My knowledge base feels complete... for now.".to_string());
         };
 

--- a/chronos/src/experimental/doctor.rs
+++ b/chronos/src/experimental/doctor.rs
@@ -6,10 +6,10 @@
 use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tardis_telemetry::gallifrey::TelemetryStore;
 use tardis_telemetry::types::Level;
-use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+use tardis_vortex::{InferenceParams, ModelHandle, VortexService};
 
 /// Vital signs of the system.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,15 +59,15 @@ pub struct Prescription {
 #[derive(Debug)]
 pub struct SystemDoctor {
     telemetry: Arc<TelemetryStore>,
-    gallifrey: Arc<Gallifrey>,
-    vortex: Option<Arc<Vortex>>,
+    gallifrey: Arc<dyn GallifreyService>,
+    vortex: Option<Arc<dyn VortexService>>,
     model_handle: Option<ModelHandle>,
 }
 
 impl SystemDoctor {
     /// Create a new System Doctor.
     #[must_use]
-    pub const fn new(telemetry: Arc<TelemetryStore>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(telemetry: Arc<TelemetryStore>, gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self {
             telemetry,
             gallifrey,
@@ -78,7 +78,7 @@ impl SystemDoctor {
 
     /// Attach Vortex AI engine.
     #[must_use]
-    pub fn with_vortex(mut self, vortex: Arc<Vortex>) -> Self {
+    pub fn with_vortex(mut self, vortex: Arc<dyn VortexService>) -> Self {
         self.vortex = Some(vortex);
         self
     }
@@ -174,7 +174,7 @@ impl SystemDoctor {
         let window = Duration::minutes(5);
         let from = now - window;
 
-        if let Ok(changes) = self.gallifrey.system_state().get_changes(from, now) {
+        if let Ok(changes) = self.gallifrey.get_system_changes(from, now) {
             for change in changes {
                 changes_desc.push(format!(
                     "Change to {} at {} ({:?})",
@@ -267,6 +267,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_doctor_diagnosis() {
+        use tardis_gallifrey::Gallifrey;
         // Setup
         let telemetry = Arc::new(TelemetryStore::new());
         let gallifrey = Arc::new(Gallifrey::new());
@@ -315,6 +316,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_doctor_ai_diagnosis() {
+        use tardis_gallifrey::Gallifrey;
         // Setup
         let telemetry = Arc::new(TelemetryStore::new());
         let gallifrey = Arc::new(Gallifrey::new());

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -43,10 +43,10 @@ use crate::error::{ChronosError, ChronosResult};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tardis_common::{EntityId, SessionId};
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 #[cfg(feature = "telemetry")]
 use tardis_telemetry::gallifrey::TelemetryStore;
-use tardis_vortex::Vortex;
+use tardis_vortex::VortexService;
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -146,8 +146,8 @@ pub struct RagResponse {
 /// The main Chronos RAG engine.
 #[derive(Debug)]
 pub struct Chronos {
-    vortex: Arc<Vortex>,
-    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<dyn VortexService>,
+    gallifrey: Arc<dyn GallifreyService>,
     #[cfg(feature = "telemetry")]
     telemetry: Option<Arc<TelemetryStore>>,
 }
@@ -155,7 +155,7 @@ pub struct Chronos {
 impl Chronos {
     /// Create a new Chronos instance.
     #[must_use]
-    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(vortex: Arc<dyn VortexService>, gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self {
             vortex,
             gallifrey,
@@ -174,7 +174,7 @@ impl Chronos {
 
     /// Get access to the underlying Vortex engine.
     #[must_use]
-    pub fn vortex(&self) -> Arc<Vortex> {
+    pub fn vortex(&self) -> Arc<dyn VortexService> {
         Arc::clone(&self.vortex)
     }
 
@@ -209,7 +209,7 @@ impl Chronos {
         info!("Query analyzed: {:?}", analysis.intent);
 
         // 2. Retrieve relevant context
-        let context = retriever::retrieve(&self.gallifrey, &analysis, &config).await?;
+        let context = retriever::retrieve(self.gallifrey.as_ref(), &analysis, &config).await?;
         info!("Retrieved {} context items", context.len());
 
         // 3. Augment the prompt

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -3,7 +3,7 @@
 use super::{ContextSource, ContextSourceType, RagConfig};
 use crate::error::{ChronosError, ChronosResult};
 use crate::pipeline::analyzer::AnalyzedQuery;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tracing::info;
 
 /// Retrieve context from all configured sources.
@@ -12,7 +12,7 @@ use tracing::info;
 ///
 /// Returns an error if retrieval fails.
 pub async fn retrieve(
-    gallifrey: &Gallifrey,
+    gallifrey: &dyn GallifreyService,
     query: &AnalyzedQuery,
     config: &RagConfig,
 ) -> ChronosResult<Vec<ContextSource>> {
@@ -49,7 +49,7 @@ pub async fn retrieve(
 /// Retrieve from knowledge graph.
 #[allow(clippy::unused_async)]
 async fn retrieve_knowledge(
-    gallifrey: &Gallifrey,
+    gallifrey: &dyn GallifreyService,
     _query: &AnalyzedQuery,
     config: &RagConfig,
     sources: &mut Vec<ContextSource>,
@@ -79,7 +79,7 @@ async fn retrieve_knowledge(
 /// Retrieve from conversation history.
 #[allow(clippy::unused_async)]
 async fn retrieve_conversation(
-    gallifrey: &Gallifrey,
+    gallifrey: &dyn GallifreyService,
     _query: &AnalyzedQuery,
     config: &RagConfig,
     sources: &mut Vec<ContextSource>,
@@ -125,7 +125,7 @@ async fn retrieve_conversation(
 /// Retrieve from system state.
 #[allow(clippy::unused_async)]
 async fn retrieve_system_state(
-    gallifrey: &Gallifrey,
+    gallifrey: &dyn GallifreyService,
     query: &AnalyzedQuery,
     _config: &RagConfig,
     sources: &mut Vec<ContextSource>,

--- a/gallifrey/src/experimental/time_capsule.rs
+++ b/gallifrey/src/experimental/time_capsule.rs
@@ -7,12 +7,13 @@
 
 use crate::domain::{Entity, Relationship};
 use crate::error::GallifreyResult;
-use crate::Gallifrey;
+use crate::traits::GallifreyService;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashSet, VecDeque};
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 /// A portable container for a knowledge subgraph.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -41,27 +42,43 @@ impl TimeCapsule {
     /// # Errors
     ///
     /// Returns an error if the root entity is not found or if graph traversal fails.
-    pub fn capture(gallifrey: &Gallifrey, root_name: &str, depth: usize) -> GallifreyResult<Self> {
-        let knowledge = gallifrey.knowledge();
+    pub async fn capture(
+        gallifrey: &dyn GallifreyService,
+        root_name: &str,
+        depth: usize,
+    ) -> GallifreyResult<Self> {
         let mut capsule = Self::new();
         let mut visited = HashSet::new();
         let mut queue = VecDeque::new();
 
-        // 1. Find the root entity
-        let mut root_id = None;
-        knowledge.scan_history(|history| {
-            // Find the most current version of the entity with the matching name
-            if let Some(entity) = history
-                .iter()
-                .find(|e| e.name == root_name && e.temporal.is_current())
-            {
-                root_id = Some(entity.id);
-            }
-        })?;
+        let root_name_owned = root_name.to_string();
+        let root_id_found = Arc::new(Mutex::new(None));
+        let root_id_clone = root_id_found.clone();
 
-        let root_id = root_id.ok_or_else(|| {
-            crate::error::GallifreyError::EntityNotFound(format!("Name: {root_name}"))
-        })?;
+        // 1. Find the root entity
+        gallifrey.scan_history(Box::new(move |history| {
+            if let Ok(mut guard) = root_id_clone.lock() {
+                if guard.is_some() {
+                    return;
+                }
+                // Find the most current version of the entity with the matching name
+                if let Some(entity) = history
+                    .iter()
+                    .find(|e| e.name == root_name_owned && e.temporal.is_current())
+                {
+                    *guard = Some(entity.id);
+                }
+            }
+        }))?;
+
+        let root_id = {
+            let guard = root_id_found.lock().map_err(|e| {
+                crate::error::GallifreyError::Internal(format!("Mutex error: {e}"))
+            })?;
+            guard.ok_or_else(|| {
+                crate::error::GallifreyError::EntityNotFound(format!("Name: {root_name}"))
+            })?
+        };
 
         queue.push_back((root_id, 0));
         visited.insert(root_id);
@@ -71,7 +88,7 @@ impl TimeCapsule {
         // 2. BFS Traversal
         while let Some((current_id, current_depth)) = queue.pop_front() {
             // Add entity history to capsule
-            if let Ok(history) = knowledge.get_entity_history(current_id) {
+            if let Ok(history) = gallifrey.get_history(current_id).await {
                 capsule.entities.extend(history);
             }
 
@@ -80,33 +97,52 @@ impl TimeCapsule {
             }
 
             // Find relationships
-            let mut next_ids = Vec::new();
-            knowledge.scan_relationships(|rels| {
-                for rel in rels {
-                    // Outgoing edges
-                    if rel.source == current_id {
-                        if visited_rels.insert(rel.id) {
-                            capsule.relationships.push(rel.clone());
-                        }
-                        if !visited.contains(&rel.target) {
-                            next_ids.push(rel.target);
-                        }
-                    }
-                    // Incoming edges (optional, but good for context)
-                    if rel.target == current_id {
-                        if visited_rels.insert(rel.id) {
-                            capsule.relationships.push(rel.clone());
-                        }
-                        if !visited.contains(&rel.source) {
-                            next_ids.push(rel.source);
+            // We need to collect next_ids and relationships in a thread-safe way for the closure
+            let captured_rels = Arc::new(Mutex::new(Vec::new()));
+            let next_ids_found = Arc::new(Mutex::new(Vec::new()));
+            let captured_rels_clone = captured_rels.clone();
+            let next_ids_clone = next_ids_found.clone();
+            // We need to pass the current set of visited nodes to avoid re-visiting?
+            // No, the closure is just scanning. We process the results after.
+            // But we need to know `visited_rels` to avoid duplicates.
+            // But `visited_rels` is local. We can't access it in the closure easily if we want to mutate it.
+            // Easier: collect all relevant rels, then filter in the main loop.
+
+            gallifrey.scan_relationships(Box::new(move |rels| {
+                if let Ok(mut rels_guard) = captured_rels_clone.lock() {
+                    if let Ok(mut next_ids_guard) = next_ids_clone.lock() {
+                        for rel in rels {
+                            // Outgoing edges
+                            if rel.source == current_id {
+                                rels_guard.push(rel.clone());
+                                next_ids_guard.push(rel.target);
+                            }
+                            // Incoming edges (optional, but good for context)
+                            if rel.target == current_id {
+                                rels_guard.push(rel.clone());
+                                next_ids_guard.push(rel.source);
+                            }
                         }
                     }
                 }
+            }))?;
+
+            let rels_to_process = captured_rels.lock().map_err(|e| {
+                crate::error::GallifreyError::Internal(format!("Mutex error: {e}"))
+            })?;
+            let ids_to_process = next_ids_found.lock().map_err(|e| {
+                crate::error::GallifreyError::Internal(format!("Mutex error: {e}"))
             })?;
 
-            for id in next_ids {
-                if visited.insert(id) {
-                    queue.push_back((id, current_depth + 1));
+            for rel in rels_to_process.iter() {
+                if visited_rels.insert(rel.id) {
+                    capsule.relationships.push(rel.clone());
+                }
+            }
+
+            for id in ids_to_process.iter() {
+                if !visited.contains(id) && visited.insert(*id) {
+                    queue.push_back((*id, current_depth + 1));
                 }
             }
         }
@@ -123,26 +159,18 @@ impl TimeCapsule {
     /// # Errors
     ///
     /// Returns an error if insertion fails.
-    pub async fn restore(&self, gallifrey: &Gallifrey) -> GallifreyResult<()> {
+    pub async fn restore(&self, gallifrey: &dyn GallifreyService) -> GallifreyResult<()> {
         // Insert entities
         for entity in &self.entities {
             // We use the public insert method which handles locking
-            // Note: In a real system, we might want to check for conflicts or merge strategies.
-            // Here, we trust Gallifrey's append-only nature.
-            // However, inserting an entity with an existing ID will create a new version.
-            // If the entity is historical (not current), we might need special handling if we want to preserve exact history.
-            // But Gallifrey::insert creates a new version with *current* transaction time.
-            // This means restored history becomes "new knowledge about the past".
-            // This is actually correct for a bitemporal system receiving data!
             let _ = gallifrey.insert(entity.clone()).await.map_err(|e| {
                 crate::error::GallifreyError::StorageError(format!("Failed to insert entity: {e}"))
             })?;
         }
 
         // Insert relationships
-        let knowledge = gallifrey.knowledge();
         for rel in &self.relationships {
-            knowledge.insert_relationship(rel.clone())?;
+            gallifrey.insert_relationship(rel.clone())?;
         }
 
         Ok(())
@@ -211,6 +239,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_capture_restore() {
+        use crate::Gallifrey;
         let source_gallifrey = Gallifrey::new();
         let target_gallifrey = Gallifrey::new();
 
@@ -232,12 +261,11 @@ mod tests {
             temporal: BiTemporalInterval::now(),
         };
         source_gallifrey
-            .knowledge()
             .insert_relationship(rel)
             .unwrap();
 
         // Capture with depth 2 to ensure deduplication works (B will be processed)
-        let capsule = TimeCapsule::capture(&source_gallifrey, "A", 2).unwrap();
+        let capsule = TimeCapsule::capture(&source_gallifrey, "A", 2).await.unwrap();
         assert_eq!(capsule.entities.len(), 2); // A and B
         assert_eq!(capsule.relationships.len(), 1); // Should be 1 (deduplicated)
 

--- a/gallifrey/src/lib.rs
+++ b/gallifrey/src/lib.rs
@@ -78,13 +78,15 @@ pub mod error;
 pub mod experimental;
 pub mod stores;
 pub mod temporal;
+pub mod traits;
 
 // Re-export main types
 pub use error::{GallifreyError, GallifreyResult};
 pub use stores::{ConversationStore, KnowledgeStore, SystemStateStore};
 pub use temporal::{BiTemporalInterval, TimeRange};
+pub use traits::GallifreyService;
 
-use crate::domain::{Change, Entity, Message, Snapshot};
+use crate::domain::{Change, Entity, Message, Relationship, Snapshot};
 use std::sync::Arc;
 use tardis_common::id::{EntityId, SessionId};
 
@@ -199,6 +201,28 @@ impl Gallifrey {
             .map_err(|e| tardis_common::Error::Internal(e.to_string()))
     }
 
+    /// Create a new conversation session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if session creation fails.
+    pub fn create_session(&self) -> tardis_common::Result<SessionId> {
+        self.conversation
+            .create_session()
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    /// End a conversation session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if session ending fails.
+    pub fn end_session(&self, session_id: SessionId) -> tardis_common::Result<()> {
+        self.conversation
+            .end_session(session_id)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
     // --- Conversation ---
 
     /// Get recent messages from a session.
@@ -259,6 +283,80 @@ impl Gallifrey {
     pub async fn record_change(&self, change: Change) -> tardis_common::Result<()> {
         self.system_state
             .record_change(change)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    /// Get system changes in a time range.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if retrieval fails.
+    #[allow(clippy::unused_async)]
+    pub fn get_system_changes(
+        &self,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Vec<Change>> {
+        self.system_state
+            .get_changes(from, to)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    /// Scan entity history.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if scanning fails.
+    #[cfg(feature = "nova")]
+    pub fn scan_history<F>(&self, f: F) -> tardis_common::Result<()>
+    where
+        F: FnMut(&[Entity]),
+    {
+        self.knowledge
+            .scan_history(f)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    /// Scan relationships.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if scanning fails.
+    #[cfg(feature = "nova")]
+    pub fn scan_relationships<F>(&self, f: F) -> tardis_common::Result<()>
+    where
+        F: FnMut(&[Relationship]),
+    {
+        self.knowledge
+            .scan_relationships(f)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    /// Insert a relationship.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if insertion fails.
+    pub fn insert_relationship(&self, rel: Relationship) -> tardis_common::Result<()> {
+        self.knowledge
+            .insert_relationship(rel)
+            .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+            .map(|_| ())
+    }
+
+    /// Get an entity at a specific point in bi-temporal time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if retrieval fails.
+    pub fn get_entity_at(
+        &self,
+        id: EntityId,
+        valid_time: chrono::DateTime<chrono::Utc>,
+        transaction_time: chrono::DateTime<chrono::Utc>,
+    ) -> tardis_common::Result<Option<Entity>> {
+        self.knowledge
+            .get_entity_at(id, valid_time, transaction_time)
             .map_err(|e| tardis_common::Error::Internal(e.to_string()))
     }
 }

--- a/gallifrey/src/traits.rs
+++ b/gallifrey/src/traits.rs
@@ -1,0 +1,152 @@
+use crate::domain::{Change, Entity, Message, Relationship, Snapshot};
+use async_trait::async_trait;
+use tardis_common::id::{EntityId, SessionId};
+use tardis_common::Result;
+
+/// The Gallifrey service trait.
+#[async_trait]
+pub trait GallifreyService: Send + Sync + std::fmt::Debug {
+    /// Insert a node into the knowledge graph.
+    async fn insert(&self, node: Entity) -> Result<EntityId>;
+
+    /// Update an existing node.
+    async fn update(&self, id: EntityId, properties: serde_json::Value) -> Result<()>;
+
+    /// Get the history of an entity.
+    async fn get_history(&self, id: EntityId) -> Result<Vec<Entity>>;
+
+    /// Semantic search for entities.
+    async fn search_knowledge(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>>;
+
+    /// Get recent messages from a session.
+    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>>;
+
+    /// Semantic search for messages.
+    async fn search_conversation(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> Result<Vec<Message>>;
+
+    /// Create a new conversation session.
+    fn create_session(&self) -> Result<SessionId>;
+
+    /// End a conversation session.
+    fn end_session(&self, session_id: SessionId) -> Result<()>;
+
+    /// Find a system snapshot at a specific time.
+    async fn find_snapshot(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<Snapshot>>;
+
+    /// Record a system change.
+    async fn record_change(&self, change: Change) -> Result<()>;
+
+    /// Get system changes in a time range.
+    fn get_system_changes(
+        &self,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<Change>>;
+
+    /// Scan entity history.
+    #[cfg(feature = "nova")]
+    fn scan_history(&self, callback: Box<dyn FnMut(&[Entity]) + Send>) -> Result<()>;
+
+    /// Scan relationships.
+    #[cfg(feature = "nova")]
+    fn scan_relationships(&self, callback: Box<dyn FnMut(&[Relationship]) + Send>) -> Result<()>;
+
+    /// Insert a relationship.
+    fn insert_relationship(&self, rel: Relationship) -> Result<()>;
+
+    /// Get an entity at a specific point in bi-temporal time.
+    fn get_entity_at(
+        &self,
+        id: EntityId,
+        valid_time: chrono::DateTime<chrono::Utc>,
+        transaction_time: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<Entity>>;
+}
+
+#[async_trait]
+impl GallifreyService for crate::Gallifrey {
+    async fn insert(&self, node: Entity) -> Result<EntityId> {
+        self.insert(node).await
+    }
+
+    async fn update(&self, id: EntityId, properties: serde_json::Value) -> Result<()> {
+        self.update(id, properties).await
+    }
+
+    async fn get_history(&self, id: EntityId) -> Result<Vec<Entity>> {
+        self.get_history(id).await
+    }
+
+    async fn search_knowledge(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>> {
+        self.search_knowledge(embedding, limit).await
+    }
+
+    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>> {
+        self.get_recent_messages(session_id, limit).await
+    }
+
+    async fn search_conversation(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> Result<Vec<Message>> {
+        self.search_conversation(embedding, limit).await
+    }
+
+    fn create_session(&self) -> Result<SessionId> {
+        self.create_session()
+    }
+
+    fn end_session(&self, session_id: SessionId) -> Result<()> {
+        self.end_session(session_id)
+    }
+
+    async fn find_snapshot(
+        &self,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<Snapshot>> {
+        self.find_snapshot(timestamp).await
+    }
+
+    async fn record_change(&self, change: Change) -> Result<()> {
+        self.record_change(change).await
+    }
+
+    fn get_system_changes(
+        &self,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<Change>> {
+        self.get_system_changes(from, to)
+    }
+
+    #[cfg(feature = "nova")]
+    fn scan_history(&self, mut callback: Box<dyn FnMut(&[Entity]) + Send>) -> Result<()> {
+        self.scan_history(|entities| callback(entities))
+    }
+
+    #[cfg(feature = "nova")]
+    fn scan_relationships(&self, mut callback: Box<dyn FnMut(&[Relationship]) + Send>) -> Result<()> {
+        self.scan_relationships(|rels| callback(rels))
+    }
+
+    fn insert_relationship(&self, rel: Relationship) -> Result<()> {
+        self.insert_relationship(rel)
+    }
+
+    fn get_entity_at(
+        &self,
+        id: EntityId,
+        valid_time: chrono::DateTime<chrono::Utc>,
+        transaction_time: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<Entity>> {
+        self.get_entity_at(id, valid_time, transaction_time)
+    }
+}

--- a/shell/src/commands/knowledge.rs
+++ b/shell/src/commands/knowledge.rs
@@ -17,7 +17,7 @@ impl ShellCommand for HistoryCommand {
     }
 
     async fn execute(&self, _args: &[String], context: &CommandContext) -> Result<CommandResult> {
-        crate::commands::history(&context.gallifrey, context.session_id);
+        crate::commands::history(context.gallifrey.as_ref(), context.session_id).await;
         Ok(CommandResult::Continue)
     }
 }

--- a/shell/src/commands/mod.rs
+++ b/shell/src/commands/mod.rs
@@ -23,9 +23,8 @@ pub mod experimental;
 /// Knowledge management commands.
 pub mod knowledge;
 
-use std::sync::Arc;
 use tardis_common::SessionId;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 
 /// Display help information.
 ///
@@ -144,8 +143,9 @@ fn command_help(command: &str) {
 /// Show conversation history.
 ///
 /// Fetches and displays recent messages from the current session.
-pub fn history(gallifrey: &Arc<Gallifrey>, session_id: SessionId) {
-    match gallifrey.conversation().get_messages(session_id) {
+pub async fn history(gallifrey: &dyn GallifreyService, session_id: SessionId) {
+    // Fetch a large number to show counts
+    match gallifrey.get_recent_messages(session_id, 1000).await {
         Ok(messages) => {
             if messages.is_empty() {
                 println!("No messages in current session.");

--- a/shell/src/commands/traits.rs
+++ b/shell/src/commands/traits.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::sync::Arc;
 use tardis_chronos::Chronos;
 use tardis_common::SessionId;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tardis_telemetry::gallifrey::TelemetryStore;
 
 #[cfg(feature = "nova")]
@@ -13,7 +13,7 @@ use tardis_chronos::experimental::prophecy::Prophet;
 /// Context provided to every shell command.
 pub struct CommandContext {
     /// Access to the Knowledge Graph.
-    pub gallifrey: Arc<Gallifrey>,
+    pub gallifrey: Arc<dyn GallifreyService>,
     /// Access to the RAG Engine.
     pub chronos: Arc<Chronos>,
     /// Access to Telemetry (optional).
@@ -28,7 +28,7 @@ pub struct CommandContext {
 impl fmt::Debug for CommandContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CommandContext")
-            .field("gallifrey", &"Arc<Gallifrey>")
+            .field("gallifrey", &"Arc<dyn GallifreyService>")
             .field("chronos", &"Arc<Chronos>")
             .field("telemetry", &self.telemetry.is_some())
             .field("session_id", &self.session_id)

--- a/shell/src/dashboard.rs
+++ b/shell/src/dashboard.rs
@@ -25,7 +25,8 @@ pub mod tui {
     #[cfg(feature = "nova")]
     use tardis_chronos::experimental::prophecy::Prophet;
     use tardis_gallifrey::domain::Entity;
-    use tardis_gallifrey::{experimental::heatmap::TemporalHeatmap, Gallifrey};
+    use tardis_gallifrey::experimental::heatmap::TemporalHeatmap;
+    use tardis_gallifrey::GallifreyService;
     use tardis_telemetry::{gallifrey::TelemetryStore, types::MetricValue};
 
     /// Shared data for the dashboard.
@@ -38,7 +39,7 @@ pub mod tui {
     /// The interactive dashboard.
     #[derive(Debug)]
     pub struct Dashboard {
-        _gallifrey: Arc<Gallifrey>,
+        _gallifrey: Arc<dyn GallifreyService>,
         heatmap: TemporalHeatmap,
         telemetry: Option<Arc<TelemetryStore>>,
         data: Arc<Mutex<DashboardData>>,
@@ -60,17 +61,26 @@ pub mod tui {
         ///
         /// Returns an error if history cannot be scanned.
         pub fn new(
-            gallifrey: Arc<Gallifrey>,
+            gallifrey: Arc<dyn GallifreyService>,
             telemetry: Option<Arc<TelemetryStore>>,
             #[cfg(feature = "nova")] prophet: Option<Arc<Prophet>>,
         ) -> Result<Self> {
             // Fetch history for heatmap
-            let mut all_history = Vec::new();
-            gallifrey.knowledge().scan_history(|history| {
-                all_history.extend_from_slice(history);
-            })?;
+            let all_history = Arc::new(Mutex::new(Vec::new()));
+            let all_history_clone = all_history.clone();
 
-            let heatmap = TemporalHeatmap::new(&all_history, 50, 20);
+            gallifrey.scan_history(Box::new(move |history| {
+                if let Ok(mut guard) = all_history_clone.lock() {
+                    guard.extend_from_slice(history);
+                }
+            }))?;
+
+            let history_vec = {
+                let guard = all_history.lock().map_err(|e| anyhow::anyhow!("Mutex error: {e}"))?;
+                guard.clone()
+            };
+
+            let heatmap = TemporalHeatmap::new(&history_vec, 50, 20);
             let data = Arc::new(Mutex::new(DashboardData::default()));
 
             // Spawn background task for prophecies

--- a/shell/src/experimental/biographer.rs
+++ b/shell/src/experimental/biographer.rs
@@ -5,22 +5,22 @@
 
 use std::fmt::Write;
 use std::sync::Arc;
-use tardis_gallifrey::Gallifrey;
-use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+use tardis_gallifrey::GallifreyService;
+use tardis_vortex::{InferenceParams, ModelHandle, VortexService};
 
 /// The Biographer engine.
 #[derive(Debug)]
 pub struct Biographer {
-    gallifrey: Arc<Gallifrey>,
-    vortex: Arc<Vortex>,
+    gallifrey: Arc<dyn GallifreyService>,
+    vortex: Arc<dyn VortexService>,
     model: Option<ModelHandle>,
 }
 
 impl Biographer {
     /// Create a new Biographer.
-    pub const fn new(
-        gallifrey: Arc<Gallifrey>,
-        vortex: Arc<Vortex>,
+    pub fn new(
+        gallifrey: Arc<dyn GallifreyService>,
+        vortex: Arc<dyn VortexService>,
         model: Option<ModelHandle>,
     ) -> Self {
         Self {
@@ -38,23 +38,37 @@ impl Biographer {
     pub async fn biography(&self, name: &str) -> anyhow::Result<String> {
         // 1. Find the entity ID by name
         // We scan history because we want *any* version of the entity that had this name.
-        let mut target_id = None;
+        let target_id = Arc::new(std::sync::Mutex::new(None));
+        let target_clone = target_id.clone();
+        let name_lower = name.to_lowercase();
 
         // Use scan_history (gated by nova in gallifrey)
         #[cfg(feature = "nova")]
-        self.gallifrey.knowledge().scan_history(|history| {
-            if target_id.is_some() {
-                return;
-            }
-            // Check if any version has the name
-            if history.iter().any(|e| e.name.eq_ignore_ascii_case(name)) {
-                if let Some(first) = history.first() {
-                    target_id = Some(first.id);
+        self.gallifrey
+            .scan_history(Box::new(move |history| {
+                if let Ok(mut guard) = target_clone.lock() {
+                    if guard.is_some() {
+                        return;
+                    }
+                    // Check if any version has the name
+                    if history
+                        .iter()
+                        .any(|e| e.name.eq_ignore_ascii_case(&name_lower))
+                    {
+                        if let Some(first) = history.first() {
+                            *guard = Some(first.id);
+                        }
+                    }
                 }
-            }
-        })?;
+            }))
+            .map_err(|e| anyhow::anyhow!("Failed to scan history: {e}"))?;
 
-        let id = target_id.ok_or_else(|| anyhow::anyhow!("Entity '{name}' not found"))?;
+        let id = {
+            let guard = target_id
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Mutex error: {e}"))?;
+            guard.ok_or_else(|| anyhow::anyhow!("Entity '{name}' not found"))?
+        };
 
         // 2. Get full history
         let history = self.gallifrey.get_history(id).await?;
@@ -119,6 +133,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_biography_generation() {
+        use tardis_gallifrey::Gallifrey;
+        use tardis_vortex::Vortex;
+
         // Setup
         let gallifrey = Arc::new(Gallifrey::new());
         let vortex = Arc::new(Vortex::new().unwrap());

--- a/shell/src/experimental/chronograph.rs
+++ b/shell/src/experimental/chronograph.rs
@@ -12,18 +12,18 @@ use std::fmt::Write;
 use std::sync::Arc;
 use tardis_common::id::EntityId;
 use tardis_gallifrey::domain::Entity;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 
 /// The `ChronoGraph` visualizer.
 #[derive(Debug)]
 pub struct ChronoGraph {
-    gallifrey: Arc<Gallifrey>,
+    gallifrey: Arc<dyn GallifreyService>,
 }
 
 impl ChronoGraph {
     /// Create a new `ChronoGraph`.
     #[must_use]
-    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(gallifrey: Arc<dyn GallifreyService>) -> Self {
         Self { gallifrey }
     }
 
@@ -69,8 +69,8 @@ impl ChronoGraph {
 
         let mut history = self
             .gallifrey
-            .knowledge()
-            .get_entity_history(root.id)
+            .get_history(root.id)
+            .await
             .map_err(|e| anyhow!(e.to_string()))?;
 
         // Sort by valid time start (primary) and transaction time start (secondary)
@@ -137,31 +137,40 @@ impl ChronoGraph {
     }
 
     fn find_entity_by_name(&self, name: &str, time: Option<DateTime<Utc>>) -> Result<Entity> {
-        let knowledge = self.gallifrey.knowledge();
-        let mut found = None;
+        let found = Arc::new(std::sync::Mutex::new(None));
+        let found_clone = found.clone();
+        let name_owned = name.to_string();
 
         // Scan all entities to find the one with the matching name
-        knowledge.scan_history(|history| {
-            if found.is_some() {
-                return;
-            }
+        self.gallifrey
+            .scan_history(Box::new(move |history| {
+                if let Ok(mut guard) = found_clone.lock() {
+                    if guard.is_some() {
+                        return;
+                    }
 
-            let entity = if let Some(t) = time {
-                history
-                    .iter()
-                    .find(|e| e.name == name && e.temporal.valid_time.contains(t))
-            } else {
-                history
-                    .iter()
-                    .find(|e| e.name == name && e.temporal.is_current())
-            };
+                    let entity = if let Some(t) = time {
+                        history.iter().find(|e| {
+                            e.name == name_owned && e.temporal.valid_time.contains(t)
+                        })
+                    } else {
+                        history
+                            .iter()
+                            .find(|e| e.name == name_owned && e.temporal.is_current())
+                    };
 
-            if let Some(e) = entity {
-                found = Some(e.clone());
-            }
-        })?;
+                    if let Some(e) = entity {
+                        *guard = Some(e.clone());
+                    }
+                }
+            }))
+            .map_err(|e| anyhow!(e.to_string()))?;
 
-        found.ok_or_else(|| anyhow!("Entity '{name}' not found"))
+        let res = {
+            let mut guard = found.lock().map_err(|e| anyhow!("Mutex error: {e}"))?;
+            guard.take()
+        };
+        res.ok_or_else(|| anyhow!("Entity '{name}' not found"))
     }
 
     fn traverse(
@@ -222,38 +231,50 @@ impl ChronoGraph {
         entity_id: EntityId,
         time: Option<DateTime<Utc>>,
     ) -> Result<Vec<tardis_gallifrey::domain::Relationship>> {
-        let knowledge = self.gallifrey.knowledge();
-        let mut relevant = Vec::new();
+        let relevant = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let relevant_clone = relevant.clone();
 
-        knowledge.scan_relationships(|rels| {
-            for rel in rels {
-                if rel.source != entity_id {
-                    continue;
+        self.gallifrey
+            .scan_relationships(Box::new(move |rels| {
+                if let Ok(mut guard) = relevant_clone.lock() {
+                    for rel in rels {
+                        if rel.source != entity_id {
+                            continue;
+                        }
+
+                        let is_valid = if let Some(t) = time {
+                            rel.temporal.valid_time.contains(t)
+                        } else {
+                            rel.temporal.is_current()
+                        };
+
+                        if is_valid {
+                            guard.push(rel.clone());
+                        }
+                    }
                 }
+            }))
+            .map_err(|e| anyhow!(e.to_string()))?;
 
-                let is_valid = if let Some(t) = time {
-                    rel.temporal.valid_time.contains(t)
-                } else {
-                    rel.temporal.is_current()
-                };
-
-                if is_valid {
-                    relevant.push(rel.clone());
-                }
-            }
-        })?;
-
-        Ok(relevant)
+        let res = relevant
+            .lock()
+            .map_err(|e| anyhow!("Mutex error: {e}"))?;
+        Ok(res.clone())
     }
 
     fn resolve_entity(&self, id: EntityId, time: Option<DateTime<Utc>>) -> Result<Option<Entity>> {
-        let knowledge = self.gallifrey.knowledge();
         if let Some(t) = time {
-            knowledge
+            self.gallifrey
                 .get_entity_at(id, t, Utc::now())
                 .map_err(|e| anyhow!(e.to_string()))
         } else {
-            knowledge.get_entity(id).map_err(|e| anyhow!(e.to_string()))
+            // If no time specified, get current. But Gallifrey facade doesn't expose get_entity(id) directly
+            // except via get_history (then pick last) or get_entity_at(now).
+            // `get_history` is overkill.
+            // But wait, `get_entity_at` with `now` is correct for current view.
+            self.gallifrey
+                .get_entity_at(id, Utc::now(), Utc::now())
+                .map_err(|e| anyhow!(e.to_string()))
         }
     }
 }
@@ -282,6 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_chronograph_basic() {
+        use tardis_gallifrey::Gallifrey;
         let gallifrey = Arc::new(Gallifrey::new());
         let graph = ChronoGraph::new(gallifrey.clone());
 
@@ -316,6 +338,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_chronograph_cycle() {
+        use tardis_gallifrey::Gallifrey;
         let gallifrey = Arc::new(Gallifrey::new());
         let graph = ChronoGraph::new(gallifrey.clone());
 
@@ -347,8 +370,8 @@ mod tests {
             temporal: BiTemporalInterval::now(),
         };
 
-        gallifrey.knowledge().insert_relationship(rel1).unwrap();
-        gallifrey.knowledge().insert_relationship(rel2).unwrap();
+        gallifrey.insert_relationship(rel1).unwrap();
+        gallifrey.insert_relationship(rel2).unwrap();
 
         let map = graph.generate_map("A", 3, None).unwrap();
         println!("{}", map);
@@ -361,6 +384,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_chronograph_timeline() {
+        use tardis_gallifrey::Gallifrey;
         let gallifrey = Arc::new(Gallifrey::new());
         let graph = ChronoGraph::new(gallifrey.clone());
 

--- a/shell/src/experimental/heatmap_cmd.rs
+++ b/shell/src/experimental/heatmap_cmd.rs
@@ -4,38 +4,48 @@
 
 use anyhow::{anyhow, Result};
 use std::fmt::Write;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tardis_gallifrey::domain::Entity;
 use tardis_gallifrey::experimental::entropy::EntropyGauge;
 use tardis_gallifrey::experimental::heatmap::TemporalHeatmap;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 
 /// Run the heatmap command.
 ///
 /// # Errors
 ///
 /// Returns an error if the entity is not found or arguments are invalid.
-pub fn run(gallifrey: &Arc<Gallifrey>, args: &[String]) -> Result<String> {
+pub fn run(gallifrey: &Arc<dyn GallifreyService>, args: &[String]) -> Result<String> {
     if args.is_empty() {
         return Ok("Usage: heatmap <entity_name>".to_string());
     }
     let name = &args[0];
-    let knowledge = gallifrey.knowledge();
 
-    let mut found_history: Option<Vec<Entity>> = None;
+    let found_history = Arc::new(Mutex::new(None));
+    let found_history_clone = found_history.clone();
+    let name_owned = name.to_string();
 
     // Scan to find the entity history by name
-    knowledge.scan_history(|history| {
-        if found_history.is_some() {
-            return;
+    gallifrey.scan_history(Box::new(move |history| {
+        if let Ok(mut guard) = found_history_clone.lock() {
+            if guard.is_some() {
+                return;
+            }
+            // Check if any version of this entity matches the name
+            if history.iter().any(|e| e.name == name_owned) {
+                *guard = Some(history.to_vec());
+            }
         }
-        // Check if any version of this entity matches the name
-        if history.iter().any(|e| e.name == *name) {
-            found_history = Some(history.to_vec());
-        }
-    })?;
+    }))?;
 
-    if let Some(history) = found_history {
+    let history_opt = {
+        let mut guard = found_history
+            .lock()
+            .map_err(|e| anyhow!("Mutex error: {e}"))?;
+        guard.take()
+    };
+
+    if let Some(history) = history_opt {
         // Create heatmap (20 bins X, 10 bins Y)
         let heatmap = TemporalHeatmap::new(&history, 40, 15);
         let entropy = EntropyGauge::measure(&history);
@@ -83,7 +93,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_heatmap_run() {
-        let gallifrey = Arc::new(Gallifrey::new());
+        use tardis_gallifrey::Gallifrey;
+        let gallifrey: Arc<dyn GallifreyService> = Arc::new(Gallifrey::new());
         let entity = create_test_entity("TestEntity");
         gallifrey.insert(entity).await.unwrap();
 
@@ -99,7 +110,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_heatmap_not_found() {
-        let gallifrey = Arc::new(Gallifrey::new());
+        use tardis_gallifrey::Gallifrey;
+        let gallifrey: Arc<dyn GallifreyService> = Arc::new(Gallifrey::new());
         let args = vec!["NonExistent".to_string()];
         let result = run(&gallifrey, &args);
 

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -14,9 +14,9 @@ use std::path::Path;
 use std::sync::Arc;
 use tardis_chronos::experimental::doctor::{HealthStatus, SystemDoctor};
 use tardis_chronos::experimental::psychic_paper::{Intent, PsychicPaper};
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tardis_telemetry::gallifrey::TelemetryStore;
-use tardis_vortex::{ModelHandle, Vortex};
+use tardis_vortex::{ModelHandle, VortexService};
 
 /// Maximum file size for inspection/repair (10 MB).
 const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
@@ -26,18 +26,18 @@ const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 pub struct SonicScrewdriver {
     paper: PsychicPaper,
     telemetry: Option<Arc<TelemetryStore>>,
-    gallifrey: Option<Arc<Gallifrey>>,
-    vortex: Option<Arc<Vortex>>,
+    gallifrey: Option<Arc<dyn GallifreyService>>,
+    vortex: Option<Arc<dyn VortexService>>,
     model_handle: Option<ModelHandle>,
 }
 
 impl SonicScrewdriver {
     /// Create a new Sonic Screwdriver.
     #[must_use]
-    pub const fn new(
+    pub fn new(
         telemetry: Option<Arc<TelemetryStore>>,
-        gallifrey: Option<Arc<Gallifrey>>,
-        vortex: Option<Arc<Vortex>>,
+        gallifrey: Option<Arc<dyn GallifreyService>>,
+        vortex: Option<Arc<dyn VortexService>>,
         model_handle: Option<ModelHandle>,
     ) -> Self {
         Self {
@@ -322,8 +322,10 @@ mod tests {
     #[tokio::test]
     async fn test_doctor_integration() {
         use std::collections::HashMap;
+        use tardis_gallifrey::Gallifrey;
         use tardis_telemetry::types::{Level, Subsystem, TraceId};
         use tardis_telemetry::userspace::layer::EventData;
+        use tardis_vortex::Vortex;
 
         // Setup dependencies
         let telemetry = Arc::new(TelemetryStore::new());

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -10,7 +10,7 @@ use rustyline::{DefaultEditor, Result as RlResult};
 use std::sync::Arc;
 use tardis_chronos::{Chronos, RagConfig};
 use tardis_common::SessionId;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::GallifreyService;
 use tardis_telemetry::gallifrey::TelemetryStore;
 use tracing::{error, info};
 
@@ -29,7 +29,7 @@ pub struct Repl {
     /// Chronos RAG engine.
     chronos: Arc<Chronos>,
     /// Gallifrey database.
-    gallifrey: Arc<Gallifrey>,
+    gallifrey: Arc<dyn GallifreyService>,
     /// Telemetry store (optional).
     #[allow(dead_code)]
     telemetry_store: Option<Arc<TelemetryStore>>,
@@ -50,14 +50,14 @@ impl Repl {
     /// Returns an error if initialization fails.
     pub fn new(
         chronos: Arc<Chronos>,
-        gallifrey: Arc<Gallifrey>,
+        gallifrey: Arc<dyn GallifreyService>,
         telemetry_store: Option<Arc<TelemetryStore>>,
         #[cfg(feature = "nova")] prophet: Option<Arc<Prophet>>,
     ) -> Result<Self> {
         let editor = DefaultEditor::new()?;
 
         // Create a new session
-        let session_id = gallifrey.conversation().create_session()?;
+        let session_id = gallifrey.create_session()?;
         info!("Created session: {}", session_id);
 
         let mut registry = CommandRegistry::new();
@@ -135,7 +135,7 @@ impl Repl {
         }
 
         // End session
-        self.gallifrey.conversation().end_session(self.session_id)?;
+        self.gallifrey.end_session(self.session_id)?;
 
         Ok(())
     }

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -48,6 +48,7 @@ pub mod inference;
 pub mod loader;
 pub mod model;
 pub mod tokenizer;
+pub mod traits;
 
 // Re-export main types
 pub use config::{InferenceParams, ModelLoadConfig};
@@ -56,3 +57,4 @@ pub use inference::Vortex;
 pub use loader::ModelPreset;
 pub use model::{ModelHandle, ModelInfo, ModelRegistry};
 pub use tokenizer::TokenizerService;
+pub use traits::VortexService;

--- a/vortex/src/traits.rs
+++ b/vortex/src/traits.rs
@@ -1,0 +1,93 @@
+use crate::config::{InferenceParams, ModelLoadConfig};
+use crate::error::VortexResult;
+use crate::loader::ModelPreset;
+use crate::model::{ModelHandle, ModelInfo};
+use async_trait::async_trait;
+
+/// The Vortex service trait.
+#[async_trait]
+pub trait VortexService: Send + Sync + std::fmt::Debug {
+    /// Load a model from disk.
+    async fn load_model(&self, path: &str, config: ModelLoadConfig) -> VortexResult<ModelHandle>;
+
+    /// Load a preset model.
+    async fn load_preset(
+        &self,
+        preset: ModelPreset,
+        device: Option<&str>,
+    ) -> VortexResult<ModelHandle>;
+
+    /// Run inference on a model.
+    async fn infer(
+        &self,
+        handle: ModelHandle,
+        prompt: &str,
+        params: InferenceParams,
+    ) -> VortexResult<String>;
+
+    /// Generate embeddings for text.
+    async fn embed(&self, handle: ModelHandle, text: &str) -> VortexResult<Vec<f32>>;
+
+    /// List available models.
+    fn list_models(&self) -> Vec<ModelInfo>;
+
+    /// List loaded models and their handles.
+    fn list_loaded_models(&self) -> Vec<(ModelHandle, ModelInfo)>;
+
+    /// Unload a model.
+    async fn unload_model(&self, handle: ModelHandle) -> VortexResult<()>;
+
+    /// Get information about a specific model.
+    fn model_info(&self, handle: ModelHandle) -> Option<ModelInfo>;
+
+    /// Check if a model is loaded.
+    fn is_model_loaded(&self, handle: ModelHandle) -> bool;
+}
+
+#[async_trait]
+impl VortexService for crate::inference::Vortex {
+    async fn load_model(&self, path: &str, config: ModelLoadConfig) -> VortexResult<ModelHandle> {
+        self.load_model(path, config).await
+    }
+
+    async fn load_preset(
+        &self,
+        preset: ModelPreset,
+        device: Option<&str>,
+    ) -> VortexResult<ModelHandle> {
+        self.load_preset(preset, device).await
+    }
+
+    async fn infer(
+        &self,
+        handle: ModelHandle,
+        prompt: &str,
+        params: InferenceParams,
+    ) -> VortexResult<String> {
+        self.infer(handle, prompt, params).await
+    }
+
+    async fn embed(&self, handle: ModelHandle, text: &str) -> VortexResult<Vec<f32>> {
+        self.embed(handle, text).await
+    }
+
+    fn list_models(&self) -> Vec<ModelInfo> {
+        self.list_models()
+    }
+
+    fn list_loaded_models(&self) -> Vec<(ModelHandle, ModelInfo)> {
+        self.list_loaded_models()
+    }
+
+    async fn unload_model(&self, handle: ModelHandle) -> VortexResult<()> {
+        self.unload_model(handle).await
+    }
+
+    fn model_info(&self, handle: ModelHandle) -> Option<ModelInfo> {
+        self.model_info(handle)
+    }
+
+    fn is_model_loaded(&self, handle: ModelHandle) -> bool {
+        self.is_model_loaded(handle)
+    }
+}


### PR DESCRIPTION
Introduced `VortexService` and `GallifreyService` traits to decouple `Chronos` and `Shell` from concrete implementations. Updated `Gallifrey` to be a true Facade. Refactored experimental tools to use traits.

---
*PR created automatically by Jules for task [14247513870048647756](https://jules.google.com/task/14247513870048647756) started by @madmax983*