### PR TITLE
🎻 Bard: Document Kernel Telemetry & Gallifrey Pitfalls

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -25,3 +25,7 @@
 ## 2026-02-13 - The Bi-Temporal Blind Spot
 **Confusion:** Users struggled to understand why `update()` created a new version instead of overwriting data, leading to "ghost" data from the past.
 **Clarification:** Expanded the "Bi-Temporality" section in `gallifrey` docs to explain the "Append-Only" nature of updates and how to query valid vs. transaction time.
+
+## 2026-06-15 - The Linear Scan Trap
+**Confusion:** Developers assumed `Gallifrey` had an index for entity names, leading to O(N) performance issues when looking up entities by name.
+**Clarification:** Documented `KnowledgeStore`'s lack of a name index and the cost of `scan_history`, warning users to rely on `EntityId` for fast lookups.

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -22,6 +22,15 @@ use tardis_common::EntityId;
 ///
 /// - **Reads**: Concurrent readers are allowed.
 /// - **Writes**: Exclusive write access is required for inserts and updates.
+///
+/// # Performance Warning
+///
+/// ⚠️ **Missing Index**: This store currently maps `EntityId` -> `Entity`.
+/// There is **no secondary index** for entity names or properties.
+///
+/// To find an entity by name, you must perform a full linear scan of the store
+/// (O(N) complexity). For production use cases involving frequent name lookups,
+/// consider maintaining an external index or using `EntityId` references.
 #[derive(Debug)]
 pub struct KnowledgeStore {
     /// Entities indexed by ID.
@@ -342,6 +351,11 @@ impl KnowledgeStore {
     ///
     /// This method allows iterating over the entire knowledge graph's history
     /// without cloning the underlying storage structure.
+    ///
+    /// # Performance
+    ///
+    /// This operation is **O(N)** where N is the number of entities in the store.
+    /// It acquires a read lock on the entire store.
     ///
     /// # Errors
     ///

--- a/telemetry/src/kernel/mod.rs
+++ b/telemetry/src/kernel/mod.rs
@@ -1,29 +1,38 @@
 //! Kernel telemetry module.
 //!
-//! Provides `no_std` compatible telemetry for the Tardis kernel:
+//! Provides `no_std` compatible telemetry for the Tardis kernel, enabling
+//! high-speed logging and tracing from ring 0.
 //!
-//! - [`RingBuffer`]: Lock-free SPSC ring buffer for event storage
-//! - [`KernelLogger`]: `log::Log` implementation writing to ring buffer
-//! - [`serial`]: Serial port output for early boot and panic messages
+//! # Components
+//!
+//! -   [`RingBuffer`]: The primary transport mechanism. A lock-free, SPSC shared memory
+//!     buffer that connects the kernel (producer) to userspace (consumer).
+//! -   [`KernelLogger`]: Implements the standard `log::Log` trait, routing `log::info!`,
+//!     `log::error!`, etc., to the ring buffer.
+//! -   [`serial`]: A direct hardware interface to the COM1 serial port, used as a
+//!     fail-safe for critical errors or when the ring buffer is unavailable.
 //!
 //! # Architecture
 //!
-//! The kernel writes telemetry entries to a ring buffer that is readable
-//! from userspace. This allows the kernel to emit events with minimal
-//! overhead while userspace handles storage and export.
+//! The system is designed to minimize kernel-side latency. Complex processing (formatting,
+//! storage, network export) is offloaded to userspace.
 //!
 //! ```text
-//! Kernel (no_std)              Userspace (std)
-//! ┌─────────────┐              ┌─────────────┐
-//! │ log::info!()│──┐           │   Drainer   │
-//! │ log::error!()│  │           │             │
-//! └─────────────┘  │           └──────▲──────┘
-//!                  │                  │
-//!                  ▼                  │
-//!            ┌───────────────────────────┐
-//!            │       Ring Buffer         │
-//!            │  (shared memory region)   │
-//!            └───────────────────────────┘
+//!                                    Shared Memory
+//! ┌────────────────┐              ┌────────────────┐              ┌───────────────┐
+//! │     Kernel     │              │   Ring Buffer  │              │   Userspace   │
+//! │                │              │                │              │               │
+//! │  [log::info!]──┼─────────────►│ [Entry 1.....] │─────────────►│ [Drainer]     │
+//! │                │              │ [Entry 2.....] │              │    │          │
+//! │  [Panic!]──────┼─────────┐    │ [..........]   │              │    ▼          │
+//! └────────────────┘         │    └────────────────┘              │ [Gallifrey]   │
+//!                            │                                    └───────────────┘
+//!                            │
+//!                            ▼
+//!                       ┌──────────┐
+//!                       │ Serial   │
+//!                       │ (COM1)   │
+//!                       └──────────┘
 //! ```
 
 #![allow(unsafe_code)]

--- a/telemetry/src/kernel/ring_buffer.rs
+++ b/telemetry/src/kernel/ring_buffer.rs
@@ -1,19 +1,33 @@
 //! Lock-free ring buffer for kernel telemetry.
 //!
-//! This module provides a Single-Producer Single-Consumer (SPSC) ring buffer
-//! optimized for kernel telemetry:
+//! # Overview
 //!
-//! - Zero allocation after initialization
-//! - Sub-microsecond write latency
-//! - Safe for use in interrupt handlers
-//! - Readable from userspace via shared memory
+//! This module implements a **Single-Producer Single-Consumer (SPSC)** ring buffer designed for
+//! extremely low-latency telemetry logging from the kernel to userspace.
 //!
-//! # Design
+//! Key characteristics:
+//! -   **Lock-Free**: Uses atomic sequence numbers to coordinate reads/writes without mutexes.
+//! -   **Zero-Copy (ish)**: Writes directly to shared memory; reads use volatile copy.
+//! -   **Interrupt-Safe**: Can be safely called from interrupt handlers or panic context.
+//! -   **Overwrite Semantics**: If the buffer fills up, old data is overwritten (circular buffer).
 //!
-//! The ring buffer uses sequence numbers for lock-free synchronization:
-//! - Each slot has a sequence number
-//! - Odd sequence = slot being written
-//! - Even sequence = slot ready to read
+//! # Safety Mechanism: The Seqlock Pattern
+//!
+//! To ensure data consistency without locks, the buffer uses a sequence counter for each slot:
+//!
+//! 1.  **State Tracking**:
+//!     -   **Even Sequence**: Slot is stable and ready to read.
+//!     -   **Odd Sequence**: Slot is being written to.
+//!
+//! 2.  **Write Protocol**:
+//!     -   Producer increments sequence to Odd (claiming the slot).
+//!     -   Producer writes data using `volatile` operations.
+//!     -   Producer increments sequence to Even (releasing the slot).
+//!
+//! 3.  **Read Protocol**:
+//!     -   Consumer reads sequence (must be Even).
+//!     -   Consumer reads data.
+//!     -   Consumer re-reads sequence. If it changed, the data is torn/corrupted -> Retry.
 //!
 //! # Memory Layout
 //!
@@ -154,6 +168,18 @@ impl RingSlot {
 ///
 /// This buffer is designed to be placed in a shared memory region
 /// accessible by both kernel and userspace.
+///
+/// # Concurrency Safety
+///
+/// This structure relies on strict memory ordering and the Single-Producer Single-Consumer invariant.
+///
+/// -   **Producer (Kernel)**: Owns `write_pos`. Advances it monotonically.
+///     Uses `Acquire`/`Release` ordering on `sequence` to publish writes.
+/// -   **Consumer (Userspace)**: Owns `read_pos`. Advances it monotonically.
+///     Uses `Acquire`/`Release` ordering to detect stable slots.
+///
+/// If multiple producers attempt to write simultaneously (e.g., re-entrant interrupt),
+/// the `compare_exchange` on the sequence number will fail for one of them, forcing a retry loop.
 #[repr(C)]
 #[allow(missing_debug_implementations)]
 pub struct RingBuffer {

--- a/telemetry/src/kernel/serial.rs
+++ b/telemetry/src/kernel/serial.rs
@@ -1,18 +1,32 @@
 //! Serial port output for kernel telemetry.
 //!
-//! Provides direct serial port (COM1) output for:
-//! - Early boot messages before ring buffer is available
-//! - Panic messages when ring buffer may be corrupted
-//! - Debug output when configured
+//! # Overview
 //!
-//! # Hardware
+//! This module provides a direct interface to the PC serial port (COM1),
+//! primarily used for:
+//! 1.  **Early Boot Logging**: Emitting messages before the memory allocator or ring buffer are initialized.
+//! 2.  **Panic Handling**: Reliability dumping panic information when the system state is corrupted.
+//! 3.  **Fallback Logging**: Providing an output channel when the telemetry ring buffer is full.
 //!
-//! Uses the standard PC COM1 port at I/O address 0x3F8 with 8N1 configuration.
+//! # Safety & Implementation
 //!
-//! # Safety
+//! This module interacts directly with hardware I/O ports (specifically `0x3F8` for COM1).
 //!
-//! This module uses port I/O which requires kernel-level access.
-//! In userspace builds, these functions are no-ops.
+//! -   **Unsafe Operations**: All functions are marked `unsafe` because they perform raw I/O
+//!     and rely on the hardware being present and correctly mapped.
+//! -   **Kernel Context**: These functions should *only* be called when running in kernel mode (ring 0).
+//! -   **Synchronization**: The implementation assumes it is the sole owner of the serial port.
+//!     While `init` has a basic atomic guard, concurrent writes from multiple cores are NOT locked
+//!     (to prevent deadlocks in panic handlers) and may result in interleaved output.
+//!
+//! # Configuration
+//!
+//! The `init()` function configures the UART to:
+//! -   **Baud Rate**: 115200
+//! -   **Data Bits**: 8
+//! -   **Parity**: None
+//! -   **Stop Bits**: 1
+//! -   **FIFO**: Enabled (14-byte threshold)
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -30,8 +44,11 @@ static SERIAL_INITIALIZED: AtomicBool = AtomicBool::new(false);
 ///
 /// # Safety
 ///
-/// This function performs port I/O and should only be called
+/// This function performs raw port I/O and should only be called
 /// during kernel initialization.
+///
+/// It checks `SERIAL_INITIALIZED` to prevent double-initialization,
+/// but callers must ensure no other code is accessing the serial port hardware.
 #[cfg(target_arch = "x86_64")]
 #[allow(clippy::needless_return)]
 pub unsafe fn init() {
@@ -61,6 +78,7 @@ pub unsafe fn init() {
         lcr.write(0x80);
 
         // Set divisor to 1 (115200 baud)
+        // Divisor = 115200 / 115200 = 1
         port.write(0x01u8);
         ier.write(0x00);
 
@@ -95,6 +113,7 @@ pub unsafe fn init() {
 /// # Safety
 ///
 /// This function performs port I/O and should only be called in kernel context.
+/// It assumes the port has been initialized via `init()`.
 #[cfg(all(target_arch = "x86_64", feature = "kernel"))]
 #[allow(clippy::needless_return)]
 pub unsafe fn write_byte(byte: u8) {
@@ -115,6 +134,7 @@ pub unsafe fn write_byte(byte: u8) {
         use x86_64::instructions::port::Port;
 
         // Wait for transmit buffer to be empty
+        // Bit 5 (0x20) of LSR indicates "Transmitter Holding Register Empty"
         let mut lsr: Port<u8> = Port::new(COM1_PORT + 5);
         while (lsr.read() & 0x20) == 0 {
             core::hint::spin_loop();
@@ -186,6 +206,7 @@ pub unsafe fn write_line(prefix: &str, message: &str) {
 /// # Safety
 ///
 /// This function calls `write_str` which performs port I/O.
+/// It is designed to be minimal and robust for use in crash conditions.
 pub unsafe fn write_panic(message: &str, file: &str, line: u32) {
     unsafe {
         write_str("\n!!! KERNEL PANIC !!!\n");


### PR DESCRIPTION
This PR improves documentation in critical areas identified as "Black Boxes" or "Traps".

### 📖 Chapter: The Black Box of Kernel Telemetry
- **Clarification**: Documented the unsafe `serial` module, explaining its role as a panic/boot fallback using direct COM1 I/O.
- **Deep Dive**: Explained the Lock-Free SPSC Ring Buffer design in `ring_buffer.rs`, detailing the Seqlock pattern used for safe concurrency without mutexes.
- **Architecture**: Added an ASCII diagram to `kernel/mod.rs` mapping the flow from `log::info!` -> Ring Buffer -> Userspace.

### 📖 Chapter: The Linear Scan Trap
- **Warning**: Added a visible performance warning to `Gallifrey::KnowledgeStore` and `scan_history`. It explicitly states that entity name lookups are O(N) linear scans due to the lack of a secondary index, preventing future confusion.

### 🧪 Verification
- `cargo test -p tardis-telemetry` passed.
- `cargo test -p tardis-gallifrey` passed.


---
*PR created automatically by Jules for task [1613766200616774341](https://jules.google.com/task/1613766200616774341) started by @madmax983*