### PR TITLE
Refactor Chronos pipeline augmenter and fix clippy issues

### DIFF
--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -10,6 +10,7 @@ use crate::experimental::psychic_paper::{Intent, PsychicPaper};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::sync::Arc;
 use tardis_common::id::EntityId;
 use tardis_common::temporal::BiTemporalInterval;
@@ -79,12 +80,12 @@ impl Dreamer {
         // 2. Construct prompt
         let mut transcript = String::new();
         for msg in &messages {
-            transcript.push_str(&format!("{:?}: {}\n", msg.role, msg.content));
+            let _ = writeln!(transcript, "{:?}: {}", msg.role, msg.content);
         }
 
         let prompt = format!(
             "CONVERSATION TRANSCRIPT:\n\
-             {}\n\n\
+             {transcript}\n\n\
              TASK: Extract key facts, user preferences, and important entities from the above conversation.\n\
              Ignore trivial greetings. Focus on long-term knowledge.\n\
              Output a JSON list of objects. Each object must have:\n\
@@ -94,8 +95,7 @@ impl Dreamer {
              - \"properties\": (object) Key-value pairs of details.\n\
              Example:\n\
              [\n  {{ \"name\": \"User\", \"type\": \"Person\", \"description\": \"The user likes blue.\", \"properties\": {{ \"favorite_color\": \"blue\" }} }}\n]\n\
-             Output ONLY JSON.",
-            transcript
+             Output ONLY JSON."
         );
 
         // 3. Inference
@@ -142,7 +142,7 @@ impl Dreamer {
                 .gallifrey
                 .insert(entity)
                 .await
-                .map_err(|e| ChronosError::Common(e.into()))?;
+                .map_err(ChronosError::Common)?;
 
             created_ids.push(id);
         }

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -22,7 +22,7 @@ pub struct Weaver {
 impl Weaver {
     /// Create a new Weaver instance.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -29,7 +29,7 @@
 //!     -   Any subsequent sources are **dropped entirely**, and a summary note
 //!         (e.g., "... (N more sources truncated)") is appended.
 
-use super::{ContextSource, ContextSourceType, RagConfig};
+use super::{ContextSource, RagConfig};
 use crate::error::ChronosResult;
 use crate::pipeline::analyzer::AnalyzedQuery;
 use chrono::Utc;
@@ -128,6 +128,19 @@ pub fn augment(
     Ok(augmented)
 }
 
+/// Estimate tokens from text (4 chars per token).
+const fn estimate_tokens(text: &str) -> usize {
+    text.len().div_ceil(4)
+}
+
+/// Truncate string to a maximum number of characters, respecting UTF-8 boundaries.
+fn truncate_string(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
 /// Write system context header to buffer.
 fn write_system_context(
     buffer: &mut String,
@@ -156,15 +169,7 @@ fn write_context(buffer: &mut String, context: &[ContextSource], max_tokens: usi
     let mut token_estimate = 0;
 
     for (i, source) in context.iter().enumerate() {
-        let source_type = match source.source_type {
-            ContextSourceType::Knowledge => "Knowledge",
-            ContextSourceType::Conversation => "Conversation",
-            ContextSourceType::SystemState => "System State",
-        };
-
-        // Rough token estimate (4 chars per token)
-        // Ceiling division to ensure non-empty sources cost at least 1 token
-        let source_tokens = source.content.len().div_ceil(4);
+        let source_tokens = estimate_tokens(&source.content);
 
         if token_estimate + source_tokens > max_tokens {
             // Calculate remaining budget
@@ -173,18 +178,11 @@ fn write_context(buffer: &mut String, context: &[ContextSource], max_tokens: usi
 
             // If we have space for at least some content, include it partially
             if chars_to_take > 0 {
-                // Bolt optimization: slice string instead of allocating new one
-                let end_index = source
-                    .content
-                    .char_indices()
-                    .map(|(i, _)| i)
-                    .nth(chars_to_take)
-                    .unwrap_or(source.content.len());
-
-                let truncated_content = &source.content[..end_index];
+                let truncated_content = truncate_string(&source.content, chars_to_take);
                 let _ = writeln!(
                     buffer,
-                    "### {source_type} {} (relevance: {:.2})\n{}...\n",
+                    "### {} {} (relevance: {:.2})\n{}...\n",
+                    source.source_type,
                     i + 1,
                     source.relevance,
                     truncated_content
@@ -211,7 +209,8 @@ fn write_context(buffer: &mut String, context: &[ContextSource], max_tokens: usi
 
         let _ = writeln!(
             buffer,
-            "### {source_type} {} (relevance: {:.2})\n{}\n",
+            "### {} {} (relevance: {:.2})\n{}\n",
+            source.source_type,
             i + 1,
             source.relevance,
             source.content

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -120,6 +120,16 @@ pub enum ContextSourceType {
     SystemState,
 }
 
+impl std::fmt::Display for ContextSourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Knowledge => write!(f, "Knowledge"),
+            Self::Conversation => write!(f, "Conversation"),
+            Self::SystemState => write!(f, "System State"),
+        }
+    }
+}
+
 /// Response from a RAG query.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RagResponse {
@@ -160,6 +170,14 @@ impl Chronos {
     }
 
     /// Execute a RAG query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Query analysis fails.
+    /// - Context retrieval fails.
+    /// - Prompt augmentation fails.
+    /// - LLM inference fails.
     #[instrument(skip(self, config))]
     pub async fn query(&self, prompt: &str, config: RagConfig) -> ChronosResult<RagResponse> {
         info!("Processing RAG query");
@@ -197,6 +215,10 @@ impl Chronos {
     }
 
     /// Store a memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the memory cannot be inserted into the knowledge graph.
     #[allow(clippy::unused_async)]
     pub async fn remember(
         &self,
@@ -233,6 +255,10 @@ impl Chronos {
     }
 
     /// Recall memories matching a query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the semantic search fails.
     #[allow(clippy::unused_async)]
     pub async fn recall(&self, query: &str, limit: usize) -> ChronosResult<Vec<ContextSource>> {
         info!("Recalling memories for: {}", &query[..query.len().min(50)]);

--- a/vortex/src/services.rs
+++ b/vortex/src/services.rs
@@ -21,7 +21,7 @@ pub struct VortexLlmService {
 impl VortexLlmService {
     /// Create a new service adapter.
     #[must_use]
-    pub fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
         Self { engine, model }
     }
 }


### PR DESCRIPTION
Refactored `chronos/src/pipeline/augmenter.rs` to improve readability by extracting helper functions for token estimation and string truncation. Also enforced idiomatic Rust patterns by implementing `Display` for `ContextSourceType` and fixing various `clippy` warnings across `chronos` and `vortex`.

---
*PR created automatically by Jules for task [12918575395045747172](https://jules.google.com/task/12918575395045747172) started by @madmax983*