### PR TITLE
Nova: The Medium (Time Travel Debugger)

### DIFF
--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -42,11 +42,7 @@ struct DreamEntity {
 impl Dreamer {
     /// Create a new Dreamer engine.
     #[must_use]
-    pub const fn new(
-        gallifrey: Arc<Gallifrey>,
-        vortex: Arc<Vortex>,
-        model: ModelHandle,
-    ) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,
@@ -143,7 +139,10 @@ impl Dreamer {
             created_ids.push(id);
         }
 
-        info!("Dreamer: Created {} new knowledge entities.", created_ids.len());
+        info!(
+            "Dreamer: Created {} new knowledge entities.",
+            created_ids.len()
+        );
 
         Ok(created_ids)
     }

--- a/chronos/src/experimental/medium.rs
+++ b/chronos/src/experimental/medium.rs
@@ -1,0 +1,133 @@
+//! The Medium: Talk to the ghosts of the system.
+//!
+//! This module allows interacting with a past version of the system state.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+
+/// The Medium allows interacting with a past version of the system state.
+#[derive(Debug)]
+pub struct Medium {
+    vortex: Arc<Vortex>,
+    model_handle: ModelHandle,
+    context: String,
+    timestamp: DateTime<Utc>,
+}
+
+impl Medium {
+    /// Summon the system state from a specific time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if history scanning fails.
+    pub fn summon(
+        gallifrey: &Gallifrey,
+        vortex: Arc<Vortex>,
+        model_handle: ModelHandle,
+        timestamp: DateTime<Utc>,
+    ) -> Result<Self> {
+        let mut context = format!("System State as of {}:\n\n", timestamp);
+        let mut entity_count = 0;
+
+        // Scan history to find active entities
+        gallifrey.knowledge().scan_history(|history| {
+            // Find the version active at both valid_time and transaction_time = timestamp
+            if let Some(entity) = history
+                .iter()
+                .find(|e| e.temporal.active_at(timestamp, timestamp))
+            {
+                if entity_count < 50 {
+                    context.push_str(&format!(
+                        "- {}: {} (ID: {})\n",
+                        entity.name, entity.entity_type, entity.id
+                    ));
+                    entity_count += 1;
+                }
+            }
+        })?;
+
+        if entity_count == 0 {
+            context.push_str("(No active entities found at this time)\n");
+        }
+
+        Ok(Self {
+            vortex,
+            model_handle,
+            context,
+            timestamp,
+        })
+    }
+
+    /// Ask the medium a question.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if inference fails.
+    pub async fn ask(&self, question: &str) -> Result<String> {
+        let prompt = format!(
+            "You are the Tardis OS as it existed at {}.
+Your knowledge is limited to the following facts:
+{}
+
+User: {}
+System:",
+            self.timestamp, self.context, question
+        );
+
+        let params = InferenceParams::default()
+            .with_max_tokens(150)
+            .with_temperature(0.7);
+
+        self.vortex
+            .infer(self.model_handle, &prompt, params)
+            .await
+            .map_err(|e| e.into())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::BiTemporalInterval;
+    use tardis_gallifrey::domain::Entity;
+
+    #[test]
+    fn test_summon_constructs_context() {
+        let gallifrey = Gallifrey::new();
+
+        // Populate gallifrey with some data
+        let id = EntityId::new();
+        let entity = Entity {
+            id,
+            entity_type: "Test".to_string(),
+            name: "Ghost".to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval::now(),
+            source: None,
+        };
+
+        gallifrey.knowledge().insert_entity(entity).unwrap();
+
+        // Query slightly in the future to ensure we are inside the interval
+        // (insert_entity sets transaction time to now, valid time to now)
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let timestamp = Utc::now();
+
+        let vortex = Arc::new(Vortex::new().unwrap());
+        let handle = ModelHandle::new(42);
+
+        let medium = Medium::summon(&gallifrey, vortex, handle, timestamp).unwrap();
+
+        // Verify context contains the entity
+        assert!(medium.context.contains("Ghost"));
+        assert!(medium.context.contains("Test"));
+        assert!(medium.context.contains(&id.to_string()));
+    }
+}

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -19,3 +19,6 @@ pub mod fugue;
 
 #[cfg(feature = "nova")]
 pub mod dreamer;
+
+#[cfg(feature = "nova")]
+pub mod medium;

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -120,11 +120,7 @@ pub fn augment(
 }
 
 /// Write system context header to buffer.
-fn write_system_context(
-    buffer: &mut String,
-    analysis: &AnalyzedQuery,
-    persona: Option<&str>,
-) {
+fn write_system_context(buffer: &mut String, analysis: &AnalyzedQuery, persona: Option<&str>) {
     if let Some(p) = persona {
         let _ = writeln!(buffer, "# {p}\n");
     } else {

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -5,6 +5,7 @@
 use crate::commands::traits::{CommandContext, CommandResult, ShellCommand};
 use anyhow::Result;
 use async_trait::async_trait;
+use std::io::Write;
 use std::sync::Arc;
 
 #[cfg(feature = "nova")]
@@ -15,6 +16,8 @@ use crate::experimental::{
 use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::dreamer::Dreamer;
+#[cfg(feature = "nova")]
+use tardis_chronos::experimental::medium::Medium;
 #[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
 
@@ -139,7 +142,10 @@ impl ShellCommand for DreamCommand {
                     if ids.is_empty() {
                         println!("No new memories formed.");
                     } else {
-                        println!("✨ Consolidated {} new memories into long-term storage.", ids.len());
+                        println!(
+                            "✨ Consolidated {} new memories into long-term storage.",
+                            ids.len()
+                        );
                     }
                 }
                 Err(e) => println!("Nightmare encountered: {e}"),
@@ -455,6 +461,97 @@ impl ShellCommand for CapsuleCommand {
             }
             _ => println!("Unknown capsule command: {subcommand}"),
         }
+        Ok(CommandResult::Continue)
+    }
+}
+
+/// Medium command (Time Travel).
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct MediumCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for MediumCommand {
+    fn name(&self) -> &str {
+        "medium"
+    }
+
+    fn description(&self) -> &str {
+        "Talk to the system state at a specific time"
+    }
+
+    async fn execute(&self, args: &[String], context: &CommandContext) -> Result<CommandResult> {
+        if args.is_empty() {
+            println!("Usage: medium <timestamp>");
+            return Ok(CommandResult::Continue);
+        }
+
+        // Parse timestamp
+        let timestamp_str = &args[0];
+        let timestamp = match chrono::DateTime::parse_from_rfc3339(timestamp_str) {
+            Ok(dt) => dt.with_timezone(&chrono::Utc),
+            Err(_) => {
+                println!("Invalid timestamp format. Use RFC3339 (e.g. 2023-10-27T10:00:00Z)");
+                return Ok(CommandResult::Continue);
+            }
+        };
+
+        // Get Vortex and Model
+        let vortex = context.chronos.vortex();
+        let loaded_models = vortex.list_loaded_models();
+
+        let model_handle = match loaded_models.first() {
+            Some((handle, _)) => *handle,
+            None => {
+                println!("No model loaded. Please load a model first using 'models load'.");
+                return Ok(CommandResult::Continue);
+            }
+        };
+
+        println!("🔮 Summoning the medium for {}...", timestamp);
+
+        // Summon Medium
+        let medium = match Medium::summon(&context.gallifrey, vortex, model_handle, timestamp) {
+            Ok(m) => m,
+            Err(e) => {
+                println!("Failed to summon medium: {e}");
+                return Ok(CommandResult::Continue);
+            }
+        };
+
+        println!("The Medium is listening. Type 'exit' to break the trance.");
+
+        // Interaction Loop
+        let stdin = std::io::stdin();
+        let mut stdout = std::io::stdout();
+        let mut buffer = String::new();
+
+        loop {
+            print!("👻 > ");
+            stdout.flush()?;
+            buffer.clear();
+
+            if stdin.read_line(&mut buffer).is_err() {
+                break;
+            }
+
+            let input = buffer.trim();
+            if input.eq_ignore_ascii_case("exit") || input.eq_ignore_ascii_case("quit") {
+                break;
+            }
+
+            if input.is_empty() {
+                continue;
+            }
+
+            match medium.ask(input).await {
+                Ok(response) => println!("\n{}\n", response),
+                Err(e) => println!("The connection fades... ({e})"),
+            }
+        }
+
+        println!("Trace ended.");
         Ok(CommandResult::Continue)
     }
 }

--- a/shell/src/commands/mod.rs
+++ b/shell/src/commands/mod.rs
@@ -11,17 +11,17 @@
 //! - `models`: List available LLMs.
 //! - `context`: Inspect session state.
 
-/// Command traits and context.
-pub mod traits;
-/// Command registry.
-pub mod registry;
-/// System maintenance commands.
-pub mod system;
 #[cfg(feature = "nova")]
 /// Experimental commands (Nova feature).
 pub mod experimental;
 /// Knowledge management commands.
 pub mod knowledge;
+/// Command registry.
+pub mod registry;
+/// System maintenance commands.
+pub mod system;
+/// Command traits and context.
+pub mod traits;
 
 use std::sync::Arc;
 use tardis_common::SessionId;

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -111,6 +111,7 @@ impl Repl {
             registry.register(Box::new(commands::experimental::CuriosityCommand));
             registry.register(Box::new(commands::experimental::CapsuleCommand));
             registry.register(Box::new(commands::experimental::DreamCommand));
+            registry.register(Box::new(commands::experimental::MediumCommand));
         }
     }
 


### PR DESCRIPTION
Implement "The Medium" experimental module.

This module allows users to "summon" a past version of the system state by specifying a timestamp. The system scans the Gallifrey knowledge graph for entities active at that time (bi-temporal query) and constructs a frozen context. The user can then ask questions to this "ghost" of the system, which are answered by Vortex (LLM) using only the historical context.

Usage:
`medium <timestamp>` (e.g., `medium 2023-10-27T10:00:00Z`)

This feature is gated behind the `nova` feature flag.


---
*PR created automatically by Jules for task [8504593548228057023](https://jules.google.com/task/8504593548228057023) started by @madmax983*