### PR TITLE
Decouple Chronos experimental modules from concrete services

### DIFF
--- a/chronos/src/experimental/medium.rs
+++ b/chronos/src/experimental/medium.rs
@@ -8,25 +8,29 @@ use crate::error::{ChronosError, ChronosResult};
 use chrono::{DateTime, Utc};
 use std::sync::Arc;
 use tardis_common::id::ModelHandle;
-use tardis_gallifrey::Gallifrey;
-use tardis_vortex::{InferenceParams, Vortex};
+use tardis_common::llm::InferenceParams;
+use tardis_common::traits::{KnowledgeService, LlmService};
 use tracing::{info, instrument};
 
 /// The Medium engine.
 #[derive(Debug)]
 pub struct Medium {
-    gallifrey: Arc<Gallifrey>,
-    vortex: Arc<Vortex>,
-    model: ModelHandle,
+    knowledge: Arc<dyn KnowledgeService>,
+    llm: Arc<dyn LlmService>,
+    model: Option<ModelHandle>,
 }
 
 impl Medium {
     /// Create a new Medium engine.
     #[must_use]
-    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub fn new(
+        knowledge: Arc<dyn KnowledgeService>,
+        llm: Arc<dyn LlmService>,
+        model: Option<ModelHandle>,
+    ) -> Self {
         Self {
-            gallifrey,
-            vortex,
+            knowledge,
+            llm,
             model,
         }
     }
@@ -41,7 +45,7 @@ impl Medium {
         info!("Medium: Summoning past state at {}", time);
 
         // 1. Gather context from the past
-        let context = self.gather_context(query, time)?;
+        let context = self.gather_context(query, time).await?;
 
         if context.trim().is_empty() {
             return Ok(
@@ -59,50 +63,40 @@ impl Medium {
              Do not hallucinate facts not present in the context.[/INST]"
         );
 
-        let params = InferenceParams::default()
+        let mut params = InferenceParams::default()
             .with_temperature(0.7)
             .with_max_tokens(512);
 
+        if let Some(model) = self.model {
+            params = params.with_model(model);
+        }
+
         let response = self
-            .vortex
-            .infer(self.model, &prompt, params)
+            .llm
+            .infer(&prompt, params)
             .await
-            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            .map_err(ChronosError::Common)?;
 
         Ok(response)
     }
 
     #[allow(clippy::format_push_string)]
-    fn gather_context(&self, query: &str, time: DateTime<Utc>) -> ChronosResult<String> {
+    async fn gather_context(&self, query: &str, time: DateTime<Utc>) -> ChronosResult<String> {
         let mut context = String::new();
-        let knowledge = self.gallifrey.knowledge();
-        let query_lower = query.to_lowercase();
-        let query_words: Vec<&str> = query_lower.split_whitespace().collect();
 
-        // Scan history for relevant entities active at `time`
-        // We use a simple heuristic: check if entity name contains any query word (if word len > 3)
-        // or if query contains entity name.
-        knowledge
-            .scan_history(|history| {
-                // Find version active at `time` (using transaction time = time for "as known then")
-                if let Some(entity) = history.iter().find(|e| e.temporal.active_at(time, time)) {
-                    let name_lower = entity.name.to_lowercase();
+        let entities = self
+            .knowledge
+            .search_history(query, Some(time), 50)
+            .await
+            .map_err(ChronosError::Common)?;
 
-                    let relevant = query_lower.contains(&name_lower)
-                        || query_words
-                            .iter()
-                            .any(|w| w.len() > 3 && name_lower.contains(w));
-
-                    if relevant {
-                        context.push_str(&format!(
-                            "- Entity: {} ({})\n",
-                            entity.name, entity.entity_type
-                        ));
-                        context.push_str(&format!("  Properties: {:?}\n", entity.properties));
-                    }
-                }
-            })
-            .map_err(|e| ChronosError::Common(e.into()))?;
+        for entity in entities {
+            context.push_str(&format!(
+                "- Entity: {} ({})\n",
+                entity.name, entity.entity_type
+            ));
+            context.push_str(&format!("  Properties: {:?}\n", entity.properties));
+        }
 
         Ok(context)
     }
@@ -117,7 +111,8 @@ mod tests {
     use tardis_common::id::EntityId;
     use tardis_common::temporal::{BiTemporalInterval, TimeRange};
     use tardis_gallifrey::domain::Entity;
-    use tardis_vortex::{ModelHandle, ModelLoadConfig};
+    use tardis_gallifrey::Gallifrey;
+    use tardis_vortex::{ModelHandle, ModelLoadConfig, Vortex, VortexLlmService};
 
     fn create_test_entity(name: &str, entity_type: &str, time: DateTime<Utc>) -> Entity {
         Entity {
@@ -172,7 +167,11 @@ mod tests {
             .load_model("dummy", ModelLoadConfig::default())
             .await
             .unwrap();
-        let medium = Medium::new(gallifrey, vortex, handle);
+
+        let llm_service = Arc::new(VortexLlmService::new(vortex.clone(), handle));
+        let knowledge_service = gallifrey.knowledge();
+
+        let medium = Medium::new(knowledge_service, llm_service, Some(handle));
 
         // Summon at T1 + 1 minute (should see OldProject, but NOT NewProject)
         let query_time = t1 + chrono::Duration::minutes(1);

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -7,25 +7,30 @@
 
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
-use tardis_gallifrey::domain::Entity;
-use tardis_gallifrey::Gallifrey;
-use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
+use tardis_common::domain::Entity;
+use tardis_common::id::ModelHandle;
+use tardis_common::llm::InferenceParams;
+use tardis_common::traits::{KnowledgeService, LlmService};
 
 /// The Weaver engine.
 #[derive(Debug)]
 pub struct Weaver {
-    gallifrey: Arc<Gallifrey>,
-    vortex: Arc<Vortex>,
-    model: ModelHandle,
+    knowledge: Arc<dyn KnowledgeService>,
+    llm: Arc<dyn LlmService>,
+    model: Option<ModelHandle>,
 }
 
 impl Weaver {
     /// Create a new Weaver instance.
     #[must_use]
-    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub fn new(
+        knowledge: Arc<dyn KnowledgeService>,
+        llm: Arc<dyn LlmService>,
+        model: Option<ModelHandle>,
+    ) -> Self {
         Self {
-            gallifrey,
-            vortex,
+            knowledge,
+            llm,
             model,
         }
     }
@@ -36,8 +41,8 @@ impl Weaver {
     ///
     /// Returns an error if entities are not found or inference fails.
     pub async fn weave(&self, entity1_name: &str, entity2_name: &str) -> Result<String> {
-        let e1 = self.find_entity(entity1_name)?;
-        let e2 = self.find_entity(entity2_name)?;
+        let e1 = self.find_entity(entity1_name).await?;
+        let e2 = self.find_entity(entity2_name).await?;
 
         let prompt = format!(
             "<s>[INST] You are The Weaver, a narrative engine for the Tardis OS.
@@ -55,39 +60,29 @@ The connection is: [/INST]",
             e1.name, e1.entity_type, e1.properties, e2.name, e2.entity_type, e2.properties
         );
 
-        let params = InferenceParams::default()
+        let mut params = InferenceParams::default()
             .with_temperature(0.8)
             .with_max_tokens(150);
 
+        if let Some(model) = self.model {
+            params = params.with_model(model);
+        }
+
         let result = self
-            .vortex
-            .infer(self.model, &prompt, params)
+            .llm
+            .infer(&prompt, params)
             .await
             .map_err(|e| anyhow!(e.to_string()))?;
 
         Ok(result)
     }
 
-    fn find_entity(&self, name: &str) -> Result<Entity> {
-        let knowledge = self.gallifrey.knowledge();
-        let mut found = None;
-
-        // Scan all entities to find the one with the matching name (case-insensitive)
-        knowledge.scan_history(|history| {
-            if found.is_some() {
-                return;
-            }
-
-            // Find latest version that matches name
-            if let Some(e) = history
-                .iter()
-                .find(|e| e.name.eq_ignore_ascii_case(name) && e.temporal.is_current())
-            {
-                found = Some(e.clone());
-            }
-        })?;
-
-        found.ok_or_else(|| anyhow!("Entity '{name}' not found in current time"))
+    async fn find_entity(&self, name: &str) -> Result<Entity> {
+        self.knowledge
+            .find_entity_by_name(name)
+            .await
+            .map_err(|e| anyhow!(e.to_string()))?
+            .ok_or_else(|| anyhow!("Entity '{name}' not found in current time"))
     }
 }
 
@@ -97,6 +92,7 @@ mod tests {
     use std::collections::HashMap;
     use tardis_common::id::EntityId;
     use tardis_common::temporal::BiTemporalInterval;
+    use tardis_gallifrey::Gallifrey;
 
     fn create_test_entity(name: &str, entity_type: &str) -> Entity {
         Entity {
@@ -113,22 +109,15 @@ mod tests {
     #[tokio::test]
     async fn test_find_entity_manual() {
         let gallifrey = Arc::new(Gallifrey::new());
+        let knowledge: Arc<dyn KnowledgeService> = gallifrey.knowledge();
         // We can't easily mock Vortex here without loading a model, so we'll just test the entity lookup part.
         // To test the full Weaver we'd need a mock Vortex or a way to bypass inference.
-        // For now, let's just verifying finding entities works.
+        // For now, let's just verifying finding entities works via the trait.
 
         let entity = create_test_entity("TestBot", "Bot");
-        gallifrey.insert(entity).await.unwrap();
+        knowledge.insert_entity(entity).await.unwrap();
 
-        let knowledge = gallifrey.knowledge();
-        let mut found = None;
-        knowledge
-            .scan_history(|history| {
-                if let Some(e) = history.iter().find(|e| e.name == "TestBot") {
-                    found = Some(e.clone());
-                }
-            })
-            .unwrap();
+        let found = knowledge.find_entity_by_name("TestBot").await.unwrap();
 
         assert!(found.is_some());
         assert_eq!(found.unwrap().name, "TestBot");

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -191,6 +191,18 @@ impl Chronos {
             )
     }
 
+    /// Get the LLM service.
+    #[must_use]
+    pub fn llm(&self) -> Arc<dyn LlmService> {
+        self.llm.clone()
+    }
+
+    /// Get the knowledge service.
+    #[must_use]
+    pub fn knowledge(&self) -> Arc<dyn KnowledgeService> {
+        self.knowledge.clone()
+    }
+
     /// Execute a RAG query.
     ///
     /// # Errors

--- a/common/src/llm.rs
+++ b/common/src/llm.rs
@@ -3,6 +3,7 @@
 //! Provides configuration structs for model loading and inference,
 //! used by both Vortex (inference engine) and Chronos (RAG orchestrator).
 
+use crate::id::ModelHandle;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for loading a model.
@@ -89,6 +90,8 @@ pub struct InferenceParams {
     pub repetition_penalty: f32,
     /// Seed for reproducibility (None = random).
     pub seed: Option<u64>,
+    /// Optional model handle to override the default model.
+    pub model: Option<ModelHandle>,
 }
 
 impl Default for InferenceParams {
@@ -101,6 +104,7 @@ impl Default for InferenceParams {
             stop_sequences: Vec::new(),
             repetition_penalty: 1.1,
             seed: None,
+            model: None,
         }
     }
 }
@@ -146,6 +150,13 @@ impl InferenceParams {
     #[must_use]
     pub fn with_stop(mut self, sequence: &str) -> Self {
         self.stop_sequences.push(sequence.to_string());
+        self
+    }
+
+    /// Set the model to use for inference.
+    #[must_use]
+    pub const fn with_model(mut self, model: ModelHandle) -> Self {
+        self.model = Some(model);
         self
     }
 }

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -47,6 +47,17 @@ pub trait KnowledgeService: Send + Sync + Debug {
 
     /// Find entities by semantic similarity.
     async fn semantic_search(&self, embedding: &[f32], limit: usize) -> Result<Vec<Entity>>;
+
+    /// Find an entity by name.
+    async fn find_entity_by_name(&self, name: &str) -> Result<Option<Entity>>;
+
+    /// Search entity history.
+    async fn search_history(
+        &self,
+        query: &str,
+        time: Option<DateTime<Utc>>,
+        limit: usize,
+    ) -> Result<Vec<Entity>>;
 }
 
 /// Interface for conversation history storage.

--- a/gallifrey/src/services.rs
+++ b/gallifrey/src/services.rs
@@ -38,6 +38,71 @@ impl KnowledgeService for KnowledgeStore {
         self.semantic_search(embedding, limit)
             .map_err(tardis_common::Error::from)
     }
+
+    async fn find_entity_by_name(&self, name: &str) -> Result<Option<Entity>> {
+        let mut found = None;
+        let now = Utc::now();
+
+        self.scan_history(|history| {
+            if found.is_some() {
+                return;
+            }
+            if let Some(e) = history.iter().find(|e| {
+                e.name.eq_ignore_ascii_case(name) && e.temporal.active_at(now, now)
+            }) {
+                found = Some(e.clone());
+            }
+        })
+        .map_err(tardis_common::Error::from)?;
+
+        Ok(found)
+    }
+
+    async fn search_history(
+        &self,
+        query: &str,
+        time: Option<DateTime<Utc>>,
+        limit: usize,
+    ) -> Result<Vec<Entity>> {
+        let mut results = Vec::new();
+        let query_lower = query.to_lowercase();
+        // Split query into words for simple keyword matching
+        let query_words: Vec<&str> = query_lower.split_whitespace().collect();
+
+        let query_time = time.unwrap_or_else(Utc::now);
+        // For historical query, we check what was valid at that time
+        // AND what was known at that time (bi-temporal snapshot).
+        let transaction_time = query_time;
+
+        self.scan_history(|history| {
+            if results.len() >= limit {
+                return;
+            }
+
+            // Find version active at query_time
+            if let Some(entity) = history
+                .iter()
+                .find(|e| e.temporal.active_at(query_time, transaction_time))
+            {
+                let name_lower = entity.name.to_lowercase();
+
+                // Simple relevance heuristic:
+                // 1. Entity name contains query (or part of it)
+                // 2. Query contains entity name
+                let relevant = query_lower.contains(&name_lower)
+                    || query_words
+                        .iter()
+                        .any(|w| w.len() > 3 && name_lower.contains(w));
+
+                if relevant {
+                    results.push(entity.clone());
+                }
+            }
+        })
+        .map_err(tardis_common::Error::from)?;
+
+        Ok(results)
+    }
 }
 
 #[async_trait]

--- a/gallifrey/src/stores/knowledge.rs
+++ b/gallifrey/src/stores/knowledge.rs
@@ -384,7 +384,6 @@ impl KnowledgeStore {
     /// # Errors
     ///
     /// Returns an error if the lock is poisoned.
-    #[cfg(feature = "nova")]
     pub fn scan_history<F>(&self, mut visitor: F) -> GallifreyResult<()>
     where
         F: FnMut(&[Entity]),
@@ -408,7 +407,6 @@ impl KnowledgeStore {
     /// # Errors
     ///
     /// Returns an error if the lock is poisoned.
-    #[cfg(feature = "nova")]
     pub fn scan_relationships<F>(&self, mut visitor: F) -> GallifreyResult<()>
     where
         F: FnMut(&[Relationship]),

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -589,9 +589,9 @@ impl ShellCommand for WeaveCommand {
         let loaded_models = context.chronos.vortex().list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let weaver = Weaver::new(
-                Arc::clone(&context.gallifrey),
-                context.chronos.vortex().clone(),
-                *handle,
+                context.gallifrey.knowledge(),
+                context.chronos.llm(),
+                Some(*handle),
             );
 
             println!("🕸️  Weaving destiny between '{entity1}' and '{entity2}'...");
@@ -651,9 +651,9 @@ impl ShellCommand for MediumCommand {
         let loaded_models = context.chronos.vortex().list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let medium = Medium::new(
-                Arc::clone(&context.gallifrey),
-                context.chronos.vortex().clone(),
-                *handle,
+                context.gallifrey.knowledge(),
+                context.chronos.llm(),
+                Some(*handle),
             );
 
             println!("🕯️ Summoning the past at {time}...");

--- a/vortex/src/services.rs
+++ b/vortex/src/services.rs
@@ -36,8 +36,9 @@ impl VortexLlmService {
 #[async_trait]
 impl LlmService for VortexLlmService {
     async fn infer(&self, prompt: &str, params: InferenceParams) -> Result<String> {
+        let model = params.model.unwrap_or(self.model);
         self.engine
-            .infer(self.model, prompt, params)
+            .infer(model, prompt, params)
             .await
             .map_err(|e| tardis_common::Error::Internal(e.to_string()))
     }


### PR DESCRIPTION
This PR decouples the `Weaver` and `Medium` experimental modules in `chronos` from concrete `Gallifrey` and `Vortex` implementations. It achieves this by extending the `KnowledgeService` and `LlmService` traits to cover the required functionality (entity lookup by name, history search, and model selection) and refactoring the modules to consume these traits. This aligns with the architectural goal of high cohesion and low coupling.

---
*PR created automatically by Jules for task [13612530830729248074](https://jules.google.com/task/13612530830729248074) started by @madmax983*