### PR TITLE
🎻 Bard: Enhance `tardis-common` documentation

### DIFF
--- a/common/src/id.rs
+++ b/common/src/id.rs
@@ -2,12 +2,29 @@
 //!
 //! Provides strongly-typed identifiers for various entities to prevent
 //! mixing up different ID types at compile time.
+//!
+//! # Rationale
+//!
+//! Instead of using raw `Uuid` or `u64` everywhere, we wrap them in distinct
+//! newtypes. This ensures that you can't accidentally pass a `SessionId` to a
+//! function expecting an `EntityId`, catching bugs at compile time.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use uuid::Uuid;
 
 /// A handle to a loaded LLM model in Vortex.
+///
+/// This is a lightweight reference to a model loaded in memory, typically backed by a `usize` index.
+///
+/// # Examples
+///
+/// ```
+/// use tardis_common::id::ModelHandle;
+///
+/// let handle = ModelHandle::new(42);
+/// assert_eq!(handle.raw(), 42);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ModelHandle(u64);
 
@@ -32,6 +49,17 @@ impl fmt::Display for ModelHandle {
 }
 
 /// Unique identifier for an entity in the knowledge graph.
+///
+/// Wraps a UUID v4.
+///
+/// # Examples
+///
+/// ```
+/// use tardis_common::id::EntityId;
+///
+/// let id = EntityId::new();
+/// println!("New entity: {}", id);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EntityId(Uuid);
 
@@ -68,6 +96,16 @@ impl fmt::Display for EntityId {
 }
 
 /// Unique identifier for a conversation session.
+///
+/// Wraps a UUID v4.
+///
+/// # Examples
+///
+/// ```
+/// use tardis_common::id::SessionId;
+///
+/// let session_id = SessionId::new();
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SessionId(Uuid);
 
@@ -104,6 +142,18 @@ impl fmt::Display for SessionId {
 }
 
 /// Unique identifier for a system state snapshot.
+///
+/// Wraps a UUID v4.
+///
+/// # Examples
+///
+/// Using `SnapshotId::max()` for range queries:
+///
+/// ```
+/// use tardis_common::id::SnapshotId;
+///
+/// let end_of_time = SnapshotId::max();
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct SnapshotId(Uuid);
 

--- a/common/src/llm.rs
+++ b/common/src/llm.rs
@@ -6,6 +6,20 @@
 use serde::{Deserialize, Serialize};
 
 /// Configuration for loading a model.
+///
+/// This struct controls hardware acceleration, quantization, and context limits.
+///
+/// # Examples
+///
+/// Loading a model on GPU with 4-bit quantization:
+///
+/// ```
+/// use tardis_common::llm::ModelLoadConfig;
+///
+/// let config = ModelLoadConfig::cuda(0)
+///     .with_quantization("q4_k")
+///     .with_context_length(4096);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelLoadConfig {
     /// Device to load on ("cpu", "cuda:0", "metal").
@@ -73,6 +87,30 @@ impl ModelLoadConfig {
 }
 
 /// Parameters for inference.
+///
+/// Controls the randomness and length of the generated text.
+///
+/// # Examples
+///
+/// Creating a creative configuration:
+///
+/// ```
+/// use tardis_common::llm::InferenceParams;
+///
+/// let params = InferenceParams::default()
+///     .with_temperature(0.8)  // Note: Requires f32
+///     .with_max_tokens(100)   // Note: Requires usize
+///     .with_stop("User:");
+/// ```
+///
+/// Creating a deterministic configuration for coding tasks:
+///
+/// ```
+/// use tardis_common::llm::InferenceParams;
+///
+/// let params = InferenceParams::deterministic()
+///     .with_max_tokens(4096);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InferenceParams {
     /// Sampling temperature (0.0 = deterministic, higher = more random).

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -1,7 +1,52 @@
 //! Shared traits for system services.
 //!
-//! These traits define the interfaces for core system components, enabling
-//! decoupling and easier testing/mocking.
+//! These traits define the core architectural boundaries of Tardis OS. By defining services
+//! as traits, we enable:
+//!
+//! 1.  **Decoupling**: Consumers (like `Chronos`) depend on abstract interfaces, not concrete implementations.
+//! 2.  **Testability**: We can easily swap in mock implementations for unit testing.
+//! 3.  **Flexibility**: We can change the underlying storage or inference engine without breaking consumers.
+//!
+//! # The Big Four Services
+//!
+//! *   [`LlmService`]: The brain. Handles text generation and embedding.
+//! *   [`KnowledgeService`]: The long-term memory. Stores facts and relationships.
+//! *   [`ConversationService`]: The short-term memory. Manages chat history.
+//! *   [`SystemStateService`]: The nervous system. Tracks OS state changes.
+//!
+//! # async_trait
+//!
+//! You'll notice all traits are annotated with `#[async_trait]`. This is because Rust
+//! currently does not support async functions in traits natively (without boxing).
+//! This macro boxes the returned futures, making the traits object-safe (`dyn Trait`).
+//!
+//! # Example: Mocking for Tests
+//!
+//! ```rust
+//! use tardis_common::traits::LlmService;
+//! use tardis_common::llm::InferenceParams;
+//! use tardis_common::Result;
+//! use async_trait::async_trait;
+//! use std::any::Any;
+//!
+//! #[derive(Debug)]
+//! struct MockLlm;
+//!
+//! #[async_trait]
+//! impl LlmService for MockLlm {
+//!     async fn infer(&self, prompt: &str, _params: InferenceParams) -> Result<String> {
+//!         Ok(format!("Mock response to: {}", prompt))
+//!     }
+//!
+//!     async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+//!         Ok(vec![0.0; 384])
+//!     }
+//!
+//!     fn as_any(&self) -> &dyn Any {
+//!         self
+//!     }
+//! }
+//! ```
 
 use crate::domain::{Change, Entity, Message, Session, Snapshot};
 use crate::id::{EntityId, SessionId};
@@ -14,25 +59,45 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 /// Interface for LLM inference services.
+///
+/// This trait abstracts over different LLM backends (e.g., local `Vortex`, remote APIs).
+/// It provides methods for text generation (`infer`) and vector embedding (`embed`).
 #[async_trait]
 pub trait LlmService: Send + Sync + Debug {
     /// Generate text based on a prompt.
+    ///
+    /// # Arguments
+    ///
+    /// * `prompt` - The input text or prompt for the model.
+    /// * `params` - Configuration for generation (temperature, max tokens, etc.).
     async fn infer(&self, prompt: &str, params: InferenceParams) -> Result<String>;
 
     /// Generate embeddings for text.
+    ///
+    /// Used for semantic search. Returns a vector of floats representing the semantic meaning.
     async fn embed(&self, text: &str) -> Result<Vec<f32>>;
 
     /// Downcast to concrete type.
+    ///
+    /// Useful when you need access to backend-specific methods not exposed by the trait.
     fn as_any(&self) -> &dyn Any;
 }
 
 /// Interface for knowledge graph storage.
+///
+/// Handles the "Long-Term Memory" of the system.
+/// Stores entities (facts) and relationships in a bi-temporal graph structure.
 #[async_trait]
 pub trait KnowledgeService: Send + Sync + Debug {
     /// Insert an entity into the knowledge graph.
+    ///
+    /// Returns the assigned `EntityId`.
     async fn insert_entity(&self, entity: Entity) -> Result<EntityId>;
 
     /// Update an entity.
+    ///
+    /// This performs a bi-temporal update (preserving history).
+    /// `updates` is a map of property names to new values.
     async fn update_entity(
         &self,
         id: EntityId,
@@ -42,14 +107,21 @@ pub trait KnowledgeService: Send + Sync + Debug {
     /// Get the current version of an entity.
     async fn get_entity(&self, id: EntityId) -> Result<Option<Entity>>;
 
-    /// Get all versions of an entity.
+    /// Get all versions of an entity (history).
+    ///
+    /// Returns a list of all historical states of the entity, sorted by time.
     async fn get_entity_history(&self, id: EntityId) -> Result<Vec<Entity>>;
 
     /// Find entities by semantic similarity.
+    ///
+    /// Uses vector search on the `embedding` field.
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>>;
 }
 
 /// Interface for conversation history storage.
+///
+/// Handles the "Short-Term Memory" of the system (context window).
+/// Groups messages into sessions.
 #[async_trait]
 pub trait ConversationService: Send + Sync + Debug {
     /// Create a new conversation session.
@@ -59,12 +131,16 @@ pub trait ConversationService: Send + Sync + Debug {
     async fn get_session(&self, id: SessionId) -> Result<Option<Session>>;
 
     /// End a session.
+    ///
+    /// Typically triggers summarization and archival.
     async fn end_session(&self, id: SessionId) -> Result<()>;
 
     /// Add a message to the store.
     async fn add_message(&self, message: Message) -> Result<EntityId>;
 
     /// Get recent messages from a session.
+    ///
+    /// Useful for rebuilding the context window for the LLM.
     async fn get_recent_messages(
         &self,
         session_id: SessionId,
@@ -76,9 +152,14 @@ pub trait ConversationService: Send + Sync + Debug {
 }
 
 /// Interface for system state storage.
+///
+/// Handles the "Nervous System" or "Audit Log".
+/// Records changes to the OS environment and allows time-travel debugging.
 #[async_trait]
 pub trait SystemStateService: Send + Sync + Debug {
     /// Find a snapshot at a specific time.
+    ///
+    /// Used to reconstruct the system state for a past event.
     async fn find_snapshot_at(&self, timestamp: DateTime<Utc>) -> Result<Option<Snapshot>>;
 
     /// Record a system change.


### PR DESCRIPTION
🎻 **Bard: The Common Chronicles**

📖 **Chapter:** The `tardis-common` crate.

🔦 **Insight:**
- Clarified the Service Architecture in `traits.rs`, explaining *why* we use traits and how `#[async_trait]` fits in.
- Demystified `InferenceParams` and `ModelLoadConfig` in `llm.rs` with concrete examples (especially the typed builder pattern).
- Gave identity to `id.rs` by showing how to use the strong types.

🧪 **Verification:**
- Added executable doctests to all modified files.
- Ran `cargo test -p tardis-common` (All passed).
- Verified docs with `cargo doc --open`.


---
*PR created automatically by Jules for task [6502522729174074421](https://jules.google.com/task/6502522729174074421) started by @madmax983*