### PR TITLE
refactor(chronos): simplify PsychicPaper interpreter

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** "Enterprise FizzBuzz" in `chronos::analyzer`. Generic closures + optimizations for <30 char strings + `TemporalRule` struct for 3 keywords.
 **Cut:** Removed generics, removed length-based optimization, used direct string matching.
 **Saved:** ~50 lines of complex code, removed `TemporalRule` and `TimeOffset` types, removed `contains_ignore_ascii_case` helper.
+
+## [Reduction]
+**Bloat:** Over-engineered "PsychicPaper" interpreter with `Intent` enum dispatch, stateful struct, and heuristic guessing for specific formats.
+**Cut:** Replaced with stateless module functions (`extract_json`, `parse_list`, `parse_kv`, `repair_structure`). Removed `PsychicPaper` struct and `Intent` enum.
+**Saved:** ~50 lines of boilerplate, removed enum dispatch, clearer call sites, fixed buggy behavior in `SonicScrewdriver`.

--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -6,7 +6,7 @@
 //! it into the Knowledge Graph (long-term memory) by extracting key entities and facts.
 
 use crate::error::{ChronosError, ChronosResult};
-use crate::experimental::psychic_paper::{Intent, PsychicPaper};
+use crate::experimental::psychic_paper;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -27,7 +27,6 @@ pub struct Dreamer {
     gallifrey: Arc<Gallifrey>,
     vortex: Arc<Vortex>,
     model: ModelHandle,
-    paper: PsychicPaper,
 }
 
 /// A simplified entity structure for LLM generation.
@@ -48,7 +47,6 @@ impl Dreamer {
             gallifrey,
             vortex,
             model,
-            paper: PsychicPaper::new(),
         }
     }
 
@@ -106,9 +104,7 @@ impl Dreamer {
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
 
         // 4. Parse output
-        let parsed = self
-            .paper
-            .interpret(&response, Intent::Json)
+        let parsed = psychic_paper::extract_json(&response)
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e)))?;
 
         let dream_entities: Vec<DreamEntity> = serde_json::from_value(parsed)

--- a/chronos/src/experimental/fugue.rs
+++ b/chronos/src/experimental/fugue.rs
@@ -6,7 +6,7 @@
 //! in the past and simulating the consequences using Vortex inference.
 
 use crate::error::{ChronosError, ChronosResult};
-use crate::experimental::psychic_paper::{Intent, PsychicPaper};
+use crate::experimental::psychic_paper;
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -42,7 +42,6 @@ pub struct FugueResult {
 pub struct Fugue {
     vortex: Arc<Vortex>,
     gallifrey: Arc<Gallifrey>,
-    paper: PsychicPaper,
 }
 
 impl Fugue {
@@ -52,7 +51,6 @@ impl Fugue {
         Self {
             vortex,
             gallifrey,
-            paper: PsychicPaper::new(),
         }
     }
 
@@ -152,9 +150,7 @@ impl Fugue {
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
 
         // 5. Parse
-        let parsed = self
-            .paper
-            .interpret(&response, Intent::Json)
+        let parsed = psychic_paper::extract_json(&response)
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e)))?;
 
         let narrative = parsed

--- a/chronos/src/experimental/prism.rs
+++ b/chronos/src/experimental/prism.rs
@@ -6,7 +6,7 @@
 //! from multiple viewpoints (personas) simultaneously to provide a comprehensive answer.
 
 use crate::error::{ChronosError, ChronosResult};
-use crate::experimental::psychic_paper::{Intent, PsychicPaper};
+use crate::experimental::psychic_paper;
 use crate::{Chronos, RagConfig};
 use std::sync::Arc;
 use tardis_common::id::ModelHandle;
@@ -27,7 +27,6 @@ pub struct PerspectiveResult {
 pub struct Prism {
     chronos: Arc<Chronos>,
     vortex: Arc<Vortex>,
-    paper: PsychicPaper,
 }
 
 impl Prism {
@@ -38,7 +37,6 @@ impl Prism {
         Self {
             chronos,
             vortex,
-            paper: PsychicPaper::new(),
         }
     }
 
@@ -72,9 +70,7 @@ impl Prism {
             .await
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
 
-        let perspectives_val = self
-            .paper
-            .interpret(&response, Intent::Json)
+        let perspectives_val = psychic_paper::extract_json(&response)
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e)))?;
 
         let mut perspectives: Vec<String> =

--- a/chronos/src/experimental/prophecy.rs
+++ b/chronos/src/experimental/prophecy.rs
@@ -6,7 +6,7 @@
 //! based on current context.
 
 use crate::error::{ChronosError, ChronosResult};
-use crate::experimental::psychic_paper::{Intent, PsychicPaper};
+use crate::experimental::psychic_paper;
 use std::sync::Arc;
 use std::time::Duration;
 use tardis_common::id::{EntityId, ModelHandle};
@@ -20,7 +20,6 @@ use tracing::{info, instrument};
 #[derive(Debug)]
 pub struct Prophet {
     vortex: Arc<Vortex>,
-    paper: PsychicPaper,
 }
 
 impl Prophet {
@@ -29,7 +28,6 @@ impl Prophet {
     pub const fn new(vortex: Arc<Vortex>) -> Self {
         Self {
             vortex,
-            paper: PsychicPaper::new(),
         }
     }
 
@@ -69,9 +67,7 @@ impl Prophet {
             .await
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e.to_string())))?;
 
-        let parsed = self
-            .paper
-            .interpret(&response, Intent::Json)
+        let parsed = psychic_paper::extract_json(&response)
             .map_err(|e| ChronosError::Common(tardis_common::Error::Internal(e)))?;
 
         let mut predictions = Vec::new();

--- a/chronos/src/experimental/psychic_paper.rs
+++ b/chronos/src/experimental/psychic_paper.rs
@@ -7,211 +7,141 @@
 
 use serde_json::{json, Value};
 
-/// The intent of the interpretation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Intent {
-    /// Try to infer the format using a best-effort heuristic:
-    /// 1. Check for JSON start characters `{` or `[`.
-    /// 2. Check for Markdown code blocks (` ```json `).
-    /// 3. Check for list markers (`-` or `*`).
-    /// 4. Check for Key-Value pairs (majority of lines have `:`).
-    /// 5. Fallback to raw string.
-    Auto,
-    /// Expect JSON (strips markdown code blocks).
-    Json,
-    /// Expect a list (bullets, numbered, or comma-separated).
-    List,
-    /// Expect Key-Value pairs (e.g., "Name: Doctor").
-    KeyValue,
+/// Extract JSON from a string, handling markdown blocks and surrounding text.
+///
+/// # Errors
+///
+/// Returns an error if no valid JSON object or array can be found.
+pub fn extract_json(text: &str) -> Result<Value, String> {
+    // 1. Try direct parse
+    if let Ok(v) = serde_json::from_str(text) {
+        return Ok(v);
+    }
+
+    // 2. Try to find JSON block
+    let start = text.find(['{', '[']);
+    let end = text.rfind(['}', ']']);
+
+    if let (Some(s), Some(e)) = (start, end) {
+        if s <= e {
+            if let Ok(v) = serde_json::from_str(&text[s..=e]) {
+                return Ok(v);
+            }
+        }
+    }
+
+    Err("Could not find valid JSON".to_string())
 }
 
-/// The Psychic Paper interpreter.
-#[derive(Debug, Default)]
-pub struct PsychicPaper;
-
-#[allow(
-    clippy::unused_self,
-    clippy::unnecessary_wraps,
-    clippy::redundant_closure_for_method_calls
-)]
-impl PsychicPaper {
-    /// Create a new `PsychicPaper` instance.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self
-    }
-
-    /// Interpret text based on the given intent.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tardis_chronos::experimental::psychic_paper::{PsychicPaper, Intent};
-    /// use serde_json::json;
-    ///
-    /// let paper = PsychicPaper::new();
-    ///
-    /// // A messy LLM response
-    /// let text = "Here is the data:\n```json\n{\"answer\": 42}\n```";
-    ///
-    /// // Auto-detect extracts the JSON inside the code block
-    /// let result = paper.interpret(text, Intent::Auto).unwrap();
-    /// assert_eq!(result, json!({"answer": 42}));
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns an error string if parsing fails.
-    pub fn interpret(&self, text: &str, intent: Intent) -> Result<Value, String> {
-        match intent {
-            Intent::Auto => self.interpret_auto(text),
-            Intent::Json => self.interpret_json(text),
-            Intent::List => self.interpret_list(text),
-            Intent::KeyValue => self.interpret_kv(text),
-        }
-    }
-
-    fn interpret_auto(&self, text: &str) -> Result<Value, String> {
-        // Simple heuristics
-        let trimmed = text.trim();
-        if trimmed.starts_with('{') || trimmed.starts_with('[') {
-            // If it looks like JSON, try JSON first
-            if let Ok(v) = self.interpret_json(text) {
-                return Ok(v);
+/// Parse a list from text (bullets, numbered, or comma-separated).
+///
+/// # Errors
+///
+/// Returns an error if parsing fails (currently infallible, returns string array).
+pub fn parse_list(text: &str) -> Result<Value, String> {
+    let items: Vec<String> = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            // Strip bullets
+            if let Some(stripped) = line.strip_prefix("- ") {
+                return stripped.to_string();
             }
-        }
-
-        // Check for Markdown code block with json
-        if trimmed.contains("```json") {
-            if let Ok(v) = self.interpret_json(text) {
-                return Ok(v);
+            if let Some(stripped) = line.strip_prefix("* ") {
+                return stripped.to_string();
             }
-        }
-
-        if trimmed.contains('\n') && (trimmed.contains("- ") || trimmed.contains("* ")) {
-            return self.interpret_list(text);
-        }
-
-        if trimmed.contains(':') {
-            // Check if it looks like KV lines
-            // Heuristic: majority of lines have ':'
-            let lines: Vec<&str> = trimmed.lines().filter(|l| !l.trim().is_empty()).collect();
-            if !lines.is_empty() {
-                let colon_count = lines.iter().filter(|l| l.contains(':')).count();
-                if colon_count >= lines.len() / 2 {
-                    return self.interpret_kv(text);
+            // Strip numbers "1. "
+            if let Some(idx) = line.find(". ") {
+                if idx > 0 && line[..idx].chars().all(char::is_numeric) {
+                    return line[idx + 2..].to_string();
                 }
             }
-        }
+            line.to_string()
+        })
+        .collect();
 
-        // Fallback: just a string
-        Ok(Value::String(text.to_string()))
+    // Fallback: Try comma separation if single line and no bullets were found
+    if items.len() == 1 && items[0] == text.trim() && !text.contains('\n') && text.contains(',') {
+        let items: Vec<String> = text
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        return Ok(json!(items));
     }
 
-    fn interpret_json(&self, text: &str) -> Result<Value, String> {
-        // 1. Try direct parse
-        if let Ok(v) = serde_json::from_str(text) {
-            return Ok(v);
+    Ok(json!(items))
+}
+
+/// Parse Key-Value pairs (e.g., "Name: Doctor").
+///
+/// # Errors
+///
+/// Returns an error if parsing fails.
+pub fn parse_kv(text: &str) -> Result<Value, String> {
+    let mut map = serde_json::Map::new();
+
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
         }
 
-        // 2. Try to find JSON block
-        // Find the outermost braces or brackets
-        let start_obj = text.find('{');
-        let start_arr = text.find('[');
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim().to_string();
+            let value = value.trim();
 
-        let start = match (start_obj, start_arr) {
-            (Some(o), Some(a)) => Some(o.min(a)),
-            (Some(o), None) => Some(o),
-            (None, Some(a)) => Some(a),
-            (None, None) => None,
-        };
+            // Try to parse value as JSON (number, boolean, null), else string
+            let json_val = if let Ok(v) = serde_json::from_str(value) {
+                v
+            } else {
+                Value::String(value.to_string())
+            };
 
-        let end_obj = text.rfind('}');
-        let end_arr = text.rfind(']');
+            map.insert(key, json_val);
+        }
+    }
 
-        let end = match (end_obj, end_arr) {
-            (Some(o), Some(a)) => Some(o.max(a)),
-            (Some(o), None) => Some(o),
-            (None, Some(a)) => Some(a),
-            (None, None) => None,
-        };
+    Ok(Value::Object(map))
+}
 
-        if let (Some(s), Some(e)) = (start, end) {
-            if s <= e {
-                let candidate = &text[s..=e];
-                if let Ok(v) = serde_json::from_str(candidate) {
+/// Attempt to infer structure and parse it.
+///
+/// Tries JSON -> List -> `KeyValue` -> String.
+///
+/// # Errors
+///
+/// Returns an error if the structure cannot be repaired or fallback fails (unlikely).
+pub fn repair_structure(text: &str) -> Result<Value, String> {
+    if let Ok(v) = extract_json(text) {
+        return Ok(v);
+    }
+
+    // Heuristic: If it has bullets or is a list, try list
+    if text.contains("- ") || text.contains("* ") || (text.contains(',') && !text.contains('\n')) {
+        if let Ok(v) = parse_list(text) {
+            if let Some(arr) = v.as_array() {
+                if !arr.is_empty() {
                     return Ok(v);
                 }
             }
         }
-
-        Err("Could not find valid JSON".to_string())
     }
 
-    fn interpret_list(&self, text: &str) -> Result<Value, String> {
-        let items: Vec<String> = text
-            .lines()
-            .map(|line| line.trim())
-            .filter(|line| !line.is_empty())
-            .map(|line| {
-                // Strip bullets
-                if let Some(stripped) = line.strip_prefix("- ") {
-                    return stripped.to_string();
+    // Heuristic: If it has colons, try KV
+    if text.contains(':') {
+        if let Ok(v) = parse_kv(text) {
+            if let Some(obj) = v.as_object() {
+                if !obj.is_empty() {
+                    return Ok(v);
                 }
-                if let Some(stripped) = line.strip_prefix("* ") {
-                    return stripped.to_string();
-                }
-                // Strip numbers "1. "
-                if let Some(idx) = line.find(". ") {
-                    if idx > 0 && line[..idx].chars().all(|c| c.is_numeric()) {
-                        return line[idx + 2..].to_string();
-                    }
-                }
-                line.to_string()
-            })
-            .collect();
-
-        // Fallback: Try comma separation if single line and no bullets were found/stripped
-        // "No bullets found" means we have exactly one item and it matches the original trimmed text.
-        if items.len() == 1 && items[0] == text.trim() && !text.contains('\n') && text.contains(',')
-        {
-            let items: Vec<String> = text
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-            return Ok(json!(items));
-        }
-
-        Ok(json!(items))
-    }
-
-    fn interpret_kv(&self, text: &str) -> Result<Value, String> {
-        let mut map = serde_json::Map::new();
-
-        for line in text.lines() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-
-            if let Some((key, value)) = line.split_once(':') {
-                let key = key.trim().to_string();
-                let value = value.trim();
-
-                // Try to parse value as JSON (number, boolean, null), else string
-                let json_val = if let Ok(v) = serde_json::from_str(value) {
-                    v
-                } else {
-                    Value::String(value.to_string())
-                };
-
-                map.insert(key, json_val);
             }
         }
-
-        Ok(Value::Object(map))
     }
+
+    // Fallback
+    Ok(Value::String(text.to_string()))
 }
 
 #[cfg(test)]
@@ -221,91 +151,43 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_interpret_json_clean() {
-        let text = r#"{"name": "Doctor", "age": 900}"#;
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::Json).unwrap();
-        assert_eq!(result, json!({"name": "Doctor", "age": 900}));
-    }
-
-    #[test]
-    fn test_interpret_json_markdown() {
-        let text = r#"Here is the JSON:
-```json
-{
-  "name": "Master",
-  "plan": "Conquest"
-}
-```
-Hope that helps."#;
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::Json).unwrap();
-        assert_eq!(result, json!({"name": "Master", "plan": "Conquest"}));
-    }
-
-    #[test]
-    fn test_interpret_list_bullets() {
-        let text = "- Sonic Screwdriver\n- TARDIS Key\n- Psychic Paper";
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::List).unwrap();
+    fn test_extract_json() {
         assert_eq!(
-            result,
-            json!(["Sonic Screwdriver", "TARDIS Key", "Psychic Paper"])
+            extract_json(r#"{"a":1}"#).unwrap(),
+            json!({"a": 1})
+        );
+        assert_eq!(
+            extract_json(r#"Prefix {"a":1} Suffix"#).unwrap(),
+            json!({"a": 1})
+        );
+        assert_eq!(
+            extract_json(r#"```json {"a":1} ```"#).unwrap(),
+            json!({"a": 1})
+        );
+        assert!(extract_json("Invalid").is_err());
+    }
+
+    #[test]
+    fn test_parse_list() {
+        assert_eq!(
+            parse_list("- A\n- B").unwrap(),
+            json!(["A", "B"])
+        );
+        assert_eq!(
+            parse_list("1. A\n2. B").unwrap(),
+            json!(["A", "B"])
+        );
+        assert_eq!(
+            parse_list("A, B, C").unwrap(),
+            json!(["A", "B", "C"])
         );
     }
 
     #[test]
-    fn test_interpret_list_numbered() {
-        let text = "1. Run\n2. Hide\n3. Save the world";
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::List).unwrap();
-        assert_eq!(result, json!(["Run", "Hide", "Save the world"]));
-    }
-
-    #[test]
-    fn test_interpret_kv() {
-        let text = "Species: Time Lord\nOrigin: Gallifrey\nRegenerations: 12";
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::KeyValue).unwrap();
+    fn test_parse_kv() {
         assert_eq!(
-            result,
-            json!({
-                "Species": "Time Lord",
-                "Origin": "Gallifrey",
-                "Regenerations": 12
-            })
+            parse_kv("Name: Doctor\nAge: 900").unwrap(),
+            json!({"Name": "Doctor", "Age": 900})
         );
-    }
-
-    #[test]
-    fn test_interpret_auto_json() {
-        let text = r#"{"type": "TARDIS"}"#;
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::Auto).unwrap();
-        assert_eq!(result, json!({"type": "TARDIS"}));
-    }
-
-    #[test]
-    fn test_interpret_auto_list() {
-        let text = "* Dalek\n* Cyberman";
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::Auto).unwrap();
-        assert_eq!(result, json!(["Dalek", "Cyberman"]));
-    }
-
-    #[test]
-    fn test_interpret_auto_kv() {
-        let text = "Enemy: Weeping Angel\nDon't: Blink";
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::Auto).unwrap();
-        assert_eq!(result, json!({"Enemy": "Weeping Angel", "Don't": "Blink"}));
-    }
-
-    #[test]
-    fn test_interpret_list_comma_separated() {
-        let text = "red, green, blue";
-        let paper = PsychicPaper::new();
-        let result = paper.interpret(text, Intent::List).unwrap();
-        assert_eq!(result, json!(["red", "green", "blue"]));
     }
 }

--- a/shell/src/experimental/sonic.rs
+++ b/shell/src/experimental/sonic.rs
@@ -13,7 +13,7 @@ use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
 use tardis_chronos::experimental::doctor::{HealthStatus, SystemDoctor};
-use tardis_chronos::experimental::psychic_paper::{Intent, PsychicPaper};
+use tardis_chronos::experimental::psychic_paper;
 use tardis_gallifrey::Gallifrey;
 use tardis_telemetry::gallifrey::TelemetryStore;
 use tardis_vortex::{ModelHandle, Vortex};
@@ -24,7 +24,6 @@ const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 /// The Sonic Screwdriver.
 #[derive(Debug, Default)]
 pub struct SonicScrewdriver {
-    paper: PsychicPaper,
     telemetry: Option<Arc<TelemetryStore>>,
     gallifrey: Option<Arc<Gallifrey>>,
     vortex: Option<Arc<Vortex>>,
@@ -41,7 +40,6 @@ impl SonicScrewdriver {
         model_handle: Option<ModelHandle>,
     ) -> Self {
         Self {
-            paper: PsychicPaper::new(),
             telemetry,
             gallifrey,
             vortex,
@@ -138,29 +136,54 @@ impl SonicScrewdriver {
         );
 
         // Try to interpret as JSON
-        match self.paper.interpret(&content, Intent::Json) {
-            Ok(_) => diagnosis.push_str("Type: Valid JSON\nStatus: Healthy 🟢"),
-            Err(_) => {
-                // Try other formats
-                if self.paper.interpret(&content, Intent::KeyValue).is_ok() {
-                    diagnosis.push_str("Type: Key-Value Pairs\nStatus: Healthy 🟢");
-                } else if self.paper.interpret(&content, Intent::List).is_ok() {
-                    diagnosis.push_str("Type: List\nStatus: Healthy 🟢");
-                } else {
-                    match self.paper.interpret(&content, Intent::Auto) {
-                        Ok(val) => {
-                            if val.is_string() {
-                                diagnosis.push_str("Type: Unknown / Text\nStatus: Ambiguous 🟡");
-                            } else {
-                                diagnosis.push_str(
-                                    "Type: Structured (Auto-detected)\nStatus: Healthy 🟢",
-                                );
-                            }
+        if psychic_paper::extract_json(&content).is_ok() {
+            diagnosis.push_str("Type: Valid JSON\nStatus: Healthy 🟢");
+        } else {
+            // Try other formats
+            let mut matched = false;
+            if let Ok(val) = psychic_paper::parse_kv(&content) {
+                if let Some(obj) = val.as_object() {
+                    if !obj.is_empty() {
+                        diagnosis.push_str("Type: Key-Value Pairs\nStatus: Healthy 🟢");
+                        matched = true;
+                    }
+                }
+            }
+
+            if !matched {
+                if let Ok(val) = psychic_paper::parse_list(&content) {
+                    if let Some(arr) = val.as_array() {
+                        let looks_like_list = if arr.len() > 1 {
+                            true
+                        } else {
+                            // Single element. Check for bullets or commas.
+                            content.contains("- ")
+                                || content.contains("* ")
+                                || content.contains(',')
+                        };
+
+                        if looks_like_list && !arr.is_empty() {
+                            diagnosis.push_str("Type: List\nStatus: Healthy 🟢");
+                            matched = true;
                         }
-                        Err(e) => {
-                            let _ =
-                                write!(diagnosis, "Type: Unknown\nStatus: Broken 🔴\nError: {e}");
+                    }
+                }
+            }
+
+            if !matched {
+                match psychic_paper::repair_structure(&content) {
+                    Ok(val) => {
+                        if val.is_string() {
+                            diagnosis.push_str("Type: Unknown / Text\nStatus: Ambiguous 🟡");
+                        } else {
+                            diagnosis.push_str(
+                                "Type: Structured (Auto-detected)\nStatus: Healthy 🟢",
+                            );
                         }
+                    }
+                    Err(e) => {
+                        let _ =
+                            write!(diagnosis, "Type: Unknown\nStatus: Broken 🔴\nError: {e}");
                     }
                 }
             }
@@ -188,9 +211,7 @@ impl SonicScrewdriver {
 
         // Attempt repair via interpretation
         // We use Auto intent to let PsychicPaper figure it out
-        let interpreted = self
-            .paper
-            .interpret(&content, Intent::Auto)
+        let interpreted = psychic_paper::repair_structure(&content)
             .map_err(|e| anyhow::anyhow!("Failed to interpret file: {e}"))?;
 
         // If it's a string, we probably didn't parse anything structured

--- a/shell/src/router.rs
+++ b/shell/src/router.rs
@@ -168,7 +168,7 @@ impl Router {
     }
 
     /// Tokenize input string respecting quotes.
-    /// Returns a vector of (token, end_offset) tuples.
+    /// Returns a vector of (token, `end_offset`) tuples.
     fn tokenize(input: &str) -> Vec<(String, usize)> {
         let mut tokens = Vec::new();
         let mut current_token = String::new();


### PR DESCRIPTION
Replaces the over-engineered PsychicPaper struct and Intent enum with stateless module functions (extract_json, parse_list, parse_kv, repair_structure). Simplifies JSON extraction logic and fixes bugs in SonicScrewdriver format detection.

---
*PR created automatically by Jules for task [10382588232780183469](https://jules.google.com/task/10382588232780183469) started by @madmax983*