### PR TITLE
🌟 Nova: The Medium - Summoning Past Entities

### DIFF
--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -94,7 +94,9 @@ impl Curiosity {
             .vortex
             .infer(self.model, &prompt, params)
             .await
-            .map_err(|e| crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            .map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            })?;
 
         Ok(format!(
             "🤔 Regarding '{}': {}",

--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -42,11 +42,7 @@ struct DreamEntity {
 impl Dreamer {
     /// Create a new Dreamer engine.
     #[must_use]
-    pub const fn new(
-        gallifrey: Arc<Gallifrey>,
-        vortex: Arc<Vortex>,
-        model: ModelHandle,
-    ) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,
@@ -77,14 +73,15 @@ impl Dreamer {
         }
 
         // 2. Construct prompt
+        use std::fmt::Write as _;
         let mut transcript = String::new();
         for msg in &messages {
-            transcript.push_str(&format!("{:?}: {}\n", msg.role, msg.content));
+            let _ = writeln!(transcript, "{:?}: {}", msg.role, msg.content);
         }
 
         let prompt = format!(
             "CONVERSATION TRANSCRIPT:\n\
-             {}\n\n\
+             {transcript}\n\n\
              TASK: Extract key facts, user preferences, and important entities from the above conversation.\n\
              Ignore trivial greetings. Focus on long-term knowledge.\n\
              Output a JSON list of objects. Each object must have:\n\
@@ -94,8 +91,7 @@ impl Dreamer {
              - \"properties\": (object) Key-value pairs of details.\n\
              Example:\n\
              [\n  {{ \"name\": \"User\", \"type\": \"Person\", \"description\": \"The user likes blue.\", \"properties\": {{ \"favorite_color\": \"blue\" }} }}\n]\n\
-             Output ONLY JSON.",
-            transcript
+             Output ONLY JSON."
         );
 
         // 3. Inference
@@ -142,12 +138,15 @@ impl Dreamer {
                 .gallifrey
                 .insert(entity)
                 .await
-                .map_err(|e| ChronosError::Common(e.into()))?;
+                .map_err(ChronosError::Common)?;
 
             created_ids.push(id);
         }
 
-        info!("Dreamer: Created {} new knowledge entities.", created_ids.len());
+        info!(
+            "Dreamer: Created {} new knowledge entities.",
+            created_ids.len()
+        );
 
         Ok(created_ids)
     }

--- a/chronos/src/experimental/medium.rs
+++ b/chronos/src/experimental/medium.rs
@@ -1,0 +1,182 @@
+//! The Medium 🔮
+//!
+//! A module for summoning the "spirits" of entities from the past.
+//! It reconstructs an entity's state at a specific point in time and uses
+//! the LLM to generate a persona that can answer questions about its existence.
+
+use crate::error::ChronosResult;
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+use tardis_common::domain::Entity;
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+
+/// The Medium service.
+#[derive(Debug)]
+pub struct Medium {
+    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<Vortex>,
+    model_handle: ModelHandle,
+}
+
+impl Medium {
+    /// Create a new Medium instance.
+    #[must_use]
+    pub const fn new(
+        gallifrey: Arc<Gallifrey>,
+        vortex: Arc<Vortex>,
+        model_handle: ModelHandle,
+    ) -> Self {
+        Self {
+            gallifrey,
+            vortex,
+            model_handle,
+        }
+    }
+
+    /// Summon an entity from a specific time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entity cannot be found or if the time is invalid.
+    pub async fn summon(
+        &self,
+        entity_name: &str,
+        timestamp: DateTime<Utc>,
+    ) -> ChronosResult<Option<MediumSession>> {
+        // Find entity ID by name (linear scan)
+        let mut target_id = None;
+
+        // We use a linear scan because Gallifrey doesn't index names yet.
+        // This is acceptable for an experimental feature.
+        let _ = self.gallifrey.knowledge().scan_history(|history| {
+            if let Some(first) = history.first() {
+                if first.name == entity_name {
+                    target_id = Some(first.id);
+                }
+            }
+        });
+
+        let Some(id) = target_id else {
+            return Ok(None);
+        };
+
+        // Get history and find the version active at timestamp
+        let history = self.gallifrey.get_history(id).await.map_err(|e| {
+            crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+        })?;
+
+        let snapshot = history
+            .into_iter()
+            .find(|e| e.temporal.active_at(timestamp, timestamp));
+
+        match snapshot {
+            Some(entity) => Ok(Some(MediumSession {
+                entity,
+                vortex: Arc::clone(&self.vortex),
+                model_handle: self.model_handle,
+                timestamp,
+            })),
+            None => Ok(None),
+        }
+    }
+}
+
+/// A session with a summoned entity.
+#[derive(Debug)]
+pub struct MediumSession {
+    entity: Entity,
+    vortex: Arc<Vortex>,
+    model_handle: ModelHandle,
+    timestamp: DateTime<Utc>,
+}
+
+impl MediumSession {
+    /// Ask the entity a question.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the LLM inference fails.
+    pub async fn ask(&self, question: &str) -> ChronosResult<String> {
+        let props = serde_json::to_string_pretty(&self.entity.properties).unwrap_or_default();
+
+        let prompt = format!(
+            "You are the spirit of '{name}', summoned from {time}.\n\
+             Your existence at that time was defined by these properties:\n{props}\n\n\
+             User Question: {question}\n\n\
+             Answer as the entity '{name}' would, based on your state at that time. \
+             Be slightly dramatic and mysterious.",
+            name = self.entity.name,
+            time = self.timestamp,
+            props = props,
+            question = question
+        );
+
+        let params = InferenceParams {
+            max_tokens: 150,
+            temperature: 0.8,
+            ..InferenceParams::default()
+        };
+
+        self.vortex
+            .infer(self.model_handle, &prompt, params)
+            .await
+            .map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::BiTemporalInterval;
+
+    #[tokio::test]
+    async fn test_medium_summon() {
+        let gallifrey = Arc::new(Gallifrey::new());
+        let vortex = Arc::new(Vortex::new().unwrap());
+
+        // Mock Vortex
+        vortex.set_mock_inference(Box::new(|_, _, _| {
+            Ok("I am the ghost of systems past...".to_string())
+        }));
+
+        let handle = ModelHandle::new(1);
+        let medium = Medium::new(Arc::clone(&gallifrey), vortex, handle);
+
+        // Create a past entity
+        let id = EntityId::new();
+        let past_time = Utc::now() - chrono::Duration::days(365);
+
+        let mut entity = Entity {
+            id,
+            entity_type: "SystemProcess".to_string(),
+            name: "OldProcess".to_string(),
+            properties: HashMap::from([("status".to_string(), serde_json::json!("Dead"))]),
+            embedding: None,
+            temporal: BiTemporalInterval::now(), // Temporarily now
+            source: None,
+        };
+        // Manually adjust temporal to be valid in the past
+        entity.temporal.valid_time.start = past_time;
+        entity.temporal.valid_time.end = Some(past_time + chrono::Duration::days(1));
+        // Also adjust transaction time so it appears we knew about it back then
+        entity.temporal.transaction_time.start = past_time;
+
+        gallifrey.insert(entity).await.unwrap();
+
+        // Summon it
+        let session = medium
+            .summon("OldProcess", past_time + chrono::Duration::hours(1))
+            .await
+            .unwrap();
+        assert!(session.is_some());
+
+        let response = session.unwrap().ask("Who are you?").await.unwrap();
+        assert_eq!(response, "I am the ghost of systems past...");
+    }
+}

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -22,3 +22,6 @@ pub mod dreamer;
 
 #[cfg(feature = "nova")]
 pub mod weaver;
+
+#[cfg(feature = "nova")]
+pub mod medium;

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -22,7 +22,7 @@ pub struct Weaver {
 impl Weaver {
     /// Create a new Weaver instance.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,
@@ -79,9 +79,10 @@ The connection is: [/INST]",
             }
 
             // Find latest version that matches name
-            if let Some(e) = history.iter().find(|e| {
-                e.name.eq_ignore_ascii_case(name) && e.temporal.is_current()
-            }) {
+            if let Some(e) = history
+                .iter()
+                .find(|e| e.name.eq_ignore_ascii_case(name) && e.temporal.is_current())
+            {
                 found = Some(e.clone());
             }
         })?;
@@ -121,11 +122,13 @@ mod tests {
 
         let knowledge = gallifrey.knowledge();
         let mut found = None;
-        knowledge.scan_history(|history| {
-             if let Some(e) = history.iter().find(|e| e.name == "TestBot") {
-                 found = Some(e.clone());
-             }
-        }).unwrap();
+        knowledge
+            .scan_history(|history| {
+                if let Some(e) = history.iter().find(|e| e.name == "TestBot") {
+                    found = Some(e.clone());
+                }
+            })
+            .unwrap();
 
         assert!(found.is_some());
         assert_eq!(found.unwrap().name, "TestBot");

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -129,11 +129,7 @@ pub fn augment(
 }
 
 /// Write system context header to buffer.
-fn write_system_context(
-    buffer: &mut String,
-    analysis: &AnalyzedQuery,
-    persona: Option<&str>,
-) {
+fn write_system_context(buffer: &mut String, analysis: &AnalyzedQuery, persona: Option<&str>) {
     if let Some(p) = persona {
         let _ = writeln!(buffer, "# {p}\n");
     } else {

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -43,8 +43,10 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tardis_common::domain::Entity;
 use tardis_common::id::{EntityId, SessionId};
-use tardis_common::traits::{LlmService, KnowledgeService, ConversationService, SystemStateService};
 use tardis_common::llm::InferenceParams;
+use tardis_common::traits::{
+    ConversationService, KnowledgeService, LlmService, SystemStateService,
+};
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -160,6 +162,10 @@ impl Chronos {
     }
 
     /// Execute a RAG query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if query analysis, retrieval, or inference fails.
     #[instrument(skip(self, config))]
     pub async fn query(&self, prompt: &str, config: RagConfig) -> ChronosResult<RagResponse> {
         info!("Processing RAG query");
@@ -174,8 +180,9 @@ impl Chronos {
             &self.conversation,
             &self.system_state,
             &analysis,
-            &config
-        ).await?;
+            &config,
+        )
+        .await?;
         info!("Retrieved {} context items", context.len());
 
         // 3. Augment the prompt
@@ -184,8 +191,8 @@ impl Chronos {
         // 4. Run inference
         let params = InferenceParams::default();
         let text = match self.llm.infer(&augmented_prompt, params).await {
-             Ok(t) => t,
-             Err(e) => return Err(ChronosError::Common(e)),
+            Ok(t) => t,
+            Err(e) => return Err(ChronosError::Common(e)),
         };
 
         Ok(RagResponse {
@@ -197,6 +204,10 @@ impl Chronos {
     }
 
     /// Store a memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the memory cannot be stored in the knowledge graph.
     #[allow(clippy::unused_async)]
     pub async fn remember(
         &self,
@@ -233,6 +244,10 @@ impl Chronos {
     }
 
     /// Recall memories matching a query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the search fails.
     #[allow(clippy::unused_async)]
     pub async fn recall(&self, query: &str, limit: usize) -> ChronosResult<Vec<ContextSource>> {
         info!("Recalling memories for: {}", &query[..query.len().min(50)]);
@@ -253,6 +268,24 @@ impl Chronos {
                 entity_id: Some(e.id),
             })
             .collect())
+    }
+}
+
+#[cfg(feature = "nova")]
+impl Chronos {
+    /// Get the underlying Vortex engine.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the LLM service is not Vortex.
+    #[must_use]
+    #[allow(clippy::expect_used)]
+    pub fn vortex(&self) -> &Arc<tardis_vortex::Vortex> {
+        self.llm
+            .as_any()
+            .downcast_ref::<tardis_vortex::VortexLlmService>()
+            .expect("Chronos LLM service must be Vortex for experimental features")
+            .engine()
     }
 }
 

--- a/common/src/domain/conversation.rs
+++ b/common/src/domain/conversation.rs
@@ -1,9 +1,9 @@
 //! Conversation entities.
 
+use crate::id::{EntityId, SessionId};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::{EntityId, SessionId};
 
 /// Role in a conversation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/common/src/domain/knowledge.rs
+++ b/common/src/domain/knowledge.rs
@@ -1,9 +1,9 @@
 //! Knowledge graph entities.
 
+use crate::id::EntityId;
 use crate::temporal::BiTemporalInterval;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::EntityId;
 
 /// A node in the knowledge graph.
 ///

--- a/common/src/domain/state.rs
+++ b/common/src/domain/state.rs
@@ -1,9 +1,9 @@
 //! System state entities.
 
+use crate::id::SnapshotId;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::SnapshotId;
 
 /// A snapshot of system state.
 ///

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -3,18 +3,21 @@
 //! These traits define the interfaces for core system components, enabling
 //! decoupling and easier testing/mocking.
 
-use async_trait::async_trait;
-use crate::llm::InferenceParams;
-use crate::domain::{Entity, Message, Session, Snapshot, Change};
+use crate::domain::{Change, Entity, Message, Session, Snapshot};
 use crate::id::{EntityId, SessionId};
+use crate::llm::InferenceParams;
 use crate::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use chrono::{DateTime, Utc};
 
 /// Interface for LLM inference services.
 #[async_trait]
 pub trait LlmService: Send + Sync + Debug {
+    /// Cast to Any for downcasting.
+    fn as_any(&self) -> &dyn std::any::Any;
+
     /// Generate text based on a prompt.
     async fn infer(&self, prompt: &str, params: InferenceParams) -> Result<String>;
 
@@ -29,7 +32,11 @@ pub trait KnowledgeService: Send + Sync + Debug {
     async fn insert_entity(&self, entity: Entity) -> Result<EntityId>;
 
     /// Update an entity.
-    async fn update_entity(&self, id: EntityId, updates: HashMap<String, serde_json::Value>) -> Result<()>;
+    async fn update_entity(
+        &self,
+        id: EntityId,
+        updates: HashMap<String, serde_json::Value>,
+    ) -> Result<()>;
 
     /// Get the current version of an entity.
     async fn get_entity(&self, id: EntityId) -> Result<Option<Entity>>;
@@ -57,7 +64,11 @@ pub trait ConversationService: Send + Sync + Debug {
     async fn add_message(&self, message: Message) -> Result<EntityId>;
 
     /// Get recent messages from a session.
-    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>>;
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> Result<Vec<Message>>;
 
     /// Search messages by semantic similarity.
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>>;

--- a/gallifrey/src/services.rs
+++ b/gallifrey/src/services.rs
@@ -1,22 +1,28 @@
 //! Service implementations for Gallifrey.
 
 use crate::stores::{ConversationStore, KnowledgeStore, SystemStateStore};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
 use tardis_common::domain::{Change, Entity, Message, Session, Snapshot};
 use tardis_common::id::{EntityId, SessionId};
 use tardis_common::traits::{ConversationService, KnowledgeService, SystemStateService};
 use tardis_common::Result;
-use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use std::collections::HashMap;
 
 #[async_trait]
 impl KnowledgeService for KnowledgeStore {
     async fn insert_entity(&self, entity: Entity) -> Result<EntityId> {
-        self.insert_entity(entity).map_err(tardis_common::Error::from)
+        self.insert_entity(entity)
+            .map_err(tardis_common::Error::from)
     }
 
-    async fn update_entity(&self, id: EntityId, updates: HashMap<String, serde_json::Value>) -> Result<()> {
-        self.update_entity(id, updates).map_err(tardis_common::Error::from)
+    async fn update_entity(
+        &self,
+        id: EntityId,
+        updates: HashMap<String, serde_json::Value>,
+    ) -> Result<()> {
+        self.update_entity(id, updates)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn get_entity(&self, id: EntityId) -> Result<Option<Entity>> {
@@ -24,11 +30,13 @@ impl KnowledgeService for KnowledgeStore {
     }
 
     async fn get_entity_history(&self, id: EntityId) -> Result<Vec<Entity>> {
-        self.get_entity_history(id).map_err(tardis_common::Error::from)
+        self.get_entity_history(id)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>> {
-        self.semantic_search(embedding, limit).map_err(tardis_common::Error::from)
+        self.semantic_search(embedding, limit)
+            .map_err(tardis_common::Error::from)
     }
 }
 
@@ -47,25 +55,34 @@ impl ConversationService for ConversationStore {
     }
 
     async fn add_message(&self, message: Message) -> Result<EntityId> {
-        self.add_message(message).map_err(tardis_common::Error::from)
+        self.add_message(message)
+            .map_err(tardis_common::Error::from)
     }
 
-    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>> {
-        self.get_recent_messages(session_id, limit).map_err(tardis_common::Error::from)
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> Result<Vec<Message>> {
+        self.get_recent_messages(session_id, limit)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>> {
-        self.semantic_search(embedding, limit).map_err(tardis_common::Error::from)
+        self.semantic_search(embedding, limit)
+            .map_err(tardis_common::Error::from)
     }
 }
 
 #[async_trait]
 impl SystemStateService for SystemStateStore {
     async fn find_snapshot_at(&self, timestamp: DateTime<Utc>) -> Result<Option<Snapshot>> {
-        self.find_snapshot_at(timestamp).map_err(tardis_common::Error::from)
+        self.find_snapshot_at(timestamp)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn record_change(&self, change: Change) -> Result<()> {
-        self.record_change(change).map_err(tardis_common::Error::from)
+        self.record_change(change)
+            .map_err(tardis_common::Error::from)
     }
 }

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -335,9 +335,9 @@ impl KnowledgeStore {
             .iter()
             .filter_map(|id| {
                 entities.get(id).and_then(|versions| {
-                    versions.iter().find(|e| {
-                        e.temporal.active_at(now, now) && e.entity_type == entity_type
-                    })
+                    versions
+                        .iter()
+                        .find(|e| e.temporal.active_at(now, now) && e.entity_type == entity_type)
                 })
             })
             .cloned()

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -14,6 +14,7 @@
 use crate::commands::traits::{CommandContext, CommandResult, ShellCommand};
 use anyhow::Result;
 use async_trait::async_trait;
+use std::io::Write;
 use std::sync::Arc;
 
 #[cfg(feature = "nova")]
@@ -24,6 +25,8 @@ use crate::experimental::{
 use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::dreamer::Dreamer;
+#[cfg(feature = "nova")]
+use tardis_chronos::experimental::medium::Medium;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::weaver::Weaver;
 #[cfg(feature = "nova")]
@@ -37,11 +40,11 @@ pub struct ChameleonCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for ChameleonCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "chameleon"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Set the system persona"
     }
 
@@ -93,13 +96,13 @@ impl ShellCommand for SonicCommand {
             return Ok(CommandResult::Continue);
         }
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context.chronos.vortex().clone().list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let screwdriver = SonicScrewdriver::new(
             context.telemetry.clone(),
             Some(Arc::clone(&context.gallifrey)),
-            Some(context.chronos.vortex()),
+            Some(context.chronos.vortex().clone()),
             model_handle,
         );
 
@@ -129,6 +132,96 @@ impl ShellCommand for SonicCommand {
     }
 }
 
+/// Medium command.
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct MediumCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for MediumCommand {
+    fn name(&self) -> &'static str {
+        "medium"
+    }
+
+    fn description(&self) -> &'static str {
+        "Summon a past entity for a chat"
+    }
+
+    async fn execute(&self, args: &[String], context: &CommandContext) -> Result<CommandResult> {
+        if args.is_empty() {
+            println!("Usage: medium <entity> [timestamp]");
+            return Ok(CommandResult::Continue);
+        }
+
+        let entity_name = &args[0];
+        let timestamp = if args.len() > 1 {
+            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&args[1]) {
+                dt.with_timezone(&chrono::Utc)
+            } else {
+                println!("Invalid timestamp format. Use RFC3339 (e.g. 2023-01-01T12:00:00Z)");
+                return Ok(CommandResult::Continue);
+            }
+        } else {
+            chrono::Utc::now()
+        };
+
+        let loaded_models = context.chronos.vortex().clone().list_loaded_models();
+        if let Some((handle, _)) = loaded_models.first() {
+            let medium = Medium::new(
+                Arc::clone(&context.gallifrey),
+                context.chronos.vortex().clone(),
+                *handle,
+            );
+
+            println!("🕯️ Summoning the spirit of '{entity_name}' from {timestamp}...");
+
+            match medium.summon(entity_name, timestamp).await {
+                Ok(Some(session)) => {
+                    println!("👻 Connection established. Type 'goodbye' to end the seance.");
+
+                    let stdin = std::io::stdin();
+                    let mut input = String::new();
+
+                    loop {
+                        input.clear();
+                        print!("🔮 You: ");
+                        let _ = std::io::stdout().flush();
+
+                        if stdin.read_line(&mut input).is_err() {
+                            break;
+                        }
+
+                        let query = input.trim();
+                        if query.eq_ignore_ascii_case("goodbye")
+                            || query.eq_ignore_ascii_case("exit")
+                        {
+                            break;
+                        }
+
+                        if query.is_empty() {
+                            continue;
+                        }
+
+                        match session.ask(query).await {
+                            Ok(response) => println!("👻 Entity: {response}"),
+                            Err(e) => println!("The connection flickers: {e}"),
+                        }
+                    }
+                    println!("The candles blow out.");
+                }
+                Ok(None) => println!(
+                    "The spirits are silent. No record of '{entity_name}' found at that time."
+                ),
+                Err(e) => println!("The ritual failed: {e}"),
+            }
+        } else {
+            println!("The Medium needs a loaded model. Use 'models load <path>'.");
+        }
+        Ok(CommandResult::Continue)
+    }
+}
+
 /// Dreamer command.
 #[cfg(feature = "nova")]
 #[derive(Debug)]
@@ -137,20 +230,20 @@ pub struct DreamCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for DreamCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "dream"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Consolidate memories from conversation"
     }
 
     async fn execute(&self, _args: &[String], context: &CommandContext) -> Result<CommandResult> {
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context.chronos.vortex().clone().list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let dreamer = Dreamer::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.chronos.vortex().clone(),
                 *handle,
             );
 
@@ -160,7 +253,10 @@ impl ShellCommand for DreamCommand {
                     if ids.is_empty() {
                         println!("No new memories formed.");
                     } else {
-                        println!("✨ Consolidated {} new memories into long-term storage.", ids.len());
+                        println!(
+                            "✨ Consolidated {} new memories into long-term storage.",
+                            ids.len()
+                        );
                     }
                 }
                 Err(e) => println!("Nightmare encountered: {e}"),
@@ -202,13 +298,13 @@ impl ShellCommand for FixCommand {
             return Ok(CommandResult::Continue);
         }
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context.chronos.vortex().clone().list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let screwdriver = SonicScrewdriver::new(
             context.telemetry.clone(),
             Some(Arc::clone(&context.gallifrey)),
-            Some(context.chronos.vortex()),
+            Some(context.chronos.vortex().clone()),
             model_handle,
         );
 
@@ -413,12 +509,12 @@ impl ShellCommand for BiographerCommand {
         }
         let entity_name = args.join(" ");
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context.chronos.vortex().clone().list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let biographer = Biographer::new(
             Arc::clone(&context.gallifrey),
-            context.chronos.vortex(),
+            context.chronos.vortex().clone(),
             model_handle,
         );
 
@@ -459,11 +555,11 @@ impl ShellCommand for CuriosityCommand {
     }
 
     async fn execute(&self, _args: &[String], context: &CommandContext) -> Result<CommandResult> {
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context.chronos.vortex().clone().list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let curiosity = Curiosity::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.chronos.vortex().clone(),
                 *handle,
             );
 
@@ -563,11 +659,11 @@ pub struct WeaveCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for WeaveCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "weave"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Generate a narrative connection between two entities"
     }
 
@@ -580,11 +676,11 @@ impl ShellCommand for WeaveCommand {
         let entity1 = &args[0];
         let entity2 = &args[1];
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context.chronos.vortex().clone().list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let weaver = Weaver::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.chronos.vortex().clone(),
                 *handle,
             );
 

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -118,6 +118,7 @@ impl Repl {
             registry.register(Box::new(commands::experimental::CuriosityCommand));
             registry.register(Box::new(commands::experimental::CapsuleCommand));
             registry.register(Box::new(commands::experimental::DreamCommand));
+            registry.register(Box::new(commands::experimental::MediumCommand));
             registry.register(Box::new(commands::experimental::WeaveCommand));
         }
     }
@@ -206,9 +207,9 @@ impl Repl {
                 }
                 #[cfg(feature = "nova")]
                 Ok(CommandResult::SetPersona(persona)) => {
-                    self.persona = persona.clone();
+                    self.persona.clone_from(&persona);
                     if let Some(p) = persona {
-                        println!("System persona set to: {}", p);
+                        println!("System persona set to: {p}");
                     } else {
                         println!("System persona reset to default.");
                     }
@@ -237,7 +238,7 @@ impl Repl {
 
         #[cfg(feature = "nova")]
         {
-            config.persona = self.persona.clone();
+            config.persona.clone_from(&self.persona);
         }
 
         match self.chronos.query(query, config).await {

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -188,10 +188,7 @@ mod tests {
     use super::*;
 
     fn test_router() -> Router {
-        Router::new(vec![
-            "help".to_string(),
-            "history".to_string(),
-        ])
+        Router::new(vec!["help".to_string(), "history".to_string()])
     }
 
     #[test]

--- a/vortex/src/services.rs
+++ b/vortex/src/services.rs
@@ -1,12 +1,12 @@
 //! Service implementations for Vortex.
 
 use crate::Vortex;
+use async_trait::async_trait;
+use std::sync::Arc;
 use tardis_common::id::ModelHandle;
 use tardis_common::llm::InferenceParams;
 use tardis_common::traits::LlmService;
 use tardis_common::Result;
-use async_trait::async_trait;
-use std::sync::Arc;
 
 /// A wrapper around Vortex that binds it to a specific model.
 ///
@@ -21,13 +21,23 @@ pub struct VortexLlmService {
 impl VortexLlmService {
     /// Create a new service adapter.
     #[must_use]
-    pub fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
         Self { engine, model }
+    }
+
+    /// Get the underlying engine.
+    #[must_use]
+    pub const fn engine(&self) -> &Arc<Vortex> {
+        &self.engine
     }
 }
 
 #[async_trait]
 impl LlmService for VortexLlmService {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
     async fn infer(&self, prompt: &str, params: InferenceParams) -> Result<String> {
         self.engine
             .infer(self.model, prompt, params)


### PR DESCRIPTION
This PR introduces the "Medium" command, a new experimental feature under the `nova` flag. The Medium allows users to "summon" an entity as it existed at a specific point in time and converse with it via a generated persona.

## Changes

1.  **Chronos**:
    *   Added `experimental/medium.rs`: Implements `Medium` logic to retrieve historical entity states and generate prompts.
    *   Added `MediumSession`: Manages the conversation context with the summoned entity.
    *   Updated `pipeline/mod.rs`: Added `vortex()` method to access the concrete `Vortex` engine (required for experimental features).
    *   Updated `LlmService` trait in `common`: Added `as_any()` to support safe downcasting.

2.  **Shell**:
    *   Added `MediumCommand` to `commands/experimental.rs`:
        *   Usage: `medium <entity_name> [timestamp]`
        *   Interactive loop using `stdin`.
    *   Registered command in `repl.rs`.

3.  **Fixes**:
    *   Addressed clippy warnings in `experimental/dreamer.rs` and `experimental/weaver.rs`.
    *   Fixed `missing_const_for_fn` in `vortex/src/services.rs`.

## Testing

*   Added unit test `test_medium_summon` in `chronos`.
*   Verified compilation with `cargo test --features nova`.
*   Verified clippy compliance.

## "The Hook"

"The TARDIS remembers everything. With the Medium, you don't just read logs—you interrogate the past. Summon a deleted process and ask it *why* it crashed."

---
*PR created automatically by Jules for task [11839625285509193140](https://jules.google.com/task/11839625285509193140) started by @madmax983*