### PR TITLE
🌟 Nova: The Medium (Seance Engine)

### DIFF
--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -94,7 +94,9 @@ impl Curiosity {
             .vortex
             .infer(self.model, &prompt, params)
             .await
-            .map_err(|e| crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            .map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            })?;
 
         Ok(format!(
             "🤔 Regarding '{}': {}",

--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -42,11 +42,7 @@ struct DreamEntity {
 impl Dreamer {
     /// Create a new Dreamer engine.
     #[must_use]
-    pub const fn new(
-        gallifrey: Arc<Gallifrey>,
-        vortex: Arc<Vortex>,
-        model: ModelHandle,
-    ) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,
@@ -147,7 +143,10 @@ impl Dreamer {
             created_ids.push(id);
         }
 
-        info!("Dreamer: Created {} new knowledge entities.", created_ids.len());
+        info!(
+            "Dreamer: Created {} new knowledge entities.",
+            created_ids.len()
+        );
 
         Ok(created_ids)
     }

--- a/chronos/src/experimental/medium.rs
+++ b/chronos/src/experimental/medium.rs
@@ -1,0 +1,188 @@
+//! The Medium: Seance Engine.
+//!
+//! "I can hear the voices of the past."
+//!
+//! This module allows querying the system state at a specific point in the past.
+
+use crate::error::{ChronosError, ChronosResult};
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+use tardis_common::id::ModelHandle;
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::{InferenceParams, Vortex};
+use tracing::{info, instrument};
+
+/// The Medium engine.
+#[derive(Debug)]
+pub struct Medium {
+    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<Vortex>,
+    model: ModelHandle,
+}
+
+impl Medium {
+    /// Create a new Medium engine.
+    #[must_use]
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+        Self {
+            gallifrey,
+            vortex,
+            model,
+        }
+    }
+
+    /// Summon the past state and answer a query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the process fails.
+    #[instrument(skip(self))]
+    pub async fn summon(&self, query: &str, time: DateTime<Utc>) -> ChronosResult<String> {
+        info!("Medium: Summoning past state at {}", time);
+
+        // 1. Gather context from the past
+        let context = self.gather_context(query, time)?;
+
+        if context.trim().is_empty() {
+            return Ok(
+                "The spirits are silent. No relevant memories found from that time.".to_string(),
+            );
+        }
+
+        // 2. Prompt LLM
+        let prompt = format!(
+            "<s>[INST] You are the Spirit of the Past, representing the system state as it was on {time}.\n\
+             Your knowledge is strictly limited to the following context recovered from that time:\n\n\
+             {context}\n\n\
+             User Question: \"{query}\"\n\n\
+             Answer the question based ONLY on the provided context. If the answer is not in the context, say so fantastically (e.g., \"The mists of time obscure this detail\").\n\
+             Do not hallucinate facts not present in the context.[/INST]"
+        );
+
+        let params = InferenceParams::default()
+            .with_temperature(0.7)
+            .with_max_tokens(512);
+
+        let response = self
+            .vortex
+            .infer(self.model, &prompt, params)
+            .await
+            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+
+        Ok(response)
+    }
+
+    #[allow(clippy::format_push_string)]
+    fn gather_context(&self, query: &str, time: DateTime<Utc>) -> ChronosResult<String> {
+        let mut context = String::new();
+        let knowledge = self.gallifrey.knowledge();
+        let query_lower = query.to_lowercase();
+        let query_words: Vec<&str> = query_lower.split_whitespace().collect();
+
+        // Scan history for relevant entities active at `time`
+        // We use a simple heuristic: check if entity name contains any query word (if word len > 3)
+        // or if query contains entity name.
+        knowledge
+            .scan_history(|history| {
+                // Find version active at `time` (using transaction time = time for "as known then")
+                if let Some(entity) = history.iter().find(|e| e.temporal.active_at(time, time)) {
+                    let name_lower = entity.name.to_lowercase();
+
+                    let relevant = query_lower.contains(&name_lower)
+                        || query_words
+                            .iter()
+                            .any(|w| w.len() > 3 && name_lower.contains(w));
+
+                    if relevant {
+                        context.push_str(&format!(
+                            "- Entity: {} ({})\n",
+                            entity.name, entity.entity_type
+                        ));
+                        context.push_str(&format!("  Properties: {:?}\n", entity.properties));
+                    }
+                }
+            })
+            .map_err(|e| ChronosError::Common(e.into()))?;
+
+        Ok(context)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use std::collections::HashMap;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+    use tardis_gallifrey::domain::Entity;
+    use tardis_vortex::{ModelHandle, ModelLoadConfig};
+
+    fn create_test_entity(name: &str, entity_type: &str, time: DateTime<Utc>) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            entity_type: entity_type.to_string(),
+            name: name.to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            // Valid from `time` onwards
+            temporal: BiTemporalInterval::with_valid_time(TimeRange::starting_at(time)),
+            source: Some("test".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_medium_summon() {
+        let gallifrey = Arc::new(Gallifrey::new());
+        let vortex = Arc::new(Vortex::new().unwrap());
+
+        // Setup:
+        // Entity A created at T1
+        // Entity B created at T2
+        // Query at T1 should see A but not B.
+
+        let t1 = Utc.with_ymd_and_hms(2023, 10, 27, 10, 0, 0).unwrap();
+        let t2 = Utc.with_ymd_and_hms(2023, 10, 27, 12, 0, 0).unwrap();
+
+        let mut e1 = create_test_entity("OldProject", "Project", t1);
+        // Backdate transaction time to T1
+        e1.temporal.transaction_time.start = t1;
+        gallifrey.insert(e1).await.unwrap();
+
+        let mut e2 = create_test_entity("NewProject", "Project", t2);
+        // Backdate transaction time to T2
+        e2.temporal.transaction_time.start = t2;
+        gallifrey.insert(e2).await.unwrap();
+
+        // Mock Vortex
+        vortex.set_mock_inference(Box::new(|_, prompt, _| {
+            if prompt.contains("- Entity: OldProject") && !prompt.contains("- Entity: NewProject") {
+                Ok("I see OldProject.".to_string())
+            } else if prompt.contains("- Entity: NewProject") {
+                Ok("I see NewProject.".to_string())
+            } else {
+                Ok("I see nothing.".to_string())
+            }
+        }));
+
+        vortex.set_mock_load_model(Box::new(|_, _| Ok(ModelHandle::new(1))));
+
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
+        let medium = Medium::new(gallifrey, vortex, handle);
+
+        // Summon at T1 + 1 minute (should see OldProject, but NOT NewProject)
+        let query_time = t1 + chrono::Duration::minutes(1);
+
+        let response = medium
+            .summon("OldProject NewProject", query_time)
+            .await
+            .unwrap();
+
+        // The LLM mock returns "I see OldProject." if NewProject is NOT in context.
+        assert_eq!(response, "I see OldProject.");
+    }
+}

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -22,3 +22,6 @@ pub mod dreamer;
 
 #[cfg(feature = "nova")]
 pub mod weaver;
+
+#[cfg(feature = "nova")]
+pub mod medium;

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -79,9 +79,10 @@ The connection is: [/INST]",
             }
 
             // Find latest version that matches name
-            if let Some(e) = history.iter().find(|e| {
-                e.name.eq_ignore_ascii_case(name) && e.temporal.is_current()
-            }) {
+            if let Some(e) = history
+                .iter()
+                .find(|e| e.name.eq_ignore_ascii_case(name) && e.temporal.is_current())
+            {
                 found = Some(e.clone());
             }
         })?;
@@ -121,11 +122,13 @@ mod tests {
 
         let knowledge = gallifrey.knowledge();
         let mut found = None;
-        knowledge.scan_history(|history| {
-             if let Some(e) = history.iter().find(|e| e.name == "TestBot") {
-                 found = Some(e.clone());
-             }
-        }).unwrap();
+        knowledge
+            .scan_history(|history| {
+                if let Some(e) = history.iter().find(|e| e.name == "TestBot") {
+                    found = Some(e.clone());
+                }
+            })
+            .unwrap();
 
         assert!(found.is_some());
         assert_eq!(found.unwrap().name, "TestBot");

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -129,11 +129,7 @@ pub fn augment(
 }
 
 /// Write system context header to buffer.
-fn write_system_context(
-    buffer: &mut String,
-    analysis: &AnalyzedQuery,
-    persona: Option<&str>,
-) {
+fn write_system_context(buffer: &mut String, analysis: &AnalyzedQuery, persona: Option<&str>) {
     if let Some(p) = persona {
         let _ = writeln!(buffer, "# {p}\n");
     } else {

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -43,8 +43,12 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tardis_common::domain::Entity;
 use tardis_common::id::{EntityId, SessionId};
-use tardis_common::traits::{LlmService, KnowledgeService, ConversationService, SystemStateService};
 use tardis_common::llm::InferenceParams;
+use tardis_common::traits::{
+    ConversationService, KnowledgeService, LlmService, SystemStateService,
+};
+#[cfg(feature = "nova")]
+use tardis_vortex::{Vortex, VortexLlmService};
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -159,6 +163,24 @@ impl Chronos {
         }
     }
 
+    /// Get the underlying Vortex engine (Nova only).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the LLM service is not a `VortexLlmService`.
+    #[cfg(feature = "nova")]
+    #[must_use]
+    #[allow(clippy::panic)]
+    pub fn vortex(&self) -> &Arc<Vortex> {
+        self.llm
+            .as_any()
+            .downcast_ref::<VortexLlmService>()
+            .map_or_else(
+                || panic!("LlmService is not VortexLlmService"),
+                VortexLlmService::engine,
+            )
+    }
+
     /// Execute a RAG query.
     #[instrument(skip(self, config))]
     pub async fn query(&self, prompt: &str, config: RagConfig) -> ChronosResult<RagResponse> {
@@ -174,8 +196,9 @@ impl Chronos {
             &self.conversation,
             &self.system_state,
             &analysis,
-            &config
-        ).await?;
+            &config,
+        )
+        .await?;
         info!("Retrieved {} context items", context.len());
 
         // 3. Augment the prompt
@@ -184,8 +207,8 @@ impl Chronos {
         // 4. Run inference
         let params = InferenceParams::default();
         let text = match self.llm.infer(&augmented_prompt, params).await {
-             Ok(t) => t,
-             Err(e) => return Err(ChronosError::Common(e)),
+            Ok(t) => t,
+            Err(e) => return Err(ChronosError::Common(e)),
         };
 
         Ok(RagResponse {

--- a/common/src/domain/conversation.rs
+++ b/common/src/domain/conversation.rs
@@ -1,9 +1,9 @@
 //! Conversation entities.
 
+use crate::id::{EntityId, SessionId};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::{EntityId, SessionId};
 
 /// Role in a conversation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/common/src/domain/knowledge.rs
+++ b/common/src/domain/knowledge.rs
@@ -1,9 +1,9 @@
 //! Knowledge graph entities.
 
+use crate::id::EntityId;
 use crate::temporal::BiTemporalInterval;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::EntityId;
 
 /// A node in the knowledge graph.
 ///

--- a/common/src/domain/state.rs
+++ b/common/src/domain/state.rs
@@ -1,9 +1,9 @@
 //! System state entities.
 
+use crate::id::SnapshotId;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::SnapshotId;
 
 /// A snapshot of system state.
 ///

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -3,14 +3,15 @@
 //! These traits define the interfaces for core system components, enabling
 //! decoupling and easier testing/mocking.
 
-use async_trait::async_trait;
-use crate::llm::InferenceParams;
-use crate::domain::{Entity, Message, Session, Snapshot, Change};
+use crate::domain::{Change, Entity, Message, Session, Snapshot};
 use crate::id::{EntityId, SessionId};
+use crate::llm::InferenceParams;
 use crate::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
-use chrono::{DateTime, Utc};
 
 /// Interface for LLM inference services.
 #[async_trait]
@@ -20,6 +21,9 @@ pub trait LlmService: Send + Sync + Debug {
 
     /// Generate embeddings for text.
     async fn embed(&self, text: &str) -> Result<Vec<f32>>;
+
+    /// Downcast to concrete type.
+    fn as_any(&self) -> &dyn Any;
 }
 
 /// Interface for knowledge graph storage.
@@ -29,7 +33,11 @@ pub trait KnowledgeService: Send + Sync + Debug {
     async fn insert_entity(&self, entity: Entity) -> Result<EntityId>;
 
     /// Update an entity.
-    async fn update_entity(&self, id: EntityId, updates: HashMap<String, serde_json::Value>) -> Result<()>;
+    async fn update_entity(
+        &self,
+        id: EntityId,
+        updates: HashMap<String, serde_json::Value>,
+    ) -> Result<()>;
 
     /// Get the current version of an entity.
     async fn get_entity(&self, id: EntityId) -> Result<Option<Entity>>;
@@ -57,7 +65,11 @@ pub trait ConversationService: Send + Sync + Debug {
     async fn add_message(&self, message: Message) -> Result<EntityId>;
 
     /// Get recent messages from a session.
-    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>>;
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> Result<Vec<Message>>;
 
     /// Search messages by semantic similarity.
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>>;

--- a/gallifrey/src/services.rs
+++ b/gallifrey/src/services.rs
@@ -1,22 +1,28 @@
 //! Service implementations for Gallifrey.
 
 use crate::stores::{ConversationStore, KnowledgeStore, SystemStateStore};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
 use tardis_common::domain::{Change, Entity, Message, Session, Snapshot};
 use tardis_common::id::{EntityId, SessionId};
 use tardis_common::traits::{ConversationService, KnowledgeService, SystemStateService};
 use tardis_common::Result;
-use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use std::collections::HashMap;
 
 #[async_trait]
 impl KnowledgeService for KnowledgeStore {
     async fn insert_entity(&self, entity: Entity) -> Result<EntityId> {
-        self.insert_entity(entity).map_err(tardis_common::Error::from)
+        self.insert_entity(entity)
+            .map_err(tardis_common::Error::from)
     }
 
-    async fn update_entity(&self, id: EntityId, updates: HashMap<String, serde_json::Value>) -> Result<()> {
-        self.update_entity(id, updates).map_err(tardis_common::Error::from)
+    async fn update_entity(
+        &self,
+        id: EntityId,
+        updates: HashMap<String, serde_json::Value>,
+    ) -> Result<()> {
+        self.update_entity(id, updates)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn get_entity(&self, id: EntityId) -> Result<Option<Entity>> {
@@ -24,11 +30,13 @@ impl KnowledgeService for KnowledgeStore {
     }
 
     async fn get_entity_history(&self, id: EntityId) -> Result<Vec<Entity>> {
-        self.get_entity_history(id).map_err(tardis_common::Error::from)
+        self.get_entity_history(id)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>> {
-        self.semantic_search(embedding, limit).map_err(tardis_common::Error::from)
+        self.semantic_search(embedding, limit)
+            .map_err(tardis_common::Error::from)
     }
 }
 
@@ -47,25 +55,34 @@ impl ConversationService for ConversationStore {
     }
 
     async fn add_message(&self, message: Message) -> Result<EntityId> {
-        self.add_message(message).map_err(tardis_common::Error::from)
+        self.add_message(message)
+            .map_err(tardis_common::Error::from)
     }
 
-    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>> {
-        self.get_recent_messages(session_id, limit).map_err(tardis_common::Error::from)
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> Result<Vec<Message>> {
+        self.get_recent_messages(session_id, limit)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>> {
-        self.semantic_search(embedding, limit).map_err(tardis_common::Error::from)
+        self.semantic_search(embedding, limit)
+            .map_err(tardis_common::Error::from)
     }
 }
 
 #[async_trait]
 impl SystemStateService for SystemStateStore {
     async fn find_snapshot_at(&self, timestamp: DateTime<Utc>) -> Result<Option<Snapshot>> {
-        self.find_snapshot_at(timestamp).map_err(tardis_common::Error::from)
+        self.find_snapshot_at(timestamp)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn record_change(&self, change: Change) -> Result<()> {
-        self.record_change(change).map_err(tardis_common::Error::from)
+        self.record_change(change)
+            .map_err(tardis_common::Error::from)
     }
 }

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -335,9 +335,9 @@ impl KnowledgeStore {
             .iter()
             .filter_map(|id| {
                 entities.get(id).and_then(|versions| {
-                    versions.iter().find(|e| {
-                        e.temporal.active_at(now, now) && e.entity_type == entity_type
-                    })
+                    versions
+                        .iter()
+                        .find(|e| e.temporal.active_at(now, now) && e.entity_type == entity_type)
                 })
             })
             .cloned()

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -10,6 +10,7 @@
 //! - **Heatmap**: Temporal activity analysis.
 //! - **Curiosity**: Active learning.
 //! - **Time Capsule**: Backup and restore entity subgraphs.
+//! - **Medium**: Seance with past system states.
 
 use crate::commands::traits::{CommandContext, CommandResult, ShellCommand};
 use anyhow::Result;
@@ -25,6 +26,8 @@ use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::dreamer::Dreamer;
 #[cfg(feature = "nova")]
+use tardis_chronos::experimental::medium::Medium;
+#[cfg(feature = "nova")]
 use tardis_chronos::experimental::weaver::Weaver;
 #[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
@@ -37,11 +40,11 @@ pub struct ChameleonCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for ChameleonCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "chameleon"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Set the system persona"
     }
 
@@ -99,7 +102,7 @@ impl ShellCommand for SonicCommand {
         let screwdriver = SonicScrewdriver::new(
             context.telemetry.clone(),
             Some(Arc::clone(&context.gallifrey)),
-            Some(context.chronos.vortex()),
+            Some(context.chronos.vortex().clone()),
             model_handle,
         );
 
@@ -137,11 +140,11 @@ pub struct DreamCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for DreamCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "dream"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Consolidate memories from conversation"
     }
 
@@ -150,7 +153,7 @@ impl ShellCommand for DreamCommand {
         if let Some((handle, _)) = loaded_models.first() {
             let dreamer = Dreamer::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.chronos.vortex().clone(),
                 *handle,
             );
 
@@ -160,7 +163,10 @@ impl ShellCommand for DreamCommand {
                     if ids.is_empty() {
                         println!("No new memories formed.");
                     } else {
-                        println!("✨ Consolidated {} new memories into long-term storage.", ids.len());
+                        println!(
+                            "✨ Consolidated {} new memories into long-term storage.",
+                            ids.len()
+                        );
                     }
                 }
                 Err(e) => println!("Nightmare encountered: {e}"),
@@ -208,7 +214,7 @@ impl ShellCommand for FixCommand {
         let screwdriver = SonicScrewdriver::new(
             context.telemetry.clone(),
             Some(Arc::clone(&context.gallifrey)),
-            Some(context.chronos.vortex()),
+            Some(context.chronos.vortex().clone()),
             model_handle,
         );
 
@@ -418,7 +424,7 @@ impl ShellCommand for BiographerCommand {
 
         let biographer = Biographer::new(
             Arc::clone(&context.gallifrey),
-            context.chronos.vortex(),
+            context.chronos.vortex().clone(),
             model_handle,
         );
 
@@ -463,7 +469,7 @@ impl ShellCommand for CuriosityCommand {
         if let Some((handle, _)) = loaded_models.first() {
             let curiosity = Curiosity::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.chronos.vortex().clone(),
                 *handle,
             );
 
@@ -563,11 +569,11 @@ pub struct WeaveCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for WeaveCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "weave"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Generate a narrative connection between two entities"
     }
 
@@ -584,7 +590,7 @@ impl ShellCommand for WeaveCommand {
         if let Some((handle, _)) = loaded_models.first() {
             let weaver = Weaver::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.chronos.vortex().clone(),
                 *handle,
             );
 
@@ -595,6 +601,68 @@ impl ShellCommand for WeaveCommand {
             }
         } else {
             println!("The Weaver needs a loaded model. Use 'models load <path>'.");
+        }
+        Ok(CommandResult::Continue)
+    }
+}
+
+/// Medium command.
+///
+/// Summon the system state from the past.
+///
+/// # Usage
+///
+/// ```text
+/// medium <time> <query>
+/// ```
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct MediumCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for MediumCommand {
+    fn name(&self) -> &'static str {
+        "medium"
+    }
+
+    fn description(&self) -> &'static str {
+        "Summon system state from the past"
+    }
+
+    async fn execute(&self, args: &[String], context: &CommandContext) -> Result<CommandResult> {
+        if args.len() < 2 {
+            println!("Usage: medium <time> <query>");
+            println!("Example: medium 2023-10-27T12:00:00Z \"Who was the active user?\"");
+            return Ok(CommandResult::Continue);
+        }
+
+        let time_str = &args[0];
+        let query = args[1..].join(" ");
+
+        let time = match chrono::DateTime::parse_from_rfc3339(time_str) {
+            Ok(t) => t.with_timezone(&chrono::Utc),
+            Err(e) => {
+                println!("Invalid time format: {e}. Use ISO 8601 (e.g., 2023-10-27T12:00:00Z)");
+                return Ok(CommandResult::Continue);
+            }
+        };
+
+        let loaded_models = context.chronos.vortex().list_loaded_models();
+        if let Some((handle, _)) = loaded_models.first() {
+            let medium = Medium::new(
+                Arc::clone(&context.gallifrey),
+                context.chronos.vortex().clone(),
+                *handle,
+            );
+
+            println!("🕯️ Summoning the past at {time}...");
+            match medium.summon(&query, time).await {
+                Ok(response) => println!("\n👻 The Spirit answers:\n\n{response}\n"),
+                Err(e) => println!("The connection was severed: {e}"),
+            }
+        } else {
+            println!("The Medium needs a loaded model. Use 'models load <path>'.");
         }
         Ok(CommandResult::Continue)
     }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -119,6 +119,7 @@ impl Repl {
             registry.register(Box::new(commands::experimental::CapsuleCommand));
             registry.register(Box::new(commands::experimental::DreamCommand));
             registry.register(Box::new(commands::experimental::WeaveCommand));
+            registry.register(Box::new(commands::experimental::MediumCommand));
         }
     }
 
@@ -206,9 +207,9 @@ impl Repl {
                 }
                 #[cfg(feature = "nova")]
                 Ok(CommandResult::SetPersona(persona)) => {
-                    self.persona = persona.clone();
+                    self.persona.clone_from(&persona);
                     if let Some(p) = persona {
-                        println!("System persona set to: {}", p);
+                        println!("System persona set to: {p}");
                     } else {
                         println!("System persona reset to default.");
                     }
@@ -237,7 +238,7 @@ impl Repl {
 
         #[cfg(feature = "nova")]
         {
-            config.persona = self.persona.clone();
+            config.persona.clone_from(&self.persona);
         }
 
         match self.chronos.query(query, config).await {

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -188,10 +188,7 @@ mod tests {
     use super::*;
 
     fn test_router() -> Router {
-        Router::new(vec![
-            "help".to_string(),
-            "history".to_string(),
-        ])
+        Router::new(vec!["help".to_string(), "history".to_string()])
     }
 
     #[test]

--- a/vortex/src/services.rs
+++ b/vortex/src/services.rs
@@ -1,12 +1,13 @@
 //! Service implementations for Vortex.
 
 use crate::Vortex;
+use async_trait::async_trait;
+use std::any::Any;
+use std::sync::Arc;
 use tardis_common::id::ModelHandle;
 use tardis_common::llm::InferenceParams;
 use tardis_common::traits::LlmService;
 use tardis_common::Result;
-use async_trait::async_trait;
-use std::sync::Arc;
 
 /// A wrapper around Vortex that binds it to a specific model.
 ///
@@ -24,6 +25,12 @@ impl VortexLlmService {
     pub fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
         Self { engine, model }
     }
+
+    /// Get the underlying Vortex engine.
+    #[must_use]
+    pub const fn engine(&self) -> &Arc<Vortex> {
+        &self.engine
+    }
 }
 
 #[async_trait]
@@ -40,5 +47,9 @@ impl LlmService for VortexLlmService {
             .embed(self.model, text)
             .await
             .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }


### PR DESCRIPTION
This PR implements the "Medium" experimental feature, allowing users to query the system state at a specific point in the past. It also addresses several compilation issues in the `shell` crate related to experimental commands.

Key changes:
1.  **Core Trait Update**: `LlmService` now supports downcasting via `as_any()`.
2.  **Chronos Enhancement**: Added `vortex()` method to accessing the concrete LLM engine when the `nova` feature is enabled.
3.  **New Feature**: `Medium` scans historical entity versions in `Gallifrey` and uses `Vortex` to answer questions based on past context.
4.  **Shell Fixes**: Fixed broken experimental commands (`Sonic`, `Dreamer`, etc.) that were failing to compile due to type mismatches and lifetime errors.


---
*PR created automatically by Jules for task [15348843907935241629](https://jules.google.com/task/15348843907935241629) started by @madmax983*