### PR TITLE
🔒 Warden: Harden Chronos pipeline & Cleanup Unsafe in Telemetry

### DIFF
--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -98,9 +98,25 @@ pub fn augment(
 ) -> ChronosResult<String> {
     let max_context_tokens = config.max_context_tokens;
 
+    // Hard limit to prevent DoS via excessive allocation
+    const MAX_TOKENS_LIMIT: usize = 100_000;
+    if max_context_tokens > MAX_TOKENS_LIMIT {
+        return Err(crate::error::ChronosError::ContextAssemblyFailed(format!(
+            "max_context_tokens {} exceeds limit {}",
+            max_context_tokens, MAX_TOKENS_LIMIT
+        )));
+    }
+
     // Bolt: Pre-allocate buffer to avoid re-allocations.
     // 4 chars per token + 1KB overhead for system prompts/instructions.
-    let capacity = max_context_tokens * 4 + 1024;
+    // Use checked arithmetic to prevent overflow panic
+    let capacity = max_context_tokens
+        .checked_mul(4)
+        .and_then(|c| c.checked_add(1024))
+        .ok_or_else(|| {
+            crate::error::ChronosError::ContextAssemblyFailed("Capacity overflow".to_string())
+        })?;
+
     let mut formatter = ContextFormatter::new(capacity);
 
     // System context

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -19,10 +19,25 @@ pub async fn retrieve(
     query: &AnalyzedQuery,
     config: &RagConfig,
 ) -> ChronosResult<Vec<ContextSource>> {
+    // Hard limit to prevent DoS via excessive allocation
+    const MAX_ITEMS_LIMIT: usize = 10_000;
+    if config.max_context_items > MAX_ITEMS_LIMIT {
+        return Err(ChronosError::RetrievalFailed(format!(
+            "max_context_items {} exceeds limit {}",
+            config.max_context_items, MAX_ITEMS_LIMIT
+        )));
+    }
+
     // Pre-allocate to avoid resizing.
     // We expect up to max_context_items from each source plus some recent messages.
     // 3 sources * max_context_items + 5 (recent messages padding)
-    let capacity = config.max_context_items * 3 + 5;
+    // Use checked arithmetic to prevent overflow
+    let capacity = config
+        .max_context_items
+        .checked_mul(3)
+        .and_then(|c| c.checked_add(5))
+        .ok_or_else(|| ChronosError::RetrievalFailed("Capacity overflow".to_string()))?;
+
     let mut sources = Vec::with_capacity(capacity);
 
     // Retrieve from each source in parallel (TODO: make truly parallel)

--- a/chronos/tests/augmenter_repro.rs
+++ b/chronos/tests/augmenter_repro.rs
@@ -1,0 +1,46 @@
+#[cfg(test)]
+mod tests {
+    use tardis_chronos::pipeline::{augment, RagConfig, AnalyzedQuery, QueryIntent};
+
+    #[test]
+    fn test_augment_capacity_overflow() {
+        let config = RagConfig {
+            max_context_tokens: (isize::MAX as usize / 4) + 1000,
+            ..RagConfig::default()
+        };
+
+        let analysis = AnalyzedQuery {
+            text: "test".to_string(),
+            intent: QueryIntent::Question,
+            temporal_refs: vec![],
+            temporal_description: None,
+            entities: vec![],
+        };
+
+        // This should return an error now, not panic
+        let result = augment("query", &[], &analysis, &config);
+        assert!(result.is_err(), "Should return error on capacity overflow");
+    }
+
+    #[test]
+    fn test_augment_excessive_limit() {
+        let config = RagConfig {
+            max_context_tokens: 100_001,
+            ..RagConfig::default()
+        };
+
+        let analysis = AnalyzedQuery {
+            text: "test".to_string(),
+            intent: QueryIntent::Question,
+            temporal_refs: vec![],
+            temporal_description: None,
+            entities: vec![],
+        };
+
+        // This should return an error because it exceeds MAX_TOKENS_LIMIT
+        let result = augment("query", &[], &analysis, &config);
+        assert!(result.is_err(), "Should return error on excessive limit");
+        let err = result.err().unwrap().to_string();
+        assert!(err.contains("exceeds limit"), "Error should mention limit");
+    }
+}

--- a/chronos/tests/retriever_repro.rs
+++ b/chronos/tests/retriever_repro.rs
@@ -1,0 +1,71 @@
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use tardis_chronos::pipeline::{retrieve, RagConfig, AnalyzedQuery, QueryIntent};
+    use tardis_common::traits::{KnowledgeService, ConversationService, SystemStateService};
+    use async_trait::async_trait;
+    use tardis_common::Result;
+    use tardis_common::domain::{Entity, Message, Session, Snapshot, Change};
+    use tardis_common::id::{EntityId, SessionId};
+    use std::collections::HashMap;
+    use chrono::{DateTime, Utc};
+
+    #[derive(Debug)]
+    struct MockKnowledge;
+    #[async_trait]
+    impl KnowledgeService for MockKnowledge {
+        async fn insert_entity(&self, _entity: Entity) -> Result<EntityId> { Ok(EntityId::new()) }
+        async fn update_entity(&self, _id: EntityId, _updates: HashMap<String, serde_json::Value>) -> Result<()> { Ok(()) }
+        async fn get_entity(&self, _id: EntityId) -> Result<Option<Entity>> { Ok(None) }
+        async fn get_entity_history(&self, _id: EntityId) -> Result<Vec<Entity>> { Ok(vec![]) }
+        async fn semantic_search(&self, _embedding: &[f32], _limit: usize) -> Result<Vec<Entity>> { Ok(vec![]) }
+        async fn find_entity_by_name(&self, _name: &str) -> Result<Option<Entity>> { Ok(None) }
+        async fn search_history(&self, _query: &str, _time: Option<DateTime<Utc>>, _limit: usize) -> Result<Vec<Entity>> { Ok(vec![]) }
+    }
+
+    #[derive(Debug)]
+    struct MockConversation;
+    #[async_trait]
+    impl ConversationService for MockConversation {
+        async fn create_session(&self) -> Result<SessionId> { Ok(SessionId::new()) }
+        async fn get_session(&self, _id: SessionId) -> Result<Option<Session>> { Ok(None) }
+        async fn end_session(&self, _id: SessionId) -> Result<()> { Ok(()) }
+        async fn add_message(&self, _message: Message) -> Result<EntityId> { Ok(EntityId::new()) }
+        async fn get_recent_messages(&self, _session_id: SessionId, _limit: usize) -> Result<Vec<Message>> { Ok(vec![]) }
+        async fn semantic_search(&self, _embedding: &[f32], _limit: usize) -> Result<Vec<Message>> { Ok(vec![]) }
+    }
+
+    #[derive(Debug)]
+    struct MockSystemState;
+    #[async_trait]
+    impl SystemStateService for MockSystemState {
+        async fn find_snapshot_at(&self, _timestamp: DateTime<Utc>) -> Result<Option<Snapshot>> { Ok(None) }
+        async fn record_change(&self, _change: Change) -> Result<()> { Ok(()) }
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_excessive_limit() {
+        let knowledge: Arc<dyn KnowledgeService> = Arc::new(MockKnowledge);
+        let conversation: Arc<dyn ConversationService> = Arc::new(MockConversation);
+        let system_state: Arc<dyn SystemStateService> = Arc::new(MockSystemState);
+
+        let config = RagConfig {
+            max_context_items: 10_001,
+            ..RagConfig::default()
+        };
+
+        let analysis = AnalyzedQuery {
+            text: "test".to_string(),
+            intent: QueryIntent::Question,
+            temporal_refs: vec![],
+            temporal_description: None,
+            entities: vec![],
+        };
+
+        // This should return an error because it exceeds MAX_ITEMS_LIMIT
+        let result = retrieve(&knowledge, &conversation, &system_state, &analysis, &config).await;
+        assert!(result.is_err(), "Should return error on excessive limit");
+        let err = result.err().unwrap().to_string();
+        assert!(err.contains("exceeds limit"), "Error should mention limit");
+    }
+}

--- a/telemetry/src/trace.rs
+++ b/telemetry/src/trace.rs
@@ -136,15 +136,13 @@ impl fmt::Display for TraceId {
     ///
     /// This implementation is optimized to avoid memory allocation and formatting overhead,
     /// writing directly to a stack-allocated buffer.
-    #[allow(unsafe_code)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut buf = [0u8; 32];
         for (i, &byte) in self.0.iter().enumerate() {
             buf[i * 2] = HEX_CHARS[(byte >> 4) as usize];
             buf[i * 2 + 1] = HEX_CHARS[(byte & 0x0f) as usize];
         }
-        // SAFETY: buf is filled only with ASCII hex characters from HEX_CHARS
-        let s = unsafe { core::str::from_utf8_unchecked(&buf) };
+        let s = core::str::from_utf8(&buf).unwrap_or("INVALID_UTF8");
         f.write_str(s)
     }
 }
@@ -216,15 +214,13 @@ impl fmt::Display for SpanId {
     ///
     /// This implementation is optimized to avoid memory allocation and formatting overhead,
     /// writing directly to a stack-allocated buffer.
-    #[allow(unsafe_code)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut buf = [0u8; 16];
         for (i, &byte) in self.0.iter().enumerate() {
             buf[i * 2] = HEX_CHARS[(byte >> 4) as usize];
             buf[i * 2 + 1] = HEX_CHARS[(byte & 0x0f) as usize];
         }
-        // SAFETY: buf is filled only with ASCII hex characters from HEX_CHARS
-        let s = unsafe { core::str::from_utf8_unchecked(&buf) };
+        let s = core::str::from_utf8(&buf).unwrap_or("INVALID_UTF8");
         f.write_str(s)
     }
 }


### PR DESCRIPTION
This PR addresses security vulnerabilities identified during the "Warden" audit.

### 🛡️ Security Hardening

1.  **DoS Prevention in `chronos`**:
    *   **Threat**: Malicious or misconfigured `RagConfig` could cause integer overflow in buffer capacity calculations or excessive memory allocation, leading to panic or OOM DoS.
    *   **Defense**:
        *   Enforced hard limits: `MAX_TOKENS_LIMIT = 100_000` in `augmenter.rs` and `MAX_ITEMS_LIMIT = 10_000` in `retriever.rs`.
        *   Replaced standard arithmetic with `checked_mul` and `checked_add` when calculating allocation sizes.
        *   Returns `ChronosError::ContextAssemblyFailed` or `ChronosError::RetrievalFailed` on violation instead of panicking.

2.  **Unsafe Code Removal in `telemetry`**:
    *   **Threat**: Use of `unsafe { core::str::from_utf8_unchecked }` in `TraceId` and `SpanId` formatting relied on manual invariants.
    *   **Defense**: Replaced with safe `core::str::from_utf8` and `unwrap_or("INVALID_UTF8")`. The performance impact is negligible, but safety is guaranteed by the compiler.

### 🧪 Verification

*   Added `chronos/tests/augmenter_repro.rs` to verify that `augment` returns `Err` on overflow/excessive limits.
*   Added `chronos/tests/retriever_repro.rs` to verify that `retrieve` returns `Err` on excessive limits.
*   Ran `cargo test --workspace` to ensure no regressions. All tests passed.


---
*PR created automatically by Jules for task [205007582190220154](https://jules.google.com/task/205007582190220154) started by @madmax983*