### PR TITLE
🔒 Warden: Fix RingBuffer DoS vulnerability

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -33,3 +33,7 @@
 **2025-06-05 - Supply Chain Attack**
 **Threat:** `serde_json` v1.0.149 introduced a malicious dependency `zmij` v1.0.19. Additionally, `zip` v7.4.0 (a typosquatted/hijacked crate version) was pulled in by `candle-core` v0.9.2. These compromised versions posed a critical risk of arbitrary code execution.
 **Defense:** Pinned `serde_json` to known safe version `=1.0.128`. Downgraded `candle-core` to `0.9.1` and patched the dependency to use the official Git repository, forcing dependency resolution to safe versions (e.g., `zip` v1.1.4). Removed compromised crate versions from `Cargo.lock`.
+
+**2025-06-06 - RingBuffer DoS Vector**
+**Threat:** `RingBuffer::available()` returned `write_pos - read_pos` without clamping, leading to potentially huge values (>> `RING_BUFFER_SIZE`) if the writer wrapped around. This could cause userspace consumers to allocate massive buffers, leading to OOM or panic.
+**Defense:** Clamped the return value of `available()` to `min(diff, RING_BUFFER_SIZE)`. Added a regression test case to verify the fix.

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -454,7 +454,9 @@ impl RingBuffer {
         let write_pos = self.write_pos.load(Ordering::Acquire);
         let read_pos = self.read_pos.load(Ordering::Relaxed);
         // Use wrapping_sub to handle potential usize wrapping correctly
-        write_pos.wrapping_sub(read_pos)
+        let available = write_pos.wrapping_sub(read_pos);
+        // Cap at buffer size to prevent misleading values when writer wraps around
+        available.min(RING_BUFFER_SIZE)
     }
 
     /// Returns the number of dropped entries.
@@ -777,6 +779,18 @@ mod tests {
                 BUFFER.available(),
                 10,
                 "available() should handle wrapping arithmetic"
+            );
+
+            // Case 3: Overflow (Writer far ahead)
+            // write_pos = 10000, read_pos = 0.
+            // available = 10000. But buffer size is 4096.
+            // Should return 4096.
+            (*read_pos_ptr).store(0, Ordering::Relaxed);
+            (*write_pos_ptr).store(10000, Ordering::Relaxed);
+            assert_eq!(
+                BUFFER.available(),
+                RING_BUFFER_SIZE,
+                "available() should be capped at RING_BUFFER_SIZE"
             );
         }
     }


### PR DESCRIPTION
🦠 Threat: `RingBuffer::available()` returned `write_pos - read_pos` without clamping. If the writer wrapped around significantly (e.g., due to a slow reader), the difference could exceed the physical buffer size (`RING_BUFFER_SIZE`), misleading consumers into allocating massive buffers (DoS/OOM) or causing logic errors.

🛡️ Defense: Modified `available()` to return `min(diff, RING_BUFFER_SIZE)`. This ensures the reported available count never exceeds the actual physical capacity of the ring buffer, aligning with the semantic expectation of "available to read".

💥 Severity: High (DoS risk in kernel telemetry consumer).

🧪 Verification: Added a new regression test case inside `telemetry/src/kernel/ring_buffer.rs` that simulates a writer wrapping around and asserts `available()` is capped at `RING_BUFFER_SIZE`. Ran all telemetry tests (`cargo test -p tardis-telemetry --features kernel`) and they passed.

---
*PR created automatically by Jules for task [10135964551271605529](https://jules.google.com/task/10135964551271605529) started by @madmax983*