### PR TITLE
🌟 Nova: Medium - Talk to the ghosts of the system

### DIFF
--- a/chronos/src/experimental/medium.rs
+++ b/chronos/src/experimental/medium.rs
@@ -1,0 +1,164 @@
+//! The Medium: Channeling the Past.
+//!
+//! "I see dead people... well, deprecated entities."
+//!
+//! This module allows users to "summon" a specific entity as it existed at a specific point in time.
+//! It constructs a persona based on the entity's state at that time and allows for a conversation.
+
+use crate::error::{ChronosError, ChronosResult};
+use chrono::{DateTime, Utc};
+use std::sync::{Arc, Mutex};
+use tardis_common::id::ModelHandle;
+use tardis_gallifrey::Gallifrey;
+use tracing::{info, instrument};
+
+/// The result of a successful summoning.
+#[derive(Debug)]
+pub struct SeanceSession {
+    /// The name of the summoned entity.
+    pub entity_name: String,
+    /// The time at which the entity is being channeled.
+    pub time: DateTime<Utc>,
+    /// The constructed system prompt defining the persona.
+    pub system_prompt: String,
+    /// The handle to the loaded model to use.
+    pub model_handle: ModelHandle,
+}
+
+/// The Medium: A bridge to the past.
+#[derive(Debug)]
+pub struct Medium {
+    gallifrey: Arc<Gallifrey>,
+}
+
+impl Medium {
+    /// Create a new Medium.
+    #[must_use]
+    pub const fn new(gallifrey: Arc<Gallifrey>) -> Self {
+        Self { gallifrey }
+    }
+
+    /// Summon an entity from the past.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entity cannot be found or no model is loaded.
+    #[instrument(skip(self))]
+    pub fn summon(
+        &self,
+        entity_name: &str,
+        time: DateTime<Utc>,
+        model_handle: ModelHandle,
+    ) -> ChronosResult<SeanceSession> {
+        info!("Summoning {} from {}", entity_name, time);
+
+        // 1. Scan history to find the entity active at the given time.
+        let entity_cell = Mutex::new(None);
+        let target_name = entity_name.to_lowercase();
+
+        self.gallifrey
+            .knowledge()
+            .scan_history(|history| {
+                // Optimization: if we already found it, stop checking (best effort, scan_history continues anyway)
+                if entity_cell.lock().unwrap().is_some() {
+                    return;
+                }
+
+                if let Some(entity) = history.iter().find(|e| {
+                    e.name.to_lowercase() == target_name && e.temporal.active_at(time, time)
+                }) {
+                    *entity_cell.lock().unwrap() = Some(entity.clone());
+                }
+            })
+            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+
+        let entity = entity_cell
+            .into_inner()
+            .unwrap()
+            .ok_or_else(|| ChronosError::Common(tardis_common::Error::EntityNotFound(format!(
+                "Entity '{}' not found active at {}",
+                entity_name, time
+            ))))?;
+
+        // 2. Construct the persona.
+        let properties_json = serde_json::to_string_pretty(&entity.properties).unwrap_or_default();
+
+        let system_prompt = format!(
+            "You are {name}, an entity within the system.\n\
+            Current Time: {time}\n\
+            Your State: {properties}\n\
+            \n\
+            INSTRUCTIONS:\n\
+            - You are roleplaying as this specific entity at this specific time.\n\
+            - You DO NOT know about events that happen after {time}.\n\
+            - Respond in character based on your properties and type ({type}).\n\
+            - If asked about the future, express ignorance or make predictions based on your current state.",
+            name = entity.name,
+            time = time.to_rfc3339(),
+            properties = properties_json,
+            type = entity.entity_type
+        );
+
+        Ok(SeanceSession {
+            entity_name: entity.name,
+            time,
+            system_prompt,
+            model_handle,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::BiTemporalInterval;
+    use tardis_gallifrey::domain::Entity;
+
+    #[test]
+    fn test_summon_entity() {
+        let gallifrey = Arc::new(Gallifrey::new());
+
+        // Insert a historical entity
+        let mut props = HashMap::new();
+        props.insert("status".to_string(), serde_json::json!("deprecated"));
+
+        let past_time = Utc::now() - chrono::Duration::days(365);
+        let active_interval = BiTemporalInterval::with_valid_time(
+            tardis_common::temporal::TimeRange::starting_at(past_time)
+        );
+
+        let entity = Entity {
+            id: EntityId::new(),
+            entity_type: "Service".to_string(),
+            name: "LegacyAPI".to_string(),
+            properties: props,
+            embedding: None,
+            temporal: active_interval,
+            source: None,
+        };
+        gallifrey.knowledge().insert_entity(entity).unwrap();
+
+        let medium = Medium::new(gallifrey);
+        let model = ModelHandle::new(1); // Fake handle
+
+        // Try to summon it at a valid time
+        let summon_time = Utc::now();
+        let session = medium.summon("LegacyAPI", summon_time, model).unwrap();
+
+        assert_eq!(session.entity_name, "LegacyAPI");
+        assert!(session.system_prompt.contains("You are LegacyAPI"));
+        assert!(session.system_prompt.contains("deprecated"));
+    }
+
+    #[test]
+    fn test_summon_not_found() {
+        let gallifrey = Arc::new(Gallifrey::new());
+        let medium = Medium::new(gallifrey);
+        let model = ModelHandle::new(1);
+
+        let result = medium.summon("NonExistent", Utc::now(), model);
+        assert!(result.is_err());
+    }
+}

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -19,3 +19,6 @@ pub mod fugue;
 
 #[cfg(feature = "nova")]
 pub mod dreamer;
+
+#[cfg(feature = "nova")]
+pub mod medium;

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -16,7 +16,11 @@ use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::dreamer::Dreamer;
 #[cfg(feature = "nova")]
+use tardis_chronos::experimental::medium::Medium;
+#[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
+#[cfg(feature = "nova")]
+use tardis_vortex::InferenceParams;
 
 /// Chameleon command (System Persona).
 #[cfg(feature = "nova")]
@@ -104,6 +108,124 @@ impl ShellCommand for SonicCommand {
             Ok(report) => println!("{report}"),
             Err(e) => println!("Sonic Screwdriver error: {e}"),
         }
+        Ok(CommandResult::Continue)
+    }
+}
+
+/// Medium command.
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct MediumCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for MediumCommand {
+    fn name(&self) -> &str {
+        "medium"
+    }
+
+    fn description(&self) -> &str {
+        "Talk to the past state of an entity"
+    }
+
+    async fn execute(&self, args: &[String], context: &CommandContext) -> Result<CommandResult> {
+        if args.len() < 2 {
+            println!("Usage: medium <entity> <time> (e.g. '2023-10-01T12:00:00Z')");
+            return Ok(CommandResult::Continue);
+        }
+
+        let entity_name = &args[0];
+        let time_str = &args[1];
+
+        let time = match chrono::DateTime::parse_from_rfc3339(time_str) {
+            Ok(t) => t.with_timezone(&chrono::Utc),
+            Err(e) => {
+                println!("Invalid time format: {e}");
+                return Ok(CommandResult::Continue);
+            }
+        };
+
+        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let model_handle = if let Some((h, _)) = loaded_models.first() {
+            *h
+        } else {
+            println!("Medium requires a loaded model. Use 'models load <path>'.");
+            return Ok(CommandResult::Continue);
+        };
+
+        let medium = Medium::new(
+            Arc::clone(&context.gallifrey),
+        );
+
+        let session = match medium.summon(entity_name, time, model_handle) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("Summoning failed: {e}");
+                return Ok(CommandResult::Continue);
+            }
+        };
+
+        println!("🕯️ Seance started with {} from {}. Type 'exit' to end.", session.entity_name, session.time);
+        println!("---------------------------------------------------");
+
+        // Initial system prompt injection (simulated conversation start)
+        // In a real chat loop we would maintain a buffer of messages.
+        let mut conversation_history = format!("<<SYS>>\n{}\n<</SYS>>\n\n", session.system_prompt);
+
+        use std::io::{self, Write};
+        let stdin = io::stdin();
+        let mut stdout = io::stdout();
+
+        loop {
+            print!("medium> ");
+            stdout.flush()?;
+
+            let mut input = String::new();
+            if stdin.read_line(&mut input).is_err() {
+                break;
+            }
+
+            let input = input.trim();
+            if input.eq_ignore_ascii_case("exit") || input.eq_ignore_ascii_case("quit") {
+                break;
+            }
+            if input.is_empty() {
+                continue;
+            }
+
+            // Append user message
+            conversation_history.push_str(&format!("[INST] {} [/INST] ", input));
+
+            // Run inference
+            let params = InferenceParams {
+                max_tokens: 512,
+                temperature: 0.8, // Higher temperature for "spirit" like creativity
+                ..Default::default()
+            };
+
+            // Use the last N chars to avoid context overflow if no truncation
+            // Ideally we use a proper window manager, but for this experiment:
+            let context_str = if conversation_history.len() > 4000 {
+                // Crude truncation keeping system prompt and tail
+                // NOTE: This is just a safety valve, real implementation needs token counting
+                let split = conversation_history.len() - 3000;
+                let tail = &conversation_history[split..];
+                format!("<<SYS>>\n{}\n<</SYS>>\n...{}", session.system_prompt, tail)
+            } else {
+                conversation_history.clone()
+            };
+
+            match context.chronos.vortex().infer(model_handle, &context_str, params).await {
+                Ok(response) => {
+                    println!("{}", response);
+                    conversation_history.push_str(&response);
+                    conversation_history.push('\n');
+                }
+                Err(e) => println!("The connection is weak... (Error: {e})"),
+            }
+        }
+
+        println!("🕯️ Seance ended.");
         Ok(CommandResult::Continue)
     }
 }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -111,6 +111,7 @@ impl Repl {
             registry.register(Box::new(commands::experimental::CuriosityCommand));
             registry.register(Box::new(commands::experimental::CapsuleCommand));
             registry.register(Box::new(commands::experimental::DreamCommand));
+            registry.register(Box::new(commands::experimental::MediumCommand));
         }
     }
 


### PR DESCRIPTION
Implemented the 'Medium' feature (aka Seance), which allows users to chat with a past version of a system entity. This leverages Gallifrey's bitemporal capabilities to retrieve the entity state at a specific valid time, and uses Vortex to simulate a persona based on that state.

The feature is implemented as:
1.  `chronos::experimental::medium::Medium`: A logic struct that queries Gallifrey and builds the prompt.
2.  `shell::commands::experimental::MediumCommand`: A shell command that runs a sub-REPL for the conversation.

This fits the "Nova" theme of exploring time-travel interactions within the OS.

---
*PR created automatically by Jules for task [9130802654544003051](https://jules.google.com/task/9130802654544003051) started by @madmax983*