### PR TITLE
Decouple Chronos from Vortex

### DIFF
--- a/chronos/Cargo.toml
+++ b/chronos/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [features]
-nova = ["telemetry", "tardis-gallifrey/nova", "dep:tardis-vortex"]
+nova = ["telemetry", "tardis-gallifrey/nova"]
 telemetry = ["dep:tardis-telemetry"]
 
 [dependencies]
@@ -20,7 +20,6 @@ tardis-common = { path = "../common" }
 tardis-telemetry = { path = "../telemetry", optional = true }
 # Optional dependency for experimental features
 tardis-gallifrey = { path = "../gallifrey", optional = true }
-tardis-vortex = { path = "../vortex", optional = true }
 
 # Async runtime
 tokio = { workspace = true }

--- a/chronos/src/experimental/curiosity.rs
+++ b/chronos/src/experimental/curiosity.rs
@@ -7,27 +7,28 @@
 
 use crate::error::ChronosResult;
 use std::sync::Arc;
+use tardis_common::id::ModelHandle;
+use tardis_common::llm::InferenceParams;
+use tardis_common::traits::LlmService;
 use tardis_gallifrey::domain::Entity;
 use tardis_gallifrey::Gallifrey;
-use tardis_vortex::config::InferenceParams;
-use tardis_vortex::{ModelHandle, Vortex};
 use tracing::{info, instrument};
 
 /// The Curiosity engine.
 #[derive(Debug)]
 pub struct Curiosity {
     gallifrey: Arc<Gallifrey>,
-    vortex: Arc<Vortex>,
+    llm: Arc<dyn LlmService>,
     model: ModelHandle,
 }
 
 impl Curiosity {
     /// Create a new Curiosity engine.
     #[must_use]
-    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub fn new(gallifrey: Arc<Gallifrey>, llm: Arc<dyn LlmService>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
-            vortex,
+            llm,
             model,
         }
     }
@@ -88,15 +89,14 @@ impl Curiosity {
         // Ask Vortex
         let params = InferenceParams::default()
             .with_temperature(0.8) // Be creative
-            .with_max_tokens(64);
+            .with_max_tokens(64)
+            .with_model(self.model);
 
         let question = self
-            .vortex
-            .infer(self.model, &prompt, params)
+            .llm
+            .infer(&prompt, params)
             .await
-            .map_err(|e| {
-                crate::error::ChronosError::Common(tardis_common::Error::Internal(e.to_string()))
-            })?;
+            .map_err(crate::error::ChronosError::Common)?;
 
         Ok(format!(
             "🤔 Regarding '{}': {}",
@@ -113,7 +113,7 @@ mod tests {
     use std::collections::HashMap;
     use tardis_common::id::EntityId;
     use tardis_common::temporal::BiTemporalInterval;
-    use tardis_vortex::ModelLoadConfig;
+    use tardis_vortex::{ModelLoadConfig, Vortex, VortexLlmService};
 
     fn create_sparse_entity(name: &str) -> Entity {
         Entity {
@@ -151,7 +151,8 @@ mod tests {
             .await
             .unwrap();
 
-        let curiosity = Curiosity::new(gallifrey, vortex, handle);
+        let llm = Arc::new(VortexLlmService::new(vortex, handle));
+        let curiosity = Curiosity::new(gallifrey, llm, handle);
 
         let question = curiosity.ask().await.unwrap();
 
@@ -173,7 +174,8 @@ mod tests {
             .await
             .unwrap();
 
-        let curiosity = Curiosity::new(gallifrey, vortex, handle);
+        let llm = Arc::new(VortexLlmService::new(vortex, handle));
+        let curiosity = Curiosity::new(gallifrey, llm, handle);
 
         let response = curiosity.ask().await.unwrap();
         assert!(response.contains("I am content"));

--- a/chronos/src/experimental/doctor.rs
+++ b/chronos/src/experimental/doctor.rs
@@ -6,10 +6,12 @@
 use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tardis_common::id::ModelHandle;
+use tardis_common::llm::InferenceParams;
+use tardis_common::traits::LlmService;
 use tardis_gallifrey::Gallifrey;
 use tardis_telemetry::gallifrey::TelemetryStore;
 use tardis_telemetry::types::Level;
-use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
 
 /// Vital signs of the system.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,7 +62,7 @@ pub struct Prescription {
 pub struct SystemDoctor {
     telemetry: Arc<TelemetryStore>,
     gallifrey: Arc<Gallifrey>,
-    vortex: Option<Arc<Vortex>>,
+    llm: Option<Arc<dyn LlmService>>,
     model_handle: Option<ModelHandle>,
 }
 
@@ -71,15 +73,15 @@ impl SystemDoctor {
         Self {
             telemetry,
             gallifrey,
-            vortex: None,
+            llm: None,
             model_handle: None,
         }
     }
 
-    /// Attach Vortex AI engine.
+    /// Attach LLM service.
     #[must_use]
-    pub fn with_vortex(mut self, vortex: Arc<Vortex>) -> Self {
-        self.vortex = Some(vortex);
+    pub fn with_llm(mut self, llm: Arc<dyn LlmService>) -> Self {
+        self.llm = Some(llm);
         self
     }
 
@@ -186,7 +188,7 @@ impl SystemDoctor {
         // Correlate with system changes (Heuristic or AI)
         let mut root_causes = Vec::new();
 
-        if let (Some(vortex), Some(handle)) = (&self.vortex, self.model_handle) {
+        if let (Some(llm), Some(handle)) = (&self.llm, self.model_handle) {
             // AI-Enhanced Diagnosis
             if status != HealthStatus::Healthy {
                 let changes_str = if changes_desc.is_empty() {
@@ -211,14 +213,15 @@ impl SystemDoctor {
                     max_tokens: 200,
                     temperature: 0.7,
                     ..InferenceParams::default()
-                };
+                }
+                .with_model(handle);
 
-                match vortex.infer(handle, &prompt, params).await {
+                match llm.infer(&prompt, params).await {
                     Ok(response) => {
                         root_causes.push(format!("[AI] {}", response.trim()));
                     }
                     Err(e) => {
-                        root_causes.push(format!("[AI Error] Failed to consult Vortex: {e}"));
+                        root_causes.push(format!("[AI Error] Failed to consult LLM: {e}"));
                     }
                 }
             }
@@ -264,6 +267,7 @@ mod tests {
     use std::time::Instant;
     use tardis_telemetry::types::{SpanId, Subsystem, TraceId};
     use tardis_telemetry::userspace::layer::{EventData, SpanData};
+    use tardis_vortex::{Vortex, VortexLlmService};
 
     #[tokio::test]
     async fn test_doctor_diagnosis() {
@@ -327,9 +331,10 @@ mod tests {
         }));
 
         let handle = ModelHandle::new(1); // Dummy handle
+        let llm = Arc::new(VortexLlmService::new(vortex, handle));
 
         let doctor = SystemDoctor::new(Arc::clone(&telemetry), gallifrey)
-            .with_vortex(vortex)
+            .with_llm(llm)
             .with_model(handle);
 
         // Inject an error to trigger diagnosis

--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -12,20 +12,20 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::sync::Arc;
-use tardis_common::id::EntityId;
+use tardis_common::id::{EntityId, ModelHandle};
+use tardis_common::llm::InferenceParams;
 use tardis_common::temporal::BiTemporalInterval;
+use tardis_common::traits::LlmService;
 use tardis_common::SessionId;
 use tardis_gallifrey::domain::Entity;
 use tardis_gallifrey::Gallifrey;
-use tardis_vortex::config::InferenceParams;
-use tardis_vortex::{ModelHandle, Vortex};
 use tracing::{info, instrument};
 
 /// The Dreamer engine.
 #[derive(Debug)]
 pub struct Dreamer {
     gallifrey: Arc<Gallifrey>,
-    vortex: Arc<Vortex>,
+    llm: Arc<dyn LlmService>,
     model: ModelHandle,
     paper: PsychicPaper,
 }
@@ -43,10 +43,10 @@ struct DreamEntity {
 impl Dreamer {
     /// Create a new Dreamer engine.
     #[must_use]
-    pub const fn new(gallifrey: Arc<Gallifrey>, vortex: Arc<Vortex>, model: ModelHandle) -> Self {
+    pub fn new(gallifrey: Arc<Gallifrey>, llm: Arc<dyn LlmService>, model: ModelHandle) -> Self {
         Self {
             gallifrey,
-            vortex,
+            llm,
             model,
             paper: PsychicPaper::new(),
         }
@@ -97,11 +97,12 @@ impl Dreamer {
         // 3. Inference
         let params = InferenceParams::default()
             .with_temperature(0.3) // Be factual
-            .with_max_tokens(1024);
+            .with_max_tokens(1024)
+            .with_model(self.model);
 
         let response = self
-            .vortex
-            .infer(self.model, &prompt, params)
+            .llm
+            .infer(&prompt, params)
             .await
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
 
@@ -159,7 +160,7 @@ mod tests {
     use chrono::Utc;
     use serde_json::json;
     use tardis_gallifrey::domain::{Message, Role};
-    use tardis_vortex::ModelLoadConfig;
+    use tardis_vortex::{ModelLoadConfig, Vortex, VortexLlmService};
 
     #[tokio::test]
     async fn test_dreamer_consolidates_memory() {
@@ -202,7 +203,8 @@ mod tests {
             .await
             .unwrap();
 
-        let dreamer = Dreamer::new(gallifrey.clone(), vortex, handle);
+        let llm = Arc::new(VortexLlmService::new(vortex, handle));
+        let dreamer = Dreamer::new(gallifrey.clone(), llm, handle);
 
         let ids = dreamer.dream(session_id).await.unwrap();
 

--- a/chronos/src/experimental/fugue.rs
+++ b/chronos/src/experimental/fugue.rs
@@ -13,10 +13,10 @@ use serde_json::Value;
 use std::cmp::Ordering;
 use std::fmt::Write;
 use std::sync::Arc;
-use tardis_common::id::ModelHandle;
+use tardis_common::llm::InferenceParams;
+use tardis_common::traits::LlmService;
 use tardis_gallifrey::domain::Entity;
 use tardis_gallifrey::Gallifrey;
-use tardis_vortex::{InferenceParams, Vortex};
 use tracing::{info, instrument};
 
 /// An event in the alternative timeline.
@@ -40,7 +40,7 @@ pub struct FugueResult {
 /// The Fugue engine.
 #[derive(Debug)]
 pub struct Fugue {
-    vortex: Arc<Vortex>,
+    llm: Arc<dyn LlmService>,
     gallifrey: Arc<Gallifrey>,
     paper: PsychicPaper,
 }
@@ -48,9 +48,9 @@ pub struct Fugue {
 impl Fugue {
     /// Create a new Fugue engine.
     #[must_use]
-    pub const fn new(vortex: Arc<Vortex>, gallifrey: Arc<Gallifrey>) -> Self {
+    pub fn new(llm: Arc<dyn LlmService>, gallifrey: Arc<Gallifrey>) -> Self {
         Self {
-            vortex,
+            llm,
             gallifrey,
             paper: PsychicPaper::new(),
         }
@@ -67,16 +67,15 @@ impl Fugue {
         divergence_time: DateTime<Utc>,
         counterfactual: &str,
         horizon: Duration,
-        model: ModelHandle,
     ) -> ChronosResult<FugueResult> {
         info!("Initiating Temporal Fugue at {}", divergence_time);
 
         // 1. Embed the counterfactual to find relevant context
         let embedding = self
-            .vortex
-            .embed(model, counterfactual)
+            .llm
+            .embed(counterfactual)
             .await
-            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            .map_err(ChronosError::Common)?;
 
         // 2. Scan history for relevant entities active at the divergence time
         let candidates_cell = std::sync::Mutex::new(Vec::new());
@@ -138,9 +137,8 @@ impl Fugue {
 
         // 4. Inference
         let response = self
-            .vortex
+            .llm
             .infer(
-                model,
                 &prompt,
                 InferenceParams {
                     max_tokens: 1024,
@@ -149,7 +147,7 @@ impl Fugue {
                 },
             )
             .await
-            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            .map_err(ChronosError::Common)?;
 
         // 5. Parse
         let parsed = self
@@ -205,6 +203,7 @@ mod tests {
     use std::collections::HashMap;
     use tardis_common::id::EntityId;
     use tardis_common::temporal::BiTemporalInterval;
+    use tardis_vortex::{Vortex, VortexLlmService};
 
     #[tokio::test]
     async fn test_fugue_simulation() {
@@ -247,12 +246,14 @@ mod tests {
         };
         gallifrey.knowledge().insert_entity(entity).unwrap();
 
-        let fugue = Fugue::new(vortex, gallifrey);
         let model = ModelHandle::new(1);
+        let llm = Arc::new(VortexLlmService::new(vortex, model));
+
+        let fugue = Fugue::new(llm, gallifrey);
         let divergence_time = Utc::now();
 
         let result = fugue
-            .simulate(divergence_time, "Database crash", Duration::hours(1), model)
+            .simulate(divergence_time, "Database crash", Duration::hours(1))
             .await
             .unwrap();
 

--- a/chronos/src/experimental/prism.rs
+++ b/chronos/src/experimental/prism.rs
@@ -10,7 +10,7 @@ use crate::experimental::psychic_paper::{Intent, PsychicPaper};
 use crate::{Chronos, RagConfig};
 use std::sync::Arc;
 use tardis_common::id::ModelHandle;
-use tardis_vortex::{InferenceParams, Vortex};
+use tardis_common::llm::InferenceParams;
 use tracing::{info, instrument, warn};
 
 /// A result from a single perspective.
@@ -26,7 +26,6 @@ pub struct PerspectiveResult {
 #[derive(Debug)]
 pub struct Prism {
     chronos: Arc<Chronos>,
-    vortex: Arc<Vortex>,
     paper: PsychicPaper,
 }
 
@@ -34,10 +33,8 @@ impl Prism {
     /// Create a new Prism engine.
     #[must_use]
     pub fn new(chronos: Arc<Chronos>) -> Self {
-        let vortex = chronos.vortex().clone();
         Self {
             chronos,
-            vortex,
             paper: PsychicPaper::new(),
         }
     }
@@ -64,13 +61,15 @@ impl Prism {
 
         let params = InferenceParams::default()
             .with_temperature(0.7)
-            .with_max_tokens(100);
+            .with_max_tokens(100)
+            .with_model(model);
 
         let response = self
-            .vortex
-            .infer(model, &prompt, params)
+            .chronos
+            .llm()
+            .infer(&prompt, params)
             .await
-            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            .map_err(ChronosError::Common)?;
 
         let perspectives_val = self
             .paper
@@ -140,8 +139,7 @@ mod tests {
     use tardis_common::traits::{
         ConversationService, KnowledgeService, LlmService, SystemStateService,
     };
-    use tardis_vortex::ModelLoadConfig;
-    use tardis_vortex::VortexLlmService;
+    use tardis_vortex::{ModelLoadConfig, Vortex, VortexLlmService};
 
     #[tokio::test]
     async fn test_refract_flow() {

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -10,25 +10,25 @@ use crate::experimental::psychic_paper::{Intent, PsychicPaper};
 use std::sync::Arc;
 use std::time::Duration;
 use tardis_common::id::{EntityId, ModelHandle};
+use tardis_common::llm::InferenceParams;
 use tardis_common::temporal::{BiTemporalInterval, TimeRange};
+use tardis_common::traits::LlmService;
 use tardis_gallifrey::domain::Entity;
-use tardis_vortex::InferenceParams;
-use tardis_vortex::Vortex;
 use tracing::{info, instrument};
 
 /// The Prophet engine.
 #[derive(Debug)]
 pub struct Prophet {
-    vortex: Arc<Vortex>,
+    llm: Arc<dyn LlmService>,
     paper: PsychicPaper,
 }
 
 impl Prophet {
     /// Create a new Prophet.
     #[must_use]
-    pub const fn new(vortex: Arc<Vortex>) -> Self {
+    pub fn new(llm: Arc<dyn LlmService>) -> Self {
         Self {
-            vortex,
+            llm,
             paper: PsychicPaper::new(),
         }
     }
@@ -56,18 +56,18 @@ impl Prophet {
         );
 
         let response = self
-            .vortex
+            .llm
             .infer(
-                model,
                 &prompt,
                 InferenceParams {
                     max_tokens: 512,
                     temperature: 0.7,
                     ..Default::default()
-                },
+                }
+                .with_model(model),
             )
             .await
-            .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
+            .map_err(ChronosError::Common)?;
 
         let parsed = self
             .paper
@@ -135,6 +135,7 @@ impl Prophet {
 mod tests {
     use super::*;
     use serde_json::json;
+    use tardis_vortex::{Vortex, VortexLlmService};
 
     #[tokio::test]
     async fn test_foresee() {
@@ -155,8 +156,10 @@ mod tests {
             Ok(response.to_string())
         }));
 
-        let prophet = Prophet::new(vortex);
         let model = ModelHandle::new(1);
+        let llm = Arc::new(VortexLlmService::new(vortex, model));
+
+        let prophet = Prophet::new(llm);
 
         let predictions = prophet
             .foresee(

--- a/chronos/src/pipeline/mod.rs
+++ b/chronos/src/pipeline/mod.rs
@@ -47,8 +47,6 @@ use tardis_common::llm::InferenceParams;
 use tardis_common::traits::{
     ConversationService, KnowledgeService, LlmService, SystemStateService,
 };
-#[cfg(feature = "nova")]
-use tardis_vortex::{Vortex, VortexLlmService};
 use tracing::{info, instrument};
 
 /// Configuration for a RAG query.
@@ -171,24 +169,6 @@ impl Chronos {
             conversation,
             system_state,
         }
-    }
-
-    /// Get the underlying Vortex engine (Nova only).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the LLM service is not a `VortexLlmService`.
-    #[cfg(feature = "nova")]
-    #[must_use]
-    #[allow(clippy::panic)]
-    pub fn vortex(&self) -> &Arc<Vortex> {
-        self.llm
-            .as_any()
-            .downcast_ref::<VortexLlmService>()
-            .map_or_else(
-                || panic!("LlmService is not VortexLlmService"),
-                VortexLlmService::engine,
-            )
     }
 
     /// Get the LLM service.

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -100,13 +100,17 @@ impl ShellCommand for SonicCommand {
             return Ok(CommandResult::Continue);
         }
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex required")
+            .list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let screwdriver = SonicScrewdriver::new(
             context.telemetry.clone(),
             Some(Arc::clone(&context.gallifrey)),
-            Some(context.chronos.vortex().clone()),
+            Some(context.chronos.llm()),
             model_handle,
         );
 
@@ -220,11 +224,15 @@ impl ShellCommand for DreamCommand {
     }
 
     async fn execute(&self, _args: &[String], context: &CommandContext) -> Result<CommandResult> {
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex required")
+            .list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let dreamer = Dreamer::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex().clone(),
+                context.chronos.llm(),
                 *handle,
             );
 
@@ -279,13 +287,17 @@ impl ShellCommand for FixCommand {
             return Ok(CommandResult::Continue);
         }
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex required")
+            .list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let screwdriver = SonicScrewdriver::new(
             context.telemetry.clone(),
             Some(Arc::clone(&context.gallifrey)),
-            Some(context.chronos.vortex().clone()),
+            Some(context.chronos.llm()),
             model_handle,
         );
 
@@ -490,12 +502,16 @@ impl ShellCommand for BiographerCommand {
         }
         let entity_name = args.join(" ");
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex required")
+            .list_loaded_models();
         let model_handle = loaded_models.first().map(|(h, _)| *h);
 
         let biographer = Biographer::new(
             Arc::clone(&context.gallifrey),
-            context.chronos.vortex().clone(),
+            context.chronos.llm(),
             model_handle,
         );
 
@@ -536,11 +552,15 @@ impl ShellCommand for CuriosityCommand {
     }
 
     async fn execute(&self, _args: &[String], context: &CommandContext) -> Result<CommandResult> {
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex required")
+            .list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let curiosity = Curiosity::new(
                 Arc::clone(&context.gallifrey),
-                context.chronos.vortex().clone(),
+                context.chronos.llm(),
                 *handle,
             );
 
@@ -657,7 +677,11 @@ impl ShellCommand for WeaveCommand {
         let entity1 = &args[0];
         let entity2 = &args[1];
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex required")
+            .list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let weaver = Weaver::new(
                 context.gallifrey.knowledge(),
@@ -719,7 +743,11 @@ impl ShellCommand for MediumCommand {
             }
         };
 
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex required")
+            .list_loaded_models();
         if let Some((handle, _)) = loaded_models.first() {
             let medium = Medium::new(
                 context.gallifrey.knowledge(),
@@ -770,7 +798,11 @@ impl ShellCommand for PrismCommand {
         }
 
         let query = args.join(" ");
-        let loaded_models = context.chronos.vortex().list_loaded_models();
+        let loaded_models = context
+            .vortex
+            .as_ref()
+            .expect("Vortex required")
+            .list_loaded_models();
 
         if let Some((handle, _)) = loaded_models.first() {
             let prism = Prism::new(context.chronos.clone());

--- a/shell/src/commands/traits.rs
+++ b/shell/src/commands/traits.rs
@@ -9,6 +9,8 @@ use tardis_telemetry::gallifrey::TelemetryStore;
 
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::prophecy::Prophet;
+#[cfg(feature = "nova")]
+use tardis_vortex::Vortex;
 
 /// Context provided to every shell command.
 pub struct CommandContext {
@@ -21,6 +23,9 @@ pub struct CommandContext {
     /// Access to the Prophet Engine (optional, Nova only).
     #[cfg(feature = "nova")]
     pub prophet: Option<Arc<Prophet>>,
+    /// Access to the Vortex Engine (optional, Nova only).
+    #[cfg(feature = "nova")]
+    pub vortex: Option<Arc<Vortex>>,
     /// The current session ID.
     pub session_id: SessionId,
 }
@@ -34,6 +39,8 @@ impl fmt::Debug for CommandContext {
 
         #[cfg(feature = "nova")]
         d.field("prophet", &self.prophet.is_some());
+        #[cfg(feature = "nova")]
+        d.field("vortex", &self.vortex.is_some());
 
         d.field("session_id", &self.session_id).finish()
     }

--- a/shell/src/experimental/biographer.rs
+++ b/shell/src/experimental/biographer.rs
@@ -5,27 +5,29 @@
 
 use std::fmt::Write;
 use std::sync::Arc;
+use tardis_common::id::ModelHandle;
+use tardis_common::llm::InferenceParams;
+use tardis_common::traits::LlmService;
 use tardis_gallifrey::Gallifrey;
-use tardis_vortex::{InferenceParams, ModelHandle, Vortex};
 
 /// The Biographer engine.
 #[derive(Debug)]
 pub struct Biographer {
     gallifrey: Arc<Gallifrey>,
-    vortex: Arc<Vortex>,
+    llm: Arc<dyn LlmService>,
     model: Option<ModelHandle>,
 }
 
 impl Biographer {
     /// Create a new Biographer.
-    pub const fn new(
+    pub fn new(
         gallifrey: Arc<Gallifrey>,
-        vortex: Arc<Vortex>,
+        llm: Arc<dyn LlmService>,
         model: Option<ModelHandle>,
     ) -> Self {
         Self {
             gallifrey,
-            vortex,
+            llm,
             model,
         }
     }
@@ -97,9 +99,14 @@ impl Biographer {
                 max_tokens: 500,
                 temperature: 0.7,
                 ..Default::default()
-            };
+            }
+            .with_model(handle);
 
-            let bio = self.vortex.infer(handle, &prompt, params).await?;
+            let bio = self
+                .llm
+                .infer(&prompt, params)
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
             Ok(bio)
         } else {
             // Fallback if no model is loaded
@@ -116,6 +123,7 @@ mod tests {
     use tardis_common::id::EntityId;
     use tardis_common::temporal::BiTemporalInterval;
     use tardis_gallifrey::domain::Entity;
+    use tardis_vortex::{Vortex, VortexLlmService};
 
     #[tokio::test]
     async fn test_biography_generation() {
@@ -151,7 +159,10 @@ mod tests {
         gallifrey.insert(entity).await.unwrap();
 
         // Test fallback (no model)
-        let bio = Biographer::new(gallifrey.clone(), vortex.clone(), None);
+        let model = ModelHandle::new(0); // dummy
+        let llm = Arc::new(VortexLlmService::new(vortex, model));
+
+        let bio = Biographer::new(gallifrey.clone(), llm, None);
         let result = bio.biography("The Doctor").await.unwrap();
 
         assert!(result.contains("The Doctor"));

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -14,9 +14,10 @@ use std::path::Path;
 use std::sync::Arc;
 use tardis_chronos::experimental::doctor::{HealthStatus, SystemDoctor};
 use tardis_chronos::experimental::psychic_paper::{Intent, PsychicPaper};
+use tardis_common::id::ModelHandle;
+use tardis_common::traits::LlmService;
 use tardis_gallifrey::Gallifrey;
 use tardis_telemetry::gallifrey::TelemetryStore;
-use tardis_vortex::{ModelHandle, Vortex};
 
 /// Maximum file size for inspection/repair (10 MB).
 const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
@@ -27,24 +28,24 @@ pub struct SonicScrewdriver {
     paper: PsychicPaper,
     telemetry: Option<Arc<TelemetryStore>>,
     gallifrey: Option<Arc<Gallifrey>>,
-    vortex: Option<Arc<Vortex>>,
+    llm: Option<Arc<dyn LlmService>>,
     model_handle: Option<ModelHandle>,
 }
 
 impl SonicScrewdriver {
     /// Create a new Sonic Screwdriver.
     #[must_use]
-    pub const fn new(
+    pub fn new(
         telemetry: Option<Arc<TelemetryStore>>,
         gallifrey: Option<Arc<Gallifrey>>,
-        vortex: Option<Arc<Vortex>>,
+        llm: Option<Arc<dyn LlmService>>,
         model_handle: Option<ModelHandle>,
     ) -> Self {
         Self {
             paper: PsychicPaper::new(),
             telemetry,
             gallifrey,
-            vortex,
+            llm,
             model_handle,
         }
     }
@@ -61,8 +62,8 @@ impl SonicScrewdriver {
 
         let mut doctor = SystemDoctor::new(telemetry.clone(), gallifrey.clone());
 
-        if let Some(vortex) = &self.vortex {
-            doctor = doctor.with_vortex(vortex.clone());
+        if let Some(llm) = &self.llm {
+            doctor = doctor.with_llm(llm.clone());
         }
 
         if let Some(handle) = self.model_handle {
@@ -321,6 +322,7 @@ mod tests {
         use std::collections::HashMap;
         use tardis_telemetry::types::{Level, Subsystem, TraceId};
         use tardis_telemetry::userspace::layer::EventData;
+        use tardis_vortex::{Vortex, VortexLlmService};
 
         // Setup dependencies
         let telemetry = Arc::new(TelemetryStore::new());
@@ -343,6 +345,8 @@ mod tests {
             Ok(expected_diagnosis.to_string())
         }));
 
+        let llm = Arc::new(VortexLlmService::new(vortex, handle));
+
         // Inject an error to trigger diagnosis
         let error_event = EventData {
             span_id: None,
@@ -357,7 +361,7 @@ mod tests {
 
         // Run Sonic Screwdriver
         let sonic =
-            SonicScrewdriver::new(Some(telemetry), Some(gallifrey), Some(vortex), Some(handle));
+            SonicScrewdriver::new(Some(telemetry), Some(gallifrey), Some(llm), Some(handle));
 
         let report = sonic.diagnose().await.unwrap();
 

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -34,10 +34,11 @@ async fn main() -> Result<()> {
     // Create adapter for Chronos
     // Use a placeholder handle for now - in a real system this would be the system model
     let model_handle = ModelHandle::new(0);
-    let llm_service = Arc::new(VortexLlmService::new(vortex.clone(), model_handle));
+    let llm_service: Arc<dyn tardis_common::traits::LlmService> =
+        Arc::new(VortexLlmService::new(vortex.clone(), model_handle));
 
     let chronos = Arc::new(Chronos::new(
-        llm_service,
+        llm_service.clone(),
         gallifrey.knowledge(),
         gallifrey.conversation(),
         gallifrey.system_state(),
@@ -47,11 +48,17 @@ async fn main() -> Result<()> {
     print_banner();
 
     #[cfg(feature = "nova")]
-    let prophet = Arc::new(Prophet::new(vortex.clone()));
+    let prophet = Arc::new(Prophet::new(llm_service));
 
     // Create and run REPL
     #[cfg(feature = "nova")]
-    let mut repl = Repl::new(chronos, gallifrey, telemetry_store, Some(prophet))?;
+    let mut repl = Repl::new(
+        chronos,
+        gallifrey,
+        telemetry_store,
+        Some(prophet),
+        Some(vortex),
+    )?;
 
     #[cfg(not(feature = "nova"))]
     let mut repl = Repl::new(chronos, gallifrey, telemetry_store)?;

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -16,6 +16,8 @@ use tracing::{error, info};
 
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::prophecy::Prophet;
+#[cfg(feature = "nova")]
+use tardis_vortex::Vortex;
 
 /// The main REPL for Tardis shell.
 #[derive(Debug)]
@@ -36,6 +38,9 @@ pub struct Repl {
     /// Prophet engine (optional, Nova only).
     #[cfg(feature = "nova")]
     prophet: Option<Arc<Prophet>>,
+    /// Vortex engine (optional, Nova only).
+    #[cfg(feature = "nova")]
+    vortex: Option<Arc<Vortex>>,
     /// Current session ID.
     session_id: SessionId,
     /// Whether to continue running.
@@ -56,6 +61,7 @@ impl Repl {
         gallifrey: Arc<Gallifrey>,
         telemetry_store: Option<Arc<TelemetryStore>>,
         #[cfg(feature = "nova")] prophet: Option<Arc<Prophet>>,
+        #[cfg(feature = "nova")] vortex: Option<Arc<Vortex>>,
     ) -> Result<Self> {
         let editor = DefaultEditor::new()?;
 
@@ -82,6 +88,8 @@ impl Repl {
             telemetry_store,
             #[cfg(feature = "nova")]
             prophet,
+            #[cfg(feature = "nova")]
+            vortex,
             session_id,
             running: true,
             #[cfg(feature = "nova")]
@@ -199,6 +207,8 @@ impl Repl {
                 telemetry: self.telemetry_store.clone(),
                 #[cfg(feature = "nova")]
                 prophet: self.prophet.clone(),
+                #[cfg(feature = "nova")]
+                vortex: self.vortex.clone(),
                 session_id: self.session_id,
             };
 


### PR DESCRIPTION
Decoupled `tardis-chronos` from `tardis-vortex` by replacing direct usages of `Vortex` with the `LlmService` trait from `tardis-common`.

Changes:
- Removed `Chronos::vortex()` method.
- Refactored experimental modules (`Prism`, `Prophet`, `Doctor`, `Curiosity`, `Fugue`, `Dreamer`) in `chronos` to use `Arc<dyn LlmService>`.
- Refactored `SonicScrewdriver` and `Biographer` in `shell` to use `Arc<dyn LlmService>`.
- Updated `tardis-shell` to pass `LlmService` to commands and engines.
- Updated `CommandContext` in `shell` to include `vortex` explicitly for model management commands, while logic uses `chronos.llm()`.
- Removed `tardis-vortex` from `[dependencies]` in `chronos/Cargo.toml` (kept in `[dev-dependencies]`).
- Updated `Fugue::simulate` to remove `ModelHandle` parameter for consistency.

This ensures `chronos` is agnostic of the LLM implementation, adhering to the dependency inversion principle.

---
*PR created automatically by Jules for task [517784929910771291](https://jules.google.com/task/517784929910771291) started by @madmax983*