### PR TITLE
feat(chronos): add Weaver experimental module

### DIFF
--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -24,7 +24,7 @@ pub struct Curiosity {
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,

--- a/chronos/src/experimental/fugue.rs
+++ b/chronos/src/experimental/fugue.rs
@@ -114,12 +114,14 @@ impl Fugue {
 
         let mut context_str = String::new();
         for entity in &context_entities {
-            context_str.push_str(&format!(
-                "- {} ({}): {}\n",
+            use std::fmt::Write;
+            let _ = writeln!(
+                context_str,
+                "- {} ({}): {}",
                 entity.name,
                 entity.entity_type,
                 serde_json::to_string(&entity.properties).unwrap_or_default()
-            ));
+            );
         }
 
         if context_str.is_empty() {
@@ -127,12 +129,11 @@ impl Fugue {
         }
 
         let prompt = format!(
-            "SYSTEM STATE at {}:\n{}\n\nHYPOTHETICAL SCENARIO: {}\n\nTASK: Simulate the consequences of this scenario over the next {}. \
+            "SYSTEM STATE at {divergence_time}:\n{context_str}\n\nHYPOTHETICAL SCENARIO: {counterfactual}\n\nTASK: Simulate the consequences of this scenario over the next {horizon_desc}. \
             Return a JSON object with two fields:\n\
             1. 'narrative': A short paragraph summarizing the timeline.\n\
             2. 'events': A list of objects, each having 'time_offset' (string) and 'description' (string).\n\
-            Output ONLY JSON.",
-            divergence_time, context_str, counterfactual, horizon_desc
+            Output ONLY JSON."
         );
 
         // 4. Inference

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -16,3 +16,6 @@ pub mod curiosity;
 
 #[cfg(feature = "nova")]
 pub mod fugue;
+
+#[cfg(feature = "nova")]
+pub mod weaver;

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -1,0 +1,283 @@
+//! The Weaver: Narrative generator for entity connections.
+//!
+//! "Everything is connected."
+//!
+//! This module finds paths between entities in the knowledge graph and weaves a narrative
+//! using the LLM to explain the connection.
+
+use crate::error::ChronosResult;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+use tardis_common::id::EntityId;
+use tardis_gallifrey::domain::Entity;
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::config::InferenceParams;
+use tardis_vortex::model::ModelHandle;
+use tardis_vortex::Vortex;
+
+/// The Weaver engine.
+#[derive(Debug)]
+pub struct Weaver {
+    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<Vortex>,
+    model_handle: ModelHandle,
+}
+
+impl Weaver {
+    /// Create a new Weaver instance.
+    #[must_use]
+    pub const fn new(
+        gallifrey: Arc<Gallifrey>,
+        vortex: Arc<Vortex>,
+        model_handle: ModelHandle,
+    ) -> Self {
+        Self {
+            gallifrey,
+            vortex,
+            model_handle,
+        }
+    }
+
+    /// Weave a narrative connecting two entities.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if entities not found or path cannot be generated.
+    pub async fn weave(&self, start_name: &str, end_name: &str) -> ChronosResult<String> {
+        // 1. Resolve names to IDs (Naive scan)
+        let start_id = self.find_entity_id(start_name)?;
+        let end_id = self.find_entity_id(end_name)?;
+
+        // 2. Build Adjacency Graph (Naive scan of relationships)
+        let graph = self.build_graph()?;
+
+        // 3. Find Path (BFS)
+        let path = Self::find_path(start_id, end_id, &graph);
+
+        if let Some(path_ids) = path {
+            // 4. Collect Path Details
+            let entities = self.get_entities(&path_ids)?;
+
+            // 5. Generate Narrative
+            let narrative = self.generate_narrative(&entities).await?;
+            Ok(narrative)
+        } else {
+            Ok(format!(
+                "The threads of time do not connect '{start_name}' and '{end_name}'."
+            ))
+        }
+    }
+
+    fn find_entity_id(&self, name: &str) -> ChronosResult<EntityId> {
+        let mut found_id = None;
+        let target_name = name.to_lowercase();
+
+        // Use scan_history to iterate all entities
+        self.gallifrey.knowledge().scan_history(|history| {
+            if found_id.is_some() {
+                return;
+            }
+            // Check the most recent version
+            if let Some(entity) = history.last() {
+                if entity.name.to_lowercase() == target_name {
+                    found_id = Some(entity.id);
+                }
+            }
+        })?;
+
+        found_id.ok_or_else(|| {
+            crate::error::ChronosError::Common(tardis_common::Error::EntityNotFound(format!(
+                "Entity '{name}' not found"
+            )))
+        })
+    }
+
+    fn build_graph(&self) -> ChronosResult<HashMap<EntityId, Vec<EntityId>>> {
+        let mut adjacency: HashMap<EntityId, Vec<EntityId>> = HashMap::new();
+
+        self.gallifrey.knowledge().scan_relationships(|rels| {
+            for rel in rels {
+                // Undirected graph for narrative purposes
+                adjacency.entry(rel.source).or_default().push(rel.target);
+                adjacency.entry(rel.target).or_default().push(rel.source);
+            }
+        })?;
+
+        Ok(adjacency)
+    }
+
+    fn find_path(
+        start: EntityId,
+        end: EntityId,
+        graph: &HashMap<EntityId, Vec<EntityId>>,
+    ) -> Option<Vec<EntityId>> {
+        let mut queue = VecDeque::new();
+        queue.push_back(vec![start]);
+        let mut visited = HashSet::new();
+        visited.insert(start);
+
+        while let Some(path) = queue.pop_front() {
+            let Some(&current) = path.last() else {
+                continue;
+            };
+
+            if current == end {
+                return Some(path);
+            }
+
+            if let Some(neighbors) = graph.get(&current) {
+                for &neighbor in neighbors {
+                    if visited.insert(neighbor) {
+                        let mut new_path = path.clone();
+                        new_path.push(neighbor);
+                        queue.push_back(new_path);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn get_entities(&self, ids: &[EntityId]) -> ChronosResult<Vec<Entity>> {
+        let mut entities = Vec::new();
+        for &id in ids {
+            if let Some(entity) = self.gallifrey.knowledge().get_entity(id)? {
+                entities.push(entity);
+            }
+        }
+        Ok(entities)
+    }
+
+    async fn generate_narrative(&self, entities: &[Entity]) -> ChronosResult<String> {
+        if entities.is_empty() {
+            return Ok("No entities in path.".to_string());
+        }
+
+        use std::fmt::Write;
+        let mut prompt = String::from("Based on the following sequence of connected entities, write a short, cohesive narrative explaining their relationship:\n\n");
+
+        for (i, entity) in entities.iter().enumerate() {
+            let _ = write!(
+                prompt,
+                "{}. Name: {}\nType: {}\n",
+                i + 1,
+                entity.name,
+                entity.entity_type
+            );
+            if let Some(desc) = entity
+                .properties
+                .get("description")
+                .and_then(|v| v.as_str())
+            {
+                let _ = writeln!(prompt, "Description: {desc}");
+            }
+            prompt.push('\n');
+        }
+
+        prompt.push_str("Narrative:");
+
+        let params = InferenceParams {
+            max_tokens: 256,
+            temperature: 0.7,
+            top_p: 0.9,
+            ..InferenceParams::default()
+        };
+
+        Ok(self
+            .vortex
+            .infer(self.model_handle, &prompt, params)
+            .await?)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::BiTemporalInterval;
+    use tardis_gallifrey::domain::{Entity, Relationship};
+    use tardis_gallifrey::Gallifrey;
+    use tardis_vortex::model::ModelHandle;
+    use tardis_vortex::Vortex;
+
+    fn create_entity(name: &str) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            entity_type: "Test".to_string(),
+            name: name.to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval::now(),
+            source: None,
+        }
+    }
+
+    fn create_rel(source: EntityId, target: EntityId) -> Relationship {
+        Relationship {
+            id: EntityId::new(),
+            relationship_type: "LINK".to_string(),
+            source,
+            target,
+            properties: HashMap::new(),
+            temporal: BiTemporalInterval::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_weaver_path() {
+        // Setup Gallifrey
+        let gallifrey = Arc::new(Gallifrey::new());
+        let e1 = create_entity("StartNode");
+        let e2 = create_entity("MiddleNode");
+        let e3 = create_entity("EndNode");
+
+        gallifrey.insert(e1.clone()).await.unwrap();
+        gallifrey.insert(e2.clone()).await.unwrap();
+        gallifrey.insert(e3.clone()).await.unwrap();
+
+        // A -> B -> C
+        let rel1 = create_rel(e1.id, e2.id);
+        let rel2 = create_rel(e2.id, e3.id);
+
+        gallifrey.knowledge().insert_relationship(rel1).unwrap();
+        gallifrey.knowledge().insert_relationship(rel2).unwrap();
+
+        // Setup Vortex
+        let vortex = Arc::new(Vortex::new().unwrap());
+        let handle = ModelHandle::new(1);
+
+        // Mock inference
+        vortex.set_mock_inference(Box::new(|_, _prompt, _| {
+            Ok("A story about connection.".to_string())
+        }));
+
+        let weaver = Weaver::new(gallifrey, vortex, handle);
+
+        let result = weaver.weave("StartNode", "EndNode").await.unwrap();
+        assert_eq!(result, "A story about connection.");
+    }
+
+    #[tokio::test]
+    async fn test_weaver_no_path() {
+        // Setup Gallifrey
+        let gallifrey = Arc::new(Gallifrey::new());
+        let e1 = create_entity("LonelyNode");
+        let e2 = create_entity("FarAwayNode");
+
+        gallifrey.insert(e1.clone()).await.unwrap();
+        gallifrey.insert(e2.clone()).await.unwrap();
+
+        // No relationships
+
+        let vortex = Arc::new(Vortex::new().unwrap());
+        let handle = ModelHandle::new(1);
+
+        let weaver = Weaver::new(gallifrey, vortex, handle);
+
+        let result = weaver.weave("LonelyNode", "FarAwayNode").await.unwrap();
+        assert!(result.contains("do not connect"));
+    }
+}

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -14,6 +14,8 @@ use crate::experimental::{
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
+use tardis_chronos::experimental::weaver::Weaver;
+#[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
 
 /// Sonic Screwdriver tool command.
@@ -377,6 +379,51 @@ impl ShellCommand for CapsuleCommand {
                 }
             }
             _ => println!("Unknown capsule command: {subcommand}"),
+        }
+        Ok(CommandResult::Continue)
+    }
+}
+
+/// Weave command.
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct WeaveCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for WeaveCommand {
+    fn name(&self) -> &str {
+        "weave"
+    }
+
+    fn description(&self) -> &str {
+        "Weave a narrative connection between two entities"
+    }
+
+    async fn execute(&self, args: &[String], context: &CommandContext) -> Result<CommandResult> {
+        if args.len() < 2 {
+            println!("Usage: weave <start_entity> <end_entity>");
+            return Ok(CommandResult::Continue);
+        }
+
+        let start_name = &args[0];
+        let end_name = &args[1];
+
+        let loaded_models = context.chronos.vortex().list_loaded_models();
+        if let Some((handle, _)) = loaded_models.first() {
+            let weaver = Weaver::new(
+                Arc::clone(&context.gallifrey),
+                context.chronos.vortex(),
+                *handle,
+            );
+
+            println!("🕸️ Weaving the threads of time...");
+            match weaver.weave(start_name, end_name).await {
+                Ok(narrative) => println!("\n{}\n", narrative),
+                Err(e) => println!("Failed to weave narrative: {e}"),
+            }
+        } else {
+            println!("Weaver needs a loaded model. Use 'models load <path>'.");
         }
         Ok(CommandResult::Continue)
     }

--- a/shell/src/commands/mod.rs
+++ b/shell/src/commands/mod.rs
@@ -11,17 +11,17 @@
 //! - `models`: List available LLMs.
 //! - `context`: Inspect session state.
 
-/// Command traits and context.
-pub mod traits;
-/// Command registry.
-pub mod registry;
-/// System maintenance commands.
-pub mod system;
 #[cfg(feature = "nova")]
 /// Experimental commands (Nova feature).
 pub mod experimental;
 /// Knowledge management commands.
 pub mod knowledge;
+/// Command registry.
+pub mod registry;
+/// System maintenance commands.
+pub mod system;
+/// Command traits and context.
+pub mod traits;
 
 use std::sync::Arc;
 use tardis_common::SessionId;

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -104,6 +104,7 @@ impl Repl {
             registry.register(Box::new(commands::experimental::BiographerCommand));
             registry.register(Box::new(commands::experimental::CuriosityCommand));
             registry.register(Box::new(commands::experimental::CapsuleCommand));
+            registry.register(Box::new(commands::experimental::WeaveCommand));
         }
     }
 


### PR DESCRIPTION
🌟 **Nova: The Weaver**

**The Spark:**
I noticed we have a Knowledge Graph (`Gallifrey`) and an LLM (`Vortex`), but we rarely use them *together* to tell stories about the data. We have `Biographer` for single entities, but nothing for *connections*.

**The Feature:**
Implemented `Weaver`, a narrative generator that finds the shortest path between two entities in the knowledge graph and uses the LLM to weave a story explaining how they are connected.

**The Potential:**
This turns dry graph data into "Timey Wimey" narratives. It helps users understand complex relationships in the system (e.g., "How is `The Doctor` connected to `The Master`?").

**Risk:**
Low. Isolated in `chronos/src/experimental/weaver.rs` and gated by `nova` feature flag. Uses standard graph traversal (BFS) and inference.

**Unslop:**
- Compiled and tested.
- Clippy compliant (for new code).
- Unit tests included.
- Pre-existing clippy errors in `shell` and other experimental modules were left untouched (out of scope), but `chronos` is clean.

---
*PR created automatically by Jules for task [16788171392405297632](https://jules.google.com/task/16788171392405297632) started by @madmax983*