### PR TITLE
🎻 Bard: Documented Chronos Experimental Modules and Common Traits

### DIFF
--- a/chronos/src/experimental/astrolabe.rs
+++ b/chronos/src/experimental/astrolabe.rs
@@ -64,9 +64,62 @@ impl Astrolabe {
 
     /// Navigate between two entities.
     ///
+    /// Uses A* search to find the most semantically relevant path between two entities.
+    /// The cost function combines hop count with "semantic drag" (1.0 - cosine similarity),
+    /// favoring paths that stay conceptually close to the target.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::sync::Arc;
+    /// use tardis_chronos::experimental::astrolabe::Astrolabe;
+    /// use tardis_gallifrey::Gallifrey;
+    /// use tardis_gallifrey::domain::Entity;
+    /// use tardis_common::temporal::BiTemporalInterval;
+    /// use tardis_common::id::EntityId;
+    /// use std::collections::HashMap;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let gallifrey = Arc::new(Gallifrey::new());
+    ///
+    /// // ... Assume "Earth" and "Gallifrey" entities exist in the store ...
+    /// # let earth = Entity {
+    /// #     id: EntityId::new(),
+    /// #     entity_type: "Planet".to_string(),
+    /// #     name: "Earth".to_string(),
+    /// #     properties: HashMap::new(),
+    /// #     embedding: None,
+    /// #     temporal: BiTemporalInterval::now(),
+    /// #     source: None,
+    /// # };
+    /// # gallifrey.insert(earth).await?;
+    /// # let gal = Entity {
+    /// #     id: EntityId::new(),
+    /// #     entity_type: "Planet".to_string(),
+    /// #     name: "Gallifrey".to_string(),
+    /// #     properties: HashMap::new(),
+    /// #     embedding: None,
+    /// #     temporal: BiTemporalInterval::now(),
+    /// #     source: None,
+    /// # };
+    /// # gallifrey.insert(gal).await?;
+    ///
+    /// let astrolabe = Astrolabe::new(gallifrey);
+    /// let path = astrolabe.navigate("Earth", "Gallifrey")?;
+    ///
+    /// for segment in path {
+    ///     println!("Visited: {}", segment.entity.name);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     /// # Errors
     ///
-    /// Returns an error if entities are not found or path cannot be found.
+    /// Returns an error if:
+    /// - The start or end entities cannot be found by name.
+    /// - No path exists between the entities.
+    /// - The knowledge graph cannot be traversed.
     pub fn navigate(&self, start_name: &str, end_name: &str) -> ChronosResult<Vec<PathSegment>> {
         let start_entity = self.find_entity(start_name)?;
         let end_entity = self.find_entity(end_name)?;
@@ -95,7 +148,9 @@ impl Astrolabe {
         }) = open_set.pop()
         {
             if current_id == end_entity.id {
-                return Ok(Self::reconstruct_path(current_id, &came_from, &entities, &g_score));
+                return Ok(Self::reconstruct_path(
+                    current_id, &came_from, &entities, &g_score,
+                ));
             }
 
             // If we found a shorter path already, skip

--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -2,32 +2,62 @@
 //!
 //! These features are unstable and hidden behind the `nova` feature flag.
 
+/// Psychic Paper: The Universal Interpreter.
+///
+/// Robust parsing for unstructured text, designed to handle the messy output of LLMs or user input.
 #[cfg(feature = "nova")]
 pub mod psychic_paper;
 
+/// Prophecy: The Future Forecast Engine.
+///
+/// Utilizes the Vortex LLM to predict likely future system states based on current context.
 #[cfg(feature = "nova")]
 pub mod prophecy;
 
+/// The System Doctor 🩺.
+///
+/// A self-diagnostic tool that correlates telemetry data (symptoms) with system state changes (causes) to prescribe fixes.
 #[cfg(feature = "nova")]
 pub mod doctor;
 
+/// The Curiosity Engine: Active Learning for Tardis.
+///
+/// Scans the knowledge graph for sparse or ambiguous entities and generates questions to ask the user.
 #[cfg(feature = "nova")]
 pub mod curiosity;
 
+/// The Temporal Fugue: An Alternative Timeline Simulator.
+///
+/// Allows exploring counterfactual scenarios by branching from a specific point in the past.
 #[cfg(feature = "nova")]
 pub mod fugue;
 
+/// The Dreamer: Memory Consolidation Engine.
+///
+/// Processes conversation history (short-term memory) and consolidates it into the Knowledge Graph (long-term memory).
 #[cfg(feature = "nova")]
 pub mod dreamer;
 
+/// The Weaver 🕸️.
+///
+/// A narrative engine that connects seemingly unrelated entities through creative storytelling.
 #[cfg(feature = "nova")]
 pub mod weaver;
 
+/// The Medium: Seance Engine.
+///
+/// Allows querying the system state at a specific point in the past.
 #[cfg(feature = "nova")]
 pub mod medium;
 
+/// The Astrolabe: Semantic Pathfinder.
+///
+/// Implements A* search over the knowledge graph to find semantic paths between entities.
 #[cfg(feature = "nova")]
 pub mod astrolabe;
 
+/// The Prism: Multi-Perspective Analysis Engine.
+///
+/// Breaks down a query into its spectral components, analyzing it from multiple viewpoints (personas).
 #[cfg(feature = "nova")]
 pub mod prism;

--- a/chronos/src/experimental/weaver.rs
+++ b/chronos/src/experimental/weaver.rs
@@ -37,9 +37,40 @@ impl Weaver {
 
     /// Weave a narrative connecting two entities.
     ///
+    /// Generates a creative story explaining the relationship between two entities found in the knowledge graph.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use std::sync::Arc;
+    /// use tardis_chronos::experimental::weaver::Weaver;
+    /// use tardis_gallifrey::Gallifrey;
+    /// use tardis_vortex::Vortex;
+    /// use tardis_vortex::VortexLlmService;
+    /// use tardis_common::id::ModelHandle;
+    /// use tardis_common::traits::{KnowledgeService, LlmService};
+    ///
+    /// # async fn example() -> anyhow::Result<()> {
+    /// let gallifrey = Arc::new(Gallifrey::new());
+    /// let vortex = Arc::new(Vortex::new()?);
+    /// let handle = ModelHandle::new(1);
+    ///
+    /// let knowledge = gallifrey.knowledge();
+    /// let llm = Arc::new(VortexLlmService::new(vortex, handle));
+    ///
+    /// let weaver = Weaver::new(knowledge, llm, Some(handle));
+    ///
+    /// let story = weaver.weave("The Doctor", "TARDIS").await?;
+    /// println!("Story: {}", story);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     /// # Errors
     ///
-    /// Returns an error if entities are not found or inference fails.
+    /// Returns an error if:
+    /// - Either entity cannot be found in the knowledge graph.
+    /// - The LLM inference fails.
     pub async fn weave(&self, entity1_name: &str, entity2_name: &str) -> Result<String> {
         let e1 = self.find_entity(entity1_name).await?;
         let e2 = self.find_entity(entity2_name).await?;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,11 +13,22 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
+/// Core domain entities (Message, Knowledge, SystemState).
 pub mod domain;
+
+/// Unified error handling types.
 pub mod error;
+
+/// Type-safe identifiers (EntityId, SessionId, etc.).
 pub mod id;
+
+/// LLM inference configuration and parameters.
 pub mod llm;
+
+/// Bi-temporal time primitives (Valid Time vs Transaction Time).
 pub mod temporal;
+
+/// Shared service interfaces (Traits for dependency injection).
 pub mod traits;
 
 // Re-export commonly used items

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -168,7 +168,7 @@ impl Router {
     }
 
     /// Tokenize input string respecting quotes.
-    /// Returns a vector of (token, end_offset) tuples.
+    /// Returns a vector of (token, `end_offset`) tuples.
     fn tokenize(input: &str) -> Vec<(String, usize)> {
         let mut tokens = Vec::new();
         let mut current_token = String::new();


### PR DESCRIPTION
Updated documentation for `chronos` experimental modules, including:
- Added module-level documentation for all `nova` features in `chronos/src/experimental/mod.rs`.
- Added detailed docstrings and usage examples for `Astrolabe::navigate` and `Weaver::weave`.
- Added module-level documentation for `tardis-common` submodules.
- Fixed a clippy `doc_markdown` lint in `tardis-shell`.
- Verified with `cargo test --features nova` and `cargo clippy`.

---
*PR created automatically by Jules for task [13144613204464291937](https://jules.google.com/task/13144613204464291937) started by @madmax983*