### PR TITLE
🗺️ Atlas: Implement Bridge Pattern for Chronos Experimental Features

### DIFF
--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -8,13 +8,13 @@
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
 use tardis_gallifrey::domain::Entity;
-use tardis_gallifrey::Gallifrey;
+use tardis_gallifrey::KnowledgeStore;
 use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
 
 /// The Weaver engine.
 #[derive(Debug)]
 pub struct Weaver {
-    gallifrey: Arc<Gallifrey>,
+    knowledge: Arc<KnowledgeStore>,
     vortex: Arc<Vortex>,
     model: ModelHandle,
 }
@@ -22,9 +22,9 @@ pub struct Weaver {
 impl Weaver {
     /// Create a new Weaver instance.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub fn new(knowledge: Arc<KnowledgeStore>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
-            gallifrey,
+            knowledge,
             vortex,
             model,
         }
@@ -69,7 +69,7 @@ The connection is: [/INST]",
     }
 
     fn find_entity(&self, name: &str) -> Result<Entity> {
-        let knowledge = self.gallifrey.knowledge();
+        let knowledge = &self.knowledge;
         let mut found = None;
 
         // Scan all entities to find the one with the matching name (case-insensitive)

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -196,6 +196,27 @@ impl Chronos {
         })
     }
 
+    /// Get the experimental Weaver engine.
+    ///
+    /// This requires the `nova` feature and concrete implementations of `VortexLlmService`
+    /// and `KnowledgeStore` to be active.
+    #[cfg(feature = "nova")]
+    #[must_use]
+    pub fn weaver(&self) -> Option<crate::experimental::weaver::Weaver> {
+        // Downcast LlmService to VortexLlmService
+        let llm = self.llm.as_any().downcast_ref::<tardis_vortex::VortexLlmService>()?;
+
+        // Downcast KnowledgeService to Arc<KnowledgeStore>
+        // Note: We need Arc<KnowledgeStore> because Weaver needs to own it (or share ownership)
+        let knowledge = self.knowledge.clone().as_any_arc().downcast::<tardis_gallifrey::KnowledgeStore>().ok()?;
+
+        Some(crate::experimental::weaver::Weaver::new(
+            knowledge,
+            llm.engine(),
+            llm.model(),
+        ))
+    }
+
     /// Store a memory.
     #[allow(clippy::unused_async)]
     pub async fn remember(

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -10,6 +10,8 @@ use crate::id::{EntityId, SessionId};
 use crate::Result;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::any::Any;
+use std::sync::Arc;
 use chrono::{DateTime, Utc};
 
 /// Interface for LLM inference services.
@@ -20,6 +22,12 @@ pub trait LlmService: Send + Sync + Debug {
 
     /// Generate embeddings for text.
     async fn embed(&self, text: &str) -> Result<Vec<f32>>;
+
+    /// Upcast to Any for downcasting to concrete type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Upcast Arc to Any for downcasting to concrete Arc type.
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 }
 
 /// Interface for knowledge graph storage.
@@ -39,6 +47,12 @@ pub trait KnowledgeService: Send + Sync + Debug {
 
     /// Find entities by semantic similarity.
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>>;
+
+    /// Upcast to Any for downcasting to concrete type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Upcast Arc to Any for downcasting to concrete Arc type.
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 }
 
 /// Interface for conversation history storage.
@@ -61,6 +75,12 @@ pub trait ConversationService: Send + Sync + Debug {
 
     /// Search messages by semantic similarity.
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>>;
+
+    /// Upcast to Any for downcasting to concrete type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Upcast Arc to Any for downcasting to concrete Arc type.
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 }
 
 /// Interface for system state storage.
@@ -71,4 +91,10 @@ pub trait SystemStateService: Send + Sync + Debug {
 
     /// Record a system change.
     async fn record_change(&self, change: Change) -> Result<()>;
+
+    /// Upcast to Any for downcasting to concrete type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Upcast Arc to Any for downcasting to concrete Arc type.
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 }

--- a/gallifrey/src/services.rs
+++ b/gallifrey/src/services.rs
@@ -8,6 +8,8 @@ use tardis_common::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
+use std::any::Any;
+use std::sync::Arc;
 
 #[async_trait]
 impl KnowledgeService for KnowledgeStore {
@@ -29,6 +31,14 @@ impl KnowledgeService for KnowledgeStore {
 
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>> {
         self.semantic_search(embedding, limit).map_err(tardis_common::Error::from)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
     }
 }
 
@@ -57,6 +67,14 @@ impl ConversationService for ConversationStore {
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>> {
         self.semantic_search(embedding, limit).map_err(tardis_common::Error::from)
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
+    }
 }
 
 #[async_trait]
@@ -67,5 +85,13 @@ impl SystemStateService for SystemStateStore {
 
     async fn record_change(&self, change: Change) -> Result<()> {
         self.record_change(change).map_err(tardis_common::Error::from)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
     }
 }

--- a/vortex/src/services.rs
+++ b/vortex/src/services.rs
@@ -7,6 +7,7 @@ use tardis_common::traits::LlmService;
 use tardis_common::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
+use std::any::Any;
 
 /// A wrapper around Vortex that binds it to a specific model.
 ///
@@ -24,6 +25,18 @@ impl VortexLlmService {
     pub fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
         Self { engine, model }
     }
+
+    /// Get the underlying Vortex engine.
+    #[must_use]
+    pub fn engine(&self) -> Arc<Vortex> {
+        Arc::clone(&self.engine)
+    }
+
+    /// Get the model handle.
+    #[must_use]
+    pub fn model(&self) -> ModelHandle {
+        self.model
+    }
 }
 
 #[async_trait]
@@ -40,5 +53,13 @@ impl LlmService for VortexLlmService {
             .embed(self.model, text)
             .await
             .map_err(|e| tardis_common::Error::Internal(e.to_string()))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
     }
 }


### PR DESCRIPTION
This PR implements the Bridge pattern to decouple the core `Chronos` engine from concrete implementations required by experimental features like `Weaver`.

**Changes:**
1.  **`tardis-common`**: Added `as_any` and `as_any_arc` methods to `LlmService`, `KnowledgeService`, `ConversationService`, and `SystemStateService` traits. This enables safe downcasting of trait objects.
2.  **`tardis-vortex`**: Implemented `as_any` and `as_any_arc` for `VortexLlmService`. Added public accessors `engine()` and `model()` to expose the underlying `Vortex` engine and model handle for experimental use.
3.  **`tardis-gallifrey`**: Implemented `as_any` and `as_any_arc` for `KnowledgeStore`, `ConversationStore`, and `SystemStateStore`.
4.  **`tardis-chronos`**:
    *   Refactored `Weaver` to accept `Arc<KnowledgeStore>` instead of `Arc<Gallifrey>`, reducing coupling.
    *   Added a `weaver()` method to `Chronos` (gated by `nova` feature) that safely downcasts the internal service trait objects to their concrete counterparts (`VortexLlmService`, `KnowledgeStore`) to instantiate the `Weaver`.

**Verification:**
*   `cargo check --workspace` passed.
*   `cargo test` passed across the workspace.
*   Verified that `Chronos` can now instantiate `Weaver` without hard dependencies in its core structure.

---
*PR created automatically by Jules for task [10142253332169706059](https://jules.google.com/task/10142253332169706059) started by @madmax983*