### PR TITLE
feat(common): implement TimeRange intersection and rigorous temporal tests

### DIFF
--- a/common/src/temporal.rs
+++ b/common/src/temporal.rs
@@ -86,6 +86,36 @@ impl TimeRange {
             end: Some(Utc::now()),
         }
     }
+
+    /// Calculate the intersection of two time ranges.
+    ///
+    /// Returns `Some(range)` representing the overlap, or `None` if they do not overlap.
+    #[must_use]
+    pub fn intersection(&self, other: &Self) -> Option<Self> {
+        // Start is the later of the two starts
+        let start = if self.start > other.start {
+            self.start
+        } else {
+            other.start
+        };
+
+        // End is the earlier of the two ends
+        // None represents positive infinity, so it's always "later" than Some(t)
+        let end = match (self.end, other.end) {
+            (Some(e1), Some(e2)) => Some(if e1 < e2 { e1 } else { e2 }),
+            (Some(e), None) | (None, Some(e)) => Some(e),
+            (None, None) => None,
+        };
+
+        // If end is defined and start >= end, the intersection is empty
+        if let Some(end_ts) = end {
+            if start >= end_ts {
+                return None;
+            }
+        }
+
+        Some(Self { start, end })
+    }
 }
 
 impl Default for TimeRange {
@@ -487,6 +517,49 @@ mod tests {
 
         let current_interval = BiTemporalInterval::now();
         assert!(current_interval.is_current_relative_to(now));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn time_range_intersection() {
+        let now = Utc::now();
+        let h1 = Duration::hours(1);
+        let h2 = Duration::hours(2);
+        let h3 = Duration::hours(3);
+        let h4 = Duration::hours(4);
+
+        // Case 1: Overlap
+        let r1 = TimeRange::bounded(now, now + h2);
+        let r2 = TimeRange::bounded(now + h1, now + h3);
+        let intersection = r1.intersection(&r2).unwrap();
+        assert_eq!(intersection.start, now + h1);
+        assert_eq!(intersection.end, Some(now + h2));
+
+        // Case 2: Disjoint
+        let r3 = TimeRange::bounded(now + h3, now + h4);
+        assert!(r1.intersection(&r3).is_none());
+
+        // Case 3: Nested
+        let r4 = TimeRange::bounded(now + h1, now + h2); // Inside r1
+        let intersection = r1.intersection(&r4).unwrap();
+        assert_eq!(intersection.start, now + h1);
+        assert_eq!(intersection.end, Some(now + h2));
+
+        // Case 4: Touching (start == end) -> Empty -> None
+        let r5 = TimeRange::bounded(now + h2, now + h3);
+        assert!(r1.intersection(&r5).is_none());
+
+        // Case 5: Open-ended
+        let r_open = TimeRange::starting_at(now + h1);
+        let intersection = r1.intersection(&r_open).unwrap();
+        assert_eq!(intersection.start, now + h1);
+        assert_eq!(intersection.end, Some(now + h2));
+
+        // Case 6: Both open-ended
+        let r_open2 = TimeRange::starting_at(now);
+        let intersection = r_open.intersection(&r_open2).unwrap();
+        assert_eq!(intersection.start, now + h1);
+        assert_eq!(intersection.end, None);
     }
 
     proptest! {

--- a/common/tests/temporal_integration.rs
+++ b/common/tests/temporal_integration.rs
@@ -1,0 +1,61 @@
+//! Integration tests for temporal primitives.
+
+use tardis_common::temporal::*;
+use chrono::{Utc, Duration};
+
+#[test]
+fn time_range_is_current_with_future_start() {
+    let now = Utc::now();
+    let future_start = now + Duration::days(1);
+
+    // Create a range starting in the future
+    let range = TimeRange::starting_at(future_start);
+
+    // Verify that is_current() returns true even if start is in future
+    // This documents existing behavior: "current" means "not ended", not "active now".
+    assert!(range.is_current(), "Future start time should still be considered current (not ended)");
+
+    // Verify contains(now) correctly returns false
+    assert!(!range.contains(now), "Future start time should NOT contain now");
+}
+
+#[test]
+fn time_range_empty() {
+    let now = Utc::now();
+    let range = TimeRange::bounded(now, now); // Empty range [now, now)
+
+    assert!(!range.contains(now), "Empty range should not contain start time");
+
+    // is_current checks end > now.
+    // Since end == now, is_current should be false.
+    assert!(!range.is_current(), "Empty range ending now should not be current");
+}
+
+#[test]
+fn bi_temporal_future_valid_time() {
+    // Construct times explicitly to avoid race conditions
+    let now = Utc::now();
+    let future_start = now + Duration::days(1);
+    let valid_range = TimeRange::starting_at(future_start);
+
+    // Manually construct interval to control transaction time
+    let interval = BiTemporalInterval {
+        valid_time: valid_range,
+        transaction_time: TimeRange::starting_at(now),
+    };
+
+    // valid_time starts in future.
+    // transaction_time starts at 'now'.
+
+    // is_current() checks if both ends are > now (or None).
+    // valid_time.end is None -> true.
+    // transaction_time.end is None -> true.
+    assert!(interval.is_current(), "Interval with future valid time should be current (not superseded)");
+
+    // But it should not be valid_at(now)
+    assert!(!interval.valid_at(now), "Interval should not be valid at now");
+
+    // It should be known_at(now)
+    // Note: range.contains(start) is true.
+    assert!(interval.known_at(now), "Interval should be known at now");
+}


### PR DESCRIPTION
This PR adds the missing `intersection` method to `TimeRange` in `tardis-common`, allowing consumers to easily calculate overlapping time periods. It also adds a suite of unit and integration tests to verify the correctness of temporal primitives, specifically documenting and testing the behavior of `is_current` with future start times, which was previously implicit. This improves the robustness of time-handling logic across the system.

---
*PR created automatically by Jules for task [5407382043995074618](https://jules.google.com/task/5407382043995074618) started by @madmax983*