### PR TITLE
feat(chronos): Implement The Medium - Entity Channeling

### DIFF
--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -79,12 +79,13 @@ impl Dreamer {
         // 2. Construct prompt
         let mut transcript = String::new();
         for msg in &messages {
-            transcript.push_str(&format!("{:?}: {}\n", msg.role, msg.content));
+            use std::fmt::Write;
+            let _ = writeln!(transcript, "{:?}: {}", msg.role, msg.content);
         }
 
         let prompt = format!(
             "CONVERSATION TRANSCRIPT:\n\
-             {}\n\n\
+             {transcript}\n\n\
              TASK: Extract key facts, user preferences, and important entities from the above conversation.\n\
              Ignore trivial greetings. Focus on long-term knowledge.\n\
              Output a JSON list of objects. Each object must have:\n\
@@ -94,8 +95,7 @@ impl Dreamer {
              - \"properties\": (object) Key-value pairs of details.\n\
              Example:\n\
              [\n  {{ \"name\": \"User\", \"type\": \"Person\", \"description\": \"The user likes blue.\", \"properties\": {{ \"favorite_color\": \"blue\" }} }}\n]\n\
-             Output ONLY JSON.",
-            transcript
+             Output ONLY JSON."
         );
 
         // 3. Inference
@@ -142,7 +142,7 @@ impl Dreamer {
                 .gallifrey
                 .insert(entity)
                 .await
-                .map_err(|e| ChronosError::Common(e.into()))?;
+                .map_err(ChronosError::Common)?;
 
             created_ids.push(id);
         }

--- a/chronos/src/experimental/medium.rs
+++ b/chronos/src/experimental/medium.rs
@@ -1,0 +1,271 @@
+//! The Medium 🔮
+//!
+//! "I see dead people... well, deprecated entities."
+//!
+//! A module that allows you to "channel" a past version of an entity, interacting with it
+//! as if it were a chatbot. It reconstructs the entity's state at a specific point in time
+//! and uses the LLM to roleplay as that entity.
+
+use crate::error::{ChronosError, ChronosResult};
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+use tardis_common::id::EntityId;
+use tardis_common::Error;
+use tardis_gallifrey::domain::Entity;
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+
+/// The Medium engine.
+#[derive(Debug)]
+pub struct Medium {
+    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<Vortex>,
+    model: ModelHandle,
+}
+
+/// A session with a summoned entity.
+#[derive(Debug)]
+pub struct MediumSession {
+    /// The summoned entity snapshot.
+    pub entity: Entity,
+    /// The time at which it was summoned.
+    pub time: DateTime<Utc>,
+    /// The LLM engine.
+    vortex: Arc<Vortex>,
+    /// The model handle.
+    model: ModelHandle,
+    /// Conversation history for this session (User, AI).
+    history: Vec<(String, String)>,
+}
+
+impl Medium {
+    /// Create a new Medium instance.
+    #[must_use]
+    pub const fn new(
+        gallifrey: Arc<Gallifrey>,
+        vortex: Arc<Vortex>,
+        model: ModelHandle,
+    ) -> Self {
+        Self {
+            gallifrey,
+            vortex,
+            model,
+        }
+    }
+
+    /// Summon an entity from the past.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entity cannot be found at the specified time.
+    pub fn summon(
+        &self,
+        entity_name: &str,
+        time: DateTime<Utc>,
+    ) -> ChronosResult<MediumSession> {
+        // 1. Find the entity ID
+        let id = self.find_entity_id_at(entity_name, time)?;
+
+        // 2. Retrieve the entity state at that time
+        // We want: Valid at `time` AND Known at `time` (Transaction Time).
+        // This simulates "what we knew then".
+        let entity = self
+            .gallifrey
+            .knowledge()
+            .get_entity_at(id, time, time)
+            .map_err(|e| ChronosError::Common(e.into()))?
+            .ok_or_else(|| {
+                ChronosError::Common(Error::EntityNotFound(format!(
+                    "Entity '{entity_name}' existed but has no valid state at {time}"
+                )))
+            })?;
+
+        Ok(MediumSession {
+            entity,
+            time,
+            vortex: self.vortex.clone(),
+            model: self.model,
+            history: Vec::new(),
+        })
+    }
+
+    fn find_entity_id_at(&self, name: &str, time: DateTime<Utc>) -> ChronosResult<EntityId> {
+        let knowledge = self.gallifrey.knowledge();
+        let mut found_id = None;
+
+        // Scan history to find an entity that had this name at the given time.
+        knowledge
+            .scan_history(|history| {
+                if found_id.is_some() {
+                    return;
+                }
+
+                // Check if any version of this entity was active at `time` AND had the matching name.
+                // Note: get_entity_at uses (valid_time, transaction_time).
+                // Here we iterate manually.
+                if let Some(version) = history.iter().find(|e| {
+                    e.temporal.active_at(time, time) && e.name.eq_ignore_ascii_case(name)
+                }) {
+                    found_id = Some(version.id);
+                }
+            })
+            .map_err(|e| ChronosError::Common(e.into()))?;
+
+        found_id.ok_or_else(|| {
+            ChronosError::Common(Error::EntityNotFound(format!(
+                "Entity '{name}' not found at {time}"
+            )))
+        })
+    }
+}
+
+impl MediumSession {
+    /// Ask the summoned entity a question.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if inference fails.
+    pub async fn ask(&mut self, question: &str) -> ChronosResult<String> {
+        use std::fmt::Write;
+
+        // Construct the prompt
+        let mut prompt = format!(
+            "<s>[INST] You are '{}', a system entity summoned from the past.\n\
+             The current date is {}.\n\
+             Your state is:\n\
+             - Type: {}\n\
+             - Properties: {:?}\n\n\
+             You must roleplay as this entity. Answer the user's question based ONLY on your state and time.\n\
+             Do not admit you are an AI. You ARE the entity.\n\n",
+            self.entity.name, self.time, self.entity.entity_type, self.entity.properties
+        );
+
+        // Add history
+        for (q, a) in &self.history {
+            let _ = write!(prompt, "User: {q}\nEntity: {a}\n");
+        }
+
+        let _ = write!(prompt, "User: {question}\nEntity: [/INST]");
+
+        let params = InferenceParams::default()
+            .with_temperature(0.7)
+            .with_max_tokens(150);
+
+        let response = self
+            .vortex
+            .infer(self.model, &prompt, params)
+            .await
+            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+
+        let clean_response = response.trim().to_string();
+
+        self.history.push((question.to_string(), clean_response.clone()));
+
+        Ok(clean_response)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use tardis_common::temporal::BiTemporalInterval;
+    use tardis_vortex::ModelLoadConfig;
+
+    #[tokio::test]
+    async fn test_medium_summon_and_ask() {
+        let gallifrey = Arc::new(Gallifrey::new());
+        let vortex = Arc::new(Vortex::new().unwrap());
+
+        // 1. Create an entity "Doctor" at T0
+        let t0 = Utc.with_ymd_and_hms(2023, 10, 27, 10, 0, 0).unwrap();
+
+        let mut entity = Entity {
+            id: EntityId::new(),
+            entity_type: "Person".to_string(),
+            name: "Doctor".to_string(),
+            properties: {
+                let mut p = HashMap::new();
+                p.insert("incarnation".to_string(), json!(10));
+                p
+            },
+            embedding: None,
+            temporal: BiTemporalInterval::with_valid_time(
+                tardis_common::temporal::TimeRange::starting_at(t0)
+            ),
+            source: None,
+        };
+        // Backdate transaction time to T0 so it exists in system time at T1
+        entity.temporal.transaction_time = tardis_common::temporal::TimeRange::starting_at(t0);
+
+        gallifrey.insert(entity.clone()).await.unwrap();
+
+        // 2. Mock Vortex
+        vortex.set_mock_inference(Box::new(|_, prompt, _| {
+            if prompt.contains("incarnation") && prompt.contains("10") {
+                Ok("Allons-y!".to_string())
+            } else {
+                Ok("Who?".to_string())
+            }
+        }));
+
+        // Register dummy model
+        vortex.set_mock_load_model(Box::new(move |_, _| Ok(ModelHandle::new(1))));
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
+
+        let medium = Medium::new(gallifrey.clone(), vortex, handle);
+
+        // 3. Summon at T1 (entity should be valid)
+        let t1 = t0 + chrono::Duration::hours(1);
+        let mut session = medium.summon("Doctor", t1).unwrap();
+
+        assert_eq!(session.entity.name, "Doctor");
+        assert_eq!(session.entity.properties.get("incarnation"), Some(&json!(10)));
+
+        // 4. Ask
+        let response = session.ask("Ready?").await.unwrap();
+        assert_eq!(response, "Allons-y!");
+    }
+
+    #[tokio::test]
+    async fn test_medium_summon_fails_before_creation() {
+        let gallifrey = Arc::new(Gallifrey::new());
+        let vortex = Arc::new(Vortex::new().unwrap());
+
+        let t0 = Utc.with_ymd_and_hms(2023, 10, 27, 10, 0, 0).unwrap();
+
+        let entity = Entity {
+            id: EntityId::new(),
+            entity_type: "Person".to_string(),
+            name: "Companion".to_string(),
+            properties: HashMap::new(),
+            embedding: None,
+            temporal: BiTemporalInterval::with_valid_time(
+                tardis_common::temporal::TimeRange::starting_at(t0)
+            ),
+            source: None,
+        };
+        gallifrey.insert(entity).await.unwrap();
+
+        // Register dummy model
+        vortex.set_mock_load_model(Box::new(move |_, _| Ok(ModelHandle::new(1))));
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
+
+        let medium = Medium::new(gallifrey.clone(), vortex, handle);
+
+        // Try to summon before T0
+        let t_before = t0 - chrono::Duration::hours(1);
+        let result = medium.summon("Companion", t_before);
+
+        assert!(result.is_err());
+    }
+}

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -22,3 +22,6 @@ pub mod dreamer;
 
 #[cfg(feature = "nova")]
 pub mod weaver;
+
+#[cfg(feature = "nova")]
+pub mod medium;

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -22,7 +22,7 @@ pub struct Weaver {
 impl Weaver {
     /// Create a new Weaver instance.
     #[must_use]
-    pub fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -41,6 +41,10 @@ pub use retriever::retrieve;
 use crate::error::{ChronosError, ChronosResult};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+#[cfg(feature = "nova")]
+use tardis_vortex::VortexLlmService;
+#[cfg(feature = "nova")]
+use tardis_vortex::Vortex;
 use tardis_common::domain::Entity;
 use tardis_common::id::{EntityId, SessionId};
 use tardis_common::traits::{LlmService, KnowledgeService, ConversationService, SystemStateService};
@@ -159,7 +163,30 @@ impl Chronos {
         }
     }
 
+    /// Get the Vortex engine.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying LLM service is not a `VortexLlmService`.
+    #[cfg(feature = "nova")]
+    #[must_use]
+    #[allow(clippy::expect_used)]
+    pub fn vortex(&self) -> Arc<Vortex> {
+        self.llm
+            .as_any()
+            .downcast_ref::<VortexLlmService>()
+            .expect("LlmService is not VortexLlmService")
+            .engine()
+    }
+
     /// Execute a RAG query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Query analysis fails.
+    /// - Context retrieval fails.
+    /// - LLM inference fails.
     #[instrument(skip(self, config))]
     pub async fn query(&self, prompt: &str, config: RagConfig) -> ChronosResult<RagResponse> {
         info!("Processing RAG query");
@@ -197,6 +224,10 @@ impl Chronos {
     }
 
     /// Store a memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the memory cannot be stored in Gallifrey.
     #[allow(clippy::unused_async)]
     pub async fn remember(
         &self,
@@ -233,6 +264,10 @@ impl Chronos {
     }
 
     /// Recall memories matching a query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the semantic search fails.
     #[allow(clippy::unused_async)]
     pub async fn recall(&self, query: &str, limit: usize) -> ChronosResult<Vec<ContextSource>> {
         info!("Recalling memories for: {}", &query[..query.len().min(50)]);

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -10,11 +10,15 @@ use crate::id::{EntityId, SessionId};
 use crate::Result;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::any::Any;
 use chrono::{DateTime, Utc};
 
 /// Interface for LLM inference services.
 #[async_trait]
 pub trait LlmService: Send + Sync + Debug {
+    /// As Any.
+    fn as_any(&self) -> &dyn Any;
+
     /// Generate text based on a prompt.
     async fn infer(&self, prompt: &str, params: InferenceParams) -> Result<String>;
 

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -25,6 +25,8 @@ use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::dreamer::Dreamer;
 #[cfg(feature = "nova")]
+use tardis_chronos::experimental::medium::Medium;
+#[cfg(feature = "nova")]
 use tardis_chronos::experimental::weaver::Weaver;
 #[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
@@ -37,11 +39,11 @@ pub struct ChameleonCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for ChameleonCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "chameleon"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Set the system persona"
     }
 
@@ -129,6 +131,100 @@ impl ShellCommand for SonicCommand {
     }
 }
 
+/// Medium command.
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct MediumCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for MediumCommand {
+    fn name(&self) -> &'static str {
+        "medium"
+    }
+
+    fn description(&self) -> &'static str {
+        "Channel a past version of an entity"
+    }
+
+    async fn execute(&self, args: &[String], context: &CommandContext) -> Result<CommandResult> {
+        if args.len() < 2 {
+            println!("Usage: medium <entity> <timestamp>");
+            println!("Example: medium Doctor 2023-10-27T10:00:00Z");
+            return Ok(CommandResult::Continue);
+        }
+
+        let entity_name = &args[0];
+        let time_str = &args[1];
+
+        // Parse time (basic RFC3339 for now)
+        let time = match chrono::DateTime::parse_from_rfc3339(time_str) {
+            Ok(dt) => dt.with_timezone(&chrono::Utc),
+            Err(e) => {
+                println!("Invalid time format: {e}. Use RFC3339 (e.g., 2023-10-27T10:00:00Z)");
+                return Ok(CommandResult::Continue);
+            }
+        };
+
+        let loaded_models = context.chronos.vortex().list_loaded_models();
+        if let Some((handle, _)) = loaded_models.first() {
+            let medium = Medium::new(
+                Arc::clone(&context.gallifrey),
+                context.chronos.vortex(),
+                *handle,
+            );
+
+            println!("🔮 Summoning '{entity_name}' from {time}...");
+
+            match medium.summon(entity_name, time) {
+                Ok(mut session) => {
+                    println!("\n[Entity Summoned. Type 'exit' to break the connection.]\n");
+
+                    // Initial greeting (optional, or just wait for user)
+                    // Let's print the entity status found
+                    println!("Entity: {} ({})", session.entity.name, session.entity.entity_type);
+                    println!("State at time: {:?}", session.entity.properties);
+                    println!();
+
+                    // Interaction loop
+                    // Note: We use std::io directly. This effectively pauses the main REPL.
+                    let stdin = std::io::stdin();
+                    let mut input = String::new();
+
+                    loop {
+                        use std::io::Write;
+                        print!("medium> ");
+                        std::io::stdout().flush()?;
+
+                        input.clear();
+                        if stdin.read_line(&mut input).is_err() {
+                            break;
+                        }
+
+                        let query = input.trim();
+                        if query.eq_ignore_ascii_case("exit") || query.eq_ignore_ascii_case("quit") {
+                            break;
+                        }
+                        if query.is_empty() {
+                            continue;
+                        }
+
+                        match session.ask(query).await {
+                            Ok(response) => println!("\n{response}\n"),
+                            Err(e) => println!("The connection wavers: {e}"),
+                        }
+                    }
+                    println!("🔮 Connection broken.");
+                }
+                Err(e) => println!("Failed to summon entity: {e}"),
+            }
+        } else {
+            println!("The Medium needs a loaded model. Use 'models load <path>'.");
+        }
+        Ok(CommandResult::Continue)
+    }
+}
+
 /// Dreamer command.
 #[cfg(feature = "nova")]
 #[derive(Debug)]
@@ -137,11 +233,11 @@ pub struct DreamCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for DreamCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "dream"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Consolidate memories from conversation"
     }
 
@@ -563,11 +659,11 @@ pub struct WeaveCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for WeaveCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "weave"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Generate a narrative connection between two entities"
     }
 

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -119,6 +119,7 @@ impl Repl {
             registry.register(Box::new(commands::experimental::CapsuleCommand));
             registry.register(Box::new(commands::experimental::DreamCommand));
             registry.register(Box::new(commands::experimental::WeaveCommand));
+            registry.register(Box::new(commands::experimental::MediumCommand));
         }
     }
 
@@ -206,9 +207,9 @@ impl Repl {
                 }
                 #[cfg(feature = "nova")]
                 Ok(CommandResult::SetPersona(persona)) => {
-                    self.persona = persona.clone();
+                    self.persona.clone_from(&persona);
                     if let Some(p) = persona {
-                        println!("System persona set to: {}", p);
+                        println!("System persona set to: {p}");
                     } else {
                         println!("System persona reset to default.");
                     }
@@ -237,7 +238,7 @@ impl Repl {
 
         #[cfg(feature = "nova")]
         {
-            config.persona = self.persona.clone();
+            config.persona.clone_from(&self.persona);
         }
 
         match self.chronos.query(query, config).await {

--- a/vortex/src/services.rs
+++ b/vortex/src/services.rs
@@ -7,6 +7,7 @@ use tardis_common::traits::LlmService;
 use tardis_common::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
+use std::any::Any;
 
 /// A wrapper around Vortex that binds it to a specific model.
 ///
@@ -21,13 +22,29 @@ pub struct VortexLlmService {
 impl VortexLlmService {
     /// Create a new service adapter.
     #[must_use]
-    pub fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
         Self { engine, model }
+    }
+
+    /// Get the underlying Vortex engine.
+    #[must_use]
+    pub fn engine(&self) -> Arc<Vortex> {
+        self.engine.clone()
+    }
+
+    /// Get the model handle.
+    #[must_use]
+    pub const fn model(&self) -> ModelHandle {
+        self.model
     }
 }
 
 #[async_trait]
 impl LlmService for VortexLlmService {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn infer(&self, prompt: &str, params: InferenceParams) -> Result<String> {
         self.engine
             .infer(self.model, prompt, params)


### PR DESCRIPTION
Implement The Medium - Entity Channeling

Introduces "The Medium", a new experimental feature that allows users to communicate with past versions of system entities.

Changes:
- Added `Medium` module in `chronos/src/experimental/medium.rs` to reconstruct entity state at a specific time and generate persona-based prompts.
- Added `MediumCommand` in `shell` to expose the feature via `medium <entity> <time>` command.
- Refactored `LlmService` trait in `common` to support downcasting (`as_any`).
- Enhanced `Chronos` pipeline to expose the underlying `Vortex` engine (gated by `nova` feature).
- Fixed various clippy warnings in `shell` and `chronos` experimental modules.

This feature enables debugging and forensic analysis by "talking" to the system's past state.

---
*PR created automatically by Jules for task [1195801472763129429](https://jules.google.com/task/1195801472763129429) started by @madmax983*