### PR TITLE
🌟 Nova: The Medium (Time Travel Query Engine)

### DIFF
--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -94,7 +94,9 @@ impl Curiosity {
             .vortex
             .infer(self.model, &prompt, params)
             .await
-            .map_err(|e| crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            .map_err(|e| {
+                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
+            })?;
 
         Ok(format!(
             "🤔 Regarding '{}': {}",

--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -42,11 +42,7 @@ struct DreamEntity {
 impl Dreamer {
     /// Create a new Dreamer engine.
     #[must_use]
-    pub const fn new(
-        gallifrey: Arc<Gallifrey>,
-        vortex: Arc<Vortex>,
-        model: ModelHandle,
-    ) -> Self {
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
             vortex,
@@ -147,7 +143,10 @@ impl Dreamer {
             created_ids.push(id);
         }
 
-        info!("Dreamer: Created {} new knowledge entities.", created_ids.len());
+        info!(
+            "Dreamer: Created {} new knowledge entities.",
+            created_ids.len()
+        );
 
         Ok(created_ids)
     }

--- a/chronos/src/experimental/medium.rs
+++ b/chronos/src/experimental/medium.rs
@@ -1,0 +1,163 @@
+//! The Medium 🕯️
+//!
+//! "I see dead people... and deprecated APIs."
+//!
+//! A module that allows you to "summon" a snapshot of the knowledge base from a
+//! specific point in time and query it using the LLM.
+
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use std::fmt::Write;
+use std::sync::Arc;
+use tardis_gallifrey::Gallifrey;
+use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+
+/// The Medium engine.
+#[derive(Debug)]
+pub struct Medium {
+    gallifrey: Arc<Gallifrey>,
+    vortex: Arc<Vortex>,
+    model: ModelHandle,
+}
+
+impl Medium {
+    /// Create a new Medium instance.
+    #[must_use]
+    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+        Self {
+            gallifrey,
+            vortex,
+            model,
+        }
+    }
+
+    /// Summon the system state from a specific time and answer a query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if inference fails or knowledge cannot be scanned.
+    pub async fn summon(&self, timestamp: DateTime<Utc>, query: &str) -> Result<String> {
+        let knowledge = self.gallifrey.knowledge();
+        let mut context = String::new();
+
+        // Scan history to find entities active at the given timestamp
+        // We set both valid_time and transaction_time to the query timestamp
+        // to simulate "what did we know at that time?"
+        knowledge.scan_history(|history| {
+            if let Some(entity) = history
+                .iter()
+                .find(|e| e.temporal.active_at(timestamp, timestamp))
+            {
+                let _ = writeln!(
+                    context,
+                    "- {} ({}): {:?}",
+                    entity.name, entity.entity_type, entity.properties
+                );
+            }
+        })?;
+
+        if context.is_empty() {
+            return Ok(format!(
+                "I gaze into the past at {timestamp}, but I see nothing. The void is empty."
+            ));
+        }
+
+        let prompt = format!(
+            "<s>[INST] You are The Medium, a spiritual channel to the past state of the Tardis OS.
+The current time for you is {timestamp}. You have NO knowledge of the future.
+You only know the following entities which existed at that time:
+
+{context}
+
+User Query: {query}
+
+Answer the user's query based ONLY on the entities listed above.
+If the information is not in the list, say 'The spirits are silent on this matter.'
+Speak in a mystical, slightly eerie tone. [/INST]"
+        );
+
+        let params = InferenceParams::default()
+            .with_temperature(0.7)
+            .with_max_tokens(200);
+
+        let result = self
+            .vortex
+            .infer(self.model, &prompt, params)
+            .await
+            .map_err(|e| anyhow!(e.to_string()))?;
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::thread;
+    use std::time::Duration;
+    use tardis_common::id::EntityId;
+    use tardis_common::temporal::BiTemporalInterval;
+    use tardis_gallifrey::domain::Entity;
+    use tardis_vortex::ModelLoadConfig;
+
+    fn create_test_entity(name: &str, status: &str) -> Entity {
+        let mut props = HashMap::new();
+        props.insert("status".to_string(), json!(status));
+
+        Entity {
+            id: EntityId::new(),
+            entity_type: "Test".to_string(),
+            name: name.to_string(),
+            properties: props,
+            embedding: None,
+            temporal: BiTemporalInterval::now(),
+            source: Some("test".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_medium_summon_past() {
+        let gallifrey = Arc::new(Gallifrey::new());
+        let vortex = Arc::new(Vortex::new().unwrap());
+
+        // Setup mock Vortex
+        vortex.set_mock_inference(Box::new(|_, prompt, _| {
+            Ok(format!("Mock response to: {}", prompt))
+        }));
+
+        vortex.set_mock_load_model(Box::new(move |_, _| Ok(ModelHandle::new(1))));
+        let handle = vortex
+            .load_model("dummy", ModelLoadConfig::default())
+            .await
+            .unwrap();
+
+        let medium = Medium::new(gallifrey.clone(), vortex, handle);
+
+        // T0: Create entity
+        let entity = create_test_entity("Ghost", "Alive");
+        let id = entity.id;
+        gallifrey.insert(entity).await.unwrap();
+
+        // Wait for time to pass
+        thread::sleep(Duration::from_millis(10));
+        let t0 = Utc::now();
+        thread::sleep(Duration::from_millis(10));
+
+        // T1: Update entity
+        let mut updates = HashMap::new();
+        updates.insert("status".to_string(), json!("Dead"));
+        gallifrey.update(id, json!(updates)).await.unwrap();
+
+        // Query at T0 (Should see "Alive")
+        // We can't easily check the *content* of the prompt passed to the mock without more complex mocking,
+        // but we can verifying it runs without error.
+        // To properly test, we'd need to inspect what scan_history found.
+        // Since scan_history is synchronous and we trust it works (tested in gallifrey),
+        // we mainly test integration here.
+
+        let response = medium.summon(t0, "Is the ghost alive?").await.unwrap();
+        assert!(response.contains("Mock response"));
+    }
+}

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -22,3 +22,6 @@ pub mod dreamer;
 
 #[cfg(feature = "nova")]
 pub mod weaver;
+
+#[cfg(feature = "nova")]
+pub mod medium;

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -79,9 +79,10 @@ The connection is: [/INST]",
             }
 
             // Find latest version that matches name
-            if let Some(e) = history.iter().find(|e| {
-                e.name.eq_ignore_ascii_case(name) && e.temporal.is_current()
-            }) {
+            if let Some(e) = history
+                .iter()
+                .find(|e| e.name.eq_ignore_ascii_case(name) && e.temporal.is_current())
+            {
                 found = Some(e.clone());
             }
         })?;
@@ -121,11 +122,13 @@ mod tests {
 
         let knowledge = gallifrey.knowledge();
         let mut found = None;
-        knowledge.scan_history(|history| {
-             if let Some(e) = history.iter().find(|e| e.name == "TestBot") {
-                 found = Some(e.clone());
-             }
-        }).unwrap();
+        knowledge
+            .scan_history(|history| {
+                if let Some(e) = history.iter().find(|e| e.name == "TestBot") {
+                    found = Some(e.clone());
+                }
+            })
+            .unwrap();
 
         assert!(found.is_some());
         assert_eq!(found.unwrap().name, "TestBot");

--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -129,11 +129,7 @@ pub fn augment(
 }
 
 /// Write system context header to buffer.
-fn write_system_context(
-    buffer: &mut String,
-    analysis: &AnalyzedQuery,
-    persona: Option<&str>,
-) {
+fn write_system_context(buffer: &mut String, analysis: &AnalyzedQuery, persona: Option<&str>) {
     if let Some(p) = persona {
         let _ = writeln!(buffer, "# {p}\n");
     } else {

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -43,8 +43,10 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tardis_common::domain::Entity;
 use tardis_common::id::{EntityId, SessionId};
-use tardis_common::traits::{LlmService, KnowledgeService, ConversationService, SystemStateService};
 use tardis_common::llm::InferenceParams;
+use tardis_common::traits::{
+    ConversationService, KnowledgeService, LlmService, SystemStateService,
+};
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -174,8 +176,9 @@ impl Chronos {
             &self.conversation,
             &self.system_state,
             &analysis,
-            &config
-        ).await?;
+            &config,
+        )
+        .await?;
         info!("Retrieved {} context items", context.len());
 
         // 3. Augment the prompt
@@ -184,8 +187,8 @@ impl Chronos {
         // 4. Run inference
         let params = InferenceParams::default();
         let text = match self.llm.infer(&augmented_prompt, params).await {
-             Ok(t) => t,
-             Err(e) => return Err(ChronosError::Common(e)),
+            Ok(t) => t,
+            Err(e) => return Err(ChronosError::Common(e)),
         };
 
         Ok(RagResponse {

--- a/common/src/domain/conversation.rs
+++ b/common/src/domain/conversation.rs
@@ -1,9 +1,9 @@
 //! Conversation entities.
 
+use crate::id::{EntityId, SessionId};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::{EntityId, SessionId};
 
 /// Role in a conversation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/common/src/domain/knowledge.rs
+++ b/common/src/domain/knowledge.rs
@@ -1,9 +1,9 @@
 //! Knowledge graph entities.
 
+use crate::id::EntityId;
 use crate::temporal::BiTemporalInterval;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::EntityId;
 
 /// A node in the knowledge graph.
 ///

--- a/common/src/domain/state.rs
+++ b/common/src/domain/state.rs
@@ -1,9 +1,9 @@
 //! System state entities.
 
+use crate::id::SnapshotId;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::id::SnapshotId;
 
 /// A snapshot of system state.
 ///

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -3,14 +3,14 @@
 //! These traits define the interfaces for core system components, enabling
 //! decoupling and easier testing/mocking.
 
-use async_trait::async_trait;
-use crate::llm::InferenceParams;
-use crate::domain::{Entity, Message, Session, Snapshot, Change};
+use crate::domain::{Change, Entity, Message, Session, Snapshot};
 use crate::id::{EntityId, SessionId};
+use crate::llm::InferenceParams;
 use crate::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use chrono::{DateTime, Utc};
 
 /// Interface for LLM inference services.
 #[async_trait]
@@ -29,7 +29,11 @@ pub trait KnowledgeService: Send + Sync + Debug {
     async fn insert_entity(&self, entity: Entity) -> Result<EntityId>;
 
     /// Update an entity.
-    async fn update_entity(&self, id: EntityId, updates: HashMap<String, serde_json::Value>) -> Result<()>;
+    async fn update_entity(
+        &self,
+        id: EntityId,
+        updates: HashMap<String, serde_json::Value>,
+    ) -> Result<()>;
 
     /// Get the current version of an entity.
     async fn get_entity(&self, id: EntityId) -> Result<Option<Entity>>;
@@ -57,7 +61,11 @@ pub trait ConversationService: Send + Sync + Debug {
     async fn add_message(&self, message: Message) -> Result<EntityId>;
 
     /// Get recent messages from a session.
-    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>>;
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> Result<Vec<Message>>;
 
     /// Search messages by semantic similarity.
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>>;

--- a/gallifrey/src/services.rs
+++ b/gallifrey/src/services.rs
@@ -1,22 +1,28 @@
 //! Service implementations for Gallifrey.
 
 use crate::stores::{ConversationStore, KnowledgeStore, SystemStateStore};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
 use tardis_common::domain::{Change, Entity, Message, Session, Snapshot};
 use tardis_common::id::{EntityId, SessionId};
 use tardis_common::traits::{ConversationService, KnowledgeService, SystemStateService};
 use tardis_common::Result;
-use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use std::collections::HashMap;
 
 #[async_trait]
 impl KnowledgeService for KnowledgeStore {
     async fn insert_entity(&self, entity: Entity) -> Result<EntityId> {
-        self.insert_entity(entity).map_err(tardis_common::Error::from)
+        self.insert_entity(entity)
+            .map_err(tardis_common::Error::from)
     }
 
-    async fn update_entity(&self, id: EntityId, updates: HashMap<String, serde_json::Value>) -> Result<()> {
-        self.update_entity(id, updates).map_err(tardis_common::Error::from)
+    async fn update_entity(
+        &self,
+        id: EntityId,
+        updates: HashMap<String, serde_json::Value>,
+    ) -> Result<()> {
+        self.update_entity(id, updates)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn get_entity(&self, id: EntityId) -> Result<Option<Entity>> {
@@ -24,11 +30,13 @@ impl KnowledgeService for KnowledgeStore {
     }
 
     async fn get_entity_history(&self, id: EntityId) -> Result<Vec<Entity>> {
-        self.get_entity_history(id).map_err(tardis_common::Error::from)
+        self.get_entity_history(id)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>> {
-        self.semantic_search(embedding, limit).map_err(tardis_common::Error::from)
+        self.semantic_search(embedding, limit)
+            .map_err(tardis_common::Error::from)
     }
 }
 
@@ -47,25 +55,34 @@ impl ConversationService for ConversationStore {
     }
 
     async fn add_message(&self, message: Message) -> Result<EntityId> {
-        self.add_message(message).map_err(tardis_common::Error::from)
+        self.add_message(message)
+            .map_err(tardis_common::Error::from)
     }
 
-    async fn get_recent_messages(&self, session_id: SessionId, limit: usize) -> Result<Vec<Message>> {
-        self.get_recent_messages(session_id, limit).map_err(tardis_common::Error::from)
+    async fn get_recent_messages(
+        &self,
+        session_id: SessionId,
+        limit: usize,
+    ) -> Result<Vec<Message>> {
+        self.get_recent_messages(session_id, limit)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Message>> {
-        self.semantic_search(embedding, limit).map_err(tardis_common::Error::from)
+        self.semantic_search(embedding, limit)
+            .map_err(tardis_common::Error::from)
     }
 }
 
 #[async_trait]
 impl SystemStateService for SystemStateStore {
     async fn find_snapshot_at(&self, timestamp: DateTime<Utc>) -> Result<Option<Snapshot>> {
-        self.find_snapshot_at(timestamp).map_err(tardis_common::Error::from)
+        self.find_snapshot_at(timestamp)
+            .map_err(tardis_common::Error::from)
     }
 
     async fn record_change(&self, change: Change) -> Result<()> {
-        self.record_change(change).map_err(tardis_common::Error::from)
+        self.record_change(change)
+            .map_err(tardis_common::Error::from)
     }
 }

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -335,9 +335,9 @@ impl KnowledgeStore {
             .iter()
             .filter_map(|id| {
                 entities.get(id).and_then(|versions| {
-                    versions.iter().find(|e| {
-                        e.temporal.active_at(now, now) && e.entity_type == entity_type
-                    })
+                    versions
+                        .iter()
+                        .find(|e| e.temporal.active_at(now, now) && e.entity_type == entity_type)
                 })
             })
             .cloned()

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -25,6 +25,8 @@ use tardis_chronos::experimental::curiosity::Curiosity;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::dreamer::Dreamer;
 #[cfg(feature = "nova")]
+use tardis_chronos::experimental::medium::Medium;
+#[cfg(feature = "nova")]
 use tardis_chronos::experimental::weaver::Weaver;
 #[cfg(feature = "nova")]
 use tardis_gallifrey::experimental::time_capsule::TimeCapsule;
@@ -37,11 +39,11 @@ pub struct ChameleonCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for ChameleonCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "chameleon"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Set the system persona"
     }
 
@@ -93,13 +95,18 @@ impl ShellCommand for SonicCommand {
             return Ok(CommandResult::Continue);
         }
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex missing")
+            .clone()
+            .list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let screwdriver = SonicScrewdriver::new(
             context.telemetry.clone(),
             Some(Arc::clone(&context.gallifrey)),
-            Some(context.chronos.vortex()),
+            context.vortex.clone(),
             model_handle,
         );
 
@@ -129,6 +136,65 @@ impl ShellCommand for SonicCommand {
     }
 }
 
+/// Medium command.
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct MediumCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for MediumCommand {
+    fn name(&self) -> &'static str {
+        "medium"
+    }
+
+    fn description(&self) -> &'static str {
+        "Summon system state from past"
+    }
+
+    async fn execute(&self, args: &[String], context: &CommandContext) -> Result<CommandResult> {
+        if args.len() < 2 {
+            println!("Usage: medium <timestamp> <query>");
+            println!("Example: medium 2023-10-27T10:00:00Z \"What was the system status?\"");
+            return Ok(CommandResult::Continue);
+        }
+
+        let timestamp_str = &args[0];
+        // Join the rest of the args as the query
+        let query = args[1..].join(" ");
+
+        let timestamp = match chrono::DateTime::parse_from_rfc3339(timestamp_str) {
+            Ok(dt) => dt.with_timezone(&chrono::Utc),
+            Err(_) => {
+                println!("Invalid timestamp format. Use RFC3339 (e.g. 2023-10-27T10:00:00Z)");
+                return Ok(CommandResult::Continue);
+            }
+        };
+
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex missing")
+            .list_loaded_models();
+        if let Some((handle, _)) = loaded_models.first() {
+            let medium = Medium::new(
+                Arc::clone(&context.gallifrey),
+                context.vortex.as_ref().expect("Vortex missing").clone(),
+                *handle,
+            );
+
+            println!("🕯️  Summoning the spirits of {}...", timestamp);
+            match medium.summon(timestamp, &query).await {
+                Ok(response) => println!("\n{response}\n"),
+                Err(e) => println!("The connection to the other side failed: {e}"),
+            }
+        } else {
+            println!("The Medium needs a loaded model. Use 'models load <path>'.");
+        }
+        Ok(CommandResult::Continue)
+    }
+}
+
 /// Dreamer command.
 #[cfg(feature = "nova")]
 #[derive(Debug)]
@@ -137,20 +203,25 @@ pub struct DreamCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for DreamCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "dream"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Consolidate memories from conversation"
     }
 
     async fn execute(&self, _args: &[String], context: &CommandContext) -> Result<CommandResult> {
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex missing")
+            .clone()
+            .list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let dreamer = Dreamer::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.vortex.as_ref().expect("Vortex missing").clone(),
                 *handle,
             );
 
@@ -160,7 +231,10 @@ impl ShellCommand for DreamCommand {
                     if ids.is_empty() {
                         println!("No new memories formed.");
                     } else {
-                        println!("✨ Consolidated {} new memories into long-term storage.", ids.len());
+                        println!(
+                            "✨ Consolidated {} new memories into long-term storage.",
+                            ids.len()
+                        );
                     }
                 }
                 Err(e) => println!("Nightmare encountered: {e}"),
@@ -202,13 +276,18 @@ impl ShellCommand for FixCommand {
             return Ok(CommandResult::Continue);
         }
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex missing")
+            .clone()
+            .list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let screwdriver = SonicScrewdriver::new(
             context.telemetry.clone(),
             Some(Arc::clone(&context.gallifrey)),
-            Some(context.chronos.vortex()),
+            context.vortex.clone(),
             model_handle,
         );
 
@@ -413,12 +492,17 @@ impl ShellCommand for BiographerCommand {
         }
         let entity_name = args.join(" ");
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex missing")
+            .clone()
+            .list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let biographer = Biographer::new(
             Arc::clone(&context.gallifrey),
-            context.chronos.vortex(),
+            context.vortex.as_ref().expect("Vortex missing").clone(),
             model_handle,
         );
 
@@ -459,11 +543,16 @@ impl ShellCommand for CuriosityCommand {
     }
 
     async fn execute(&self, _args: &[String], context: &CommandContext) -> Result<CommandResult> {
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex missing")
+            .clone()
+            .list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let curiosity = Curiosity::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.vortex.as_ref().expect("Vortex missing").clone(),
                 *handle,
             );
 
@@ -563,11 +652,11 @@ pub struct WeaveCommand;
 #[cfg(feature = "nova")]
 #[async_trait]
 impl ShellCommand for WeaveCommand {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "weave"
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "Generate a narrative connection between two entities"
     }
 
@@ -580,11 +669,16 @@ impl ShellCommand for WeaveCommand {
         let entity1 = &args[0];
         let entity2 = &args[1];
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex missing")
+            .clone()
+            .list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let weaver = Weaver::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex(),
+                context.vortex.as_ref().expect("Vortex missing").clone(),
                 *handle,
             );
 

--- a/shell/src/commands/traits.rs
+++ b/shell/src/commands/traits.rs
@@ -21,6 +21,9 @@ pub struct CommandContext {
     /// Access to the Prophet Engine (optional, Nova only).
     #[cfg(feature = "nova")]
     pub prophet: Option<Arc<Prophet>>,
+    /// Access to the Vortex Engine (optional, Nova only).
+    #[cfg(feature = "nova")]
+    pub vortex: Option<Arc<tardis_vortex::Vortex>>,
     /// The current session ID.
     pub session_id: SessionId,
 }
@@ -33,7 +36,10 @@ impl fmt::Debug for CommandContext {
             .field("telemetry", &self.telemetry.is_some());
 
         #[cfg(feature = "nova")]
-        d.field("prophet", &self.prophet.is_some());
+        {
+            d.field("prophet", &self.prophet.is_some());
+            d.field("vortex", &self.vortex.is_some());
+        }
 
         d.field("session_id", &self.session_id).finish()
     }

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -51,7 +51,13 @@ async fn main() -> Result<()> {
 
     // Create and run REPL
     #[cfg(feature = "nova")]
-    let mut repl = Repl::new(chronos, gallifrey, telemetry_store, Some(prophet))?;
+    let mut repl = Repl::new(
+        chronos,
+        gallifrey,
+        telemetry_store,
+        Some(prophet),
+        Some(vortex),
+    )?;
 
     #[cfg(not(feature = "nova"))]
     let mut repl = Repl::new(chronos, gallifrey, telemetry_store)?;

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -12,6 +12,7 @@ use tardis_chronos::{Chronos, RagConfig};
 use tardis_common::SessionId;
 use tardis_gallifrey::Gallifrey;
 use tardis_telemetry::gallifrey::TelemetryStore;
+use tardis_vortex::Vortex;
 use tracing::{error, info};
 
 #[cfg(feature = "nova")]
@@ -36,6 +37,9 @@ pub struct Repl {
     /// Prophet engine (optional, Nova only).
     #[cfg(feature = "nova")]
     prophet: Option<Arc<Prophet>>,
+    /// Vortex engine (optional, Nova only).
+    #[cfg(feature = "nova")]
+    vortex: Option<Arc<Vortex>>,
     /// Current session ID.
     session_id: SessionId,
     /// Whether to continue running.
@@ -56,6 +60,7 @@ impl Repl {
         gallifrey: Arc<Gallifrey>,
         telemetry_store: Option<Arc<TelemetryStore>>,
         #[cfg(feature = "nova")] prophet: Option<Arc<Prophet>>,
+        #[cfg(feature = "nova")] vortex: Option<Arc<Vortex>>,
     ) -> Result<Self> {
         let editor = DefaultEditor::new()?;
 
@@ -82,6 +87,8 @@ impl Repl {
             telemetry_store,
             #[cfg(feature = "nova")]
             prophet,
+            #[cfg(feature = "nova")]
+            vortex,
             session_id,
             running: true,
             #[cfg(feature = "nova")]
@@ -119,6 +126,7 @@ impl Repl {
             registry.register(Box::new(commands::experimental::CapsuleCommand));
             registry.register(Box::new(commands::experimental::DreamCommand));
             registry.register(Box::new(commands::experimental::WeaveCommand));
+            registry.register(Box::new(commands::experimental::MediumCommand));
         }
     }
 
@@ -196,6 +204,8 @@ impl Repl {
                 telemetry: self.telemetry_store.clone(),
                 #[cfg(feature = "nova")]
                 prophet: self.prophet.clone(),
+                #[cfg(feature = "nova")]
+                vortex: self.vortex.clone(),
                 session_id: self.session_id,
             };
 

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -188,10 +188,7 @@ mod tests {
     use super::*;
 
     fn test_router() -> Router {
-        Router::new(vec![
-            "help".to_string(),
-            "history".to_string(),
-        ])
+        Router::new(vec!["help".to_string(), "history".to_string()])
     }
 
     #[test]

--- a/vortex/src/services.rs
+++ b/vortex/src/services.rs
@@ -1,12 +1,12 @@
 //! Service implementations for Vortex.
 
 use crate::Vortex;
+use async_trait::async_trait;
+use std::sync::Arc;
 use tardis_common::id::ModelHandle;
 use tardis_common::llm::InferenceParams;
 use tardis_common::traits::LlmService;
 use tardis_common::Result;
-use async_trait::async_trait;
-use std::sync::Arc;
 
 /// A wrapper around Vortex that binds it to a specific model.
 ///
@@ -21,7 +21,7 @@ pub struct VortexLlmService {
 impl VortexLlmService {
     /// Create a new service adapter.
     #[must_use]
-    pub fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub const fn new(engine: Arc<Vortex>, model: ModelHandle) -> Self {
         Self { engine, model }
     }
 }


### PR DESCRIPTION
This PR introduces "The Medium", a new experimental feature for the Tardis OS that allows users to "summon" a snapshot of the system's knowledge base from a specific point in the past and query it using the LLM.

This feature is accessible via the new `medium <timestamp> <query>` shell command. It leverages Gallifrey's bi-temporal `scan_history` capability to reconstruct the state of entities at the given time and injects them into the Vortex context.

Additionally, this PR fixes several compilation issues in the `shell` crate related to experimental commands (incorrect lifetime signatures and missing access to the Vortex engine) by refactoring `CommandContext` to provide direct optional access to `Vortex` when the `nova` feature is enabled.

---
*PR created automatically by Jules for task [7524253424025072087](https://jules.google.com/task/7524253424025072087) started by @madmax983*