### PR TITLE
⚡ Bolt: Lazy formatting for retrieval candidates

### DIFF
--- a/chronos/src/pipeline/augmenter.rs
+++ b/chronos/src/pipeline/augmenter.rs
@@ -96,14 +96,13 @@ pub fn augment(
     analysis: &AnalyzedQuery,
     config: &RagConfig,
 ) -> ChronosResult<String> {
-    let max_context_tokens = config.max_context_tokens;
-
     // Hard limit to prevent DoS via excessive allocation
     const MAX_TOKENS_LIMIT: usize = 100_000;
+    let max_context_tokens = config.max_context_tokens;
+
     if max_context_tokens > MAX_TOKENS_LIMIT {
         return Err(crate::error::ChronosError::ContextAssemblyFailed(format!(
-            "max_context_tokens {} exceeds limit {}",
-            max_context_tokens, MAX_TOKENS_LIMIT
+            "max_context_tokens {max_context_tokens} exceeds limit {MAX_TOKENS_LIMIT}",
         )));
     }
 

--- a/chronos/src/pipeline/retriever.rs
+++ b/chronos/src/pipeline/retriever.rs
@@ -4,6 +4,7 @@ use super::{ContextSource, ContextSourceType, RagConfig};
 use crate::error::{ChronosError, ChronosResult};
 use crate::pipeline::analyzer::AnalyzedQuery;
 use std::sync::Arc;
+use tardis_common::domain::{Entity, Message, Snapshot};
 use tardis_common::traits::{ConversationService, KnowledgeService, SystemStateService};
 use tracing::info;
 
@@ -38,30 +39,86 @@ pub async fn retrieve(
         .and_then(|c| c.checked_add(5))
         .ok_or_else(|| ChronosError::RetrievalFailed("Capacity overflow".to_string()))?;
 
-    let mut sources = Vec::with_capacity(capacity);
+    // Bolt: Use intermediate candidate struct to avoid expensive formatting on discarded items.
+    let mut candidates = Vec::with_capacity(capacity);
 
     // Retrieve from each source in parallel (TODO: make truly parallel)
     if config.include_knowledge {
-        retrieve_knowledge(knowledge, query, config, &mut sources).await?;
+        retrieve_knowledge(knowledge, query, config, &mut candidates).await?;
     }
 
     if config.include_conversation {
-        retrieve_conversation(conversation, query, config, &mut sources).await?;
+        retrieve_conversation(conversation, query, config, &mut candidates).await?;
     }
 
     if config.include_system_state {
-        retrieve_system_state(system_state, query, config, &mut sources).await?;
+        retrieve_system_state(system_state, query, config, &mut candidates).await?;
     }
 
     // Sort by relevance and limit
-    sources.sort_by(|a, b| {
+    // Bolt: Sorting ScoredCandidate is cheaper than sorting ContextSource (which owns Strings)
+    candidates.sort_by(|a, b| {
         b.relevance
             .partial_cmp(&a.relevance)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    sources.truncate(config.max_context_items);
+    candidates.truncate(config.max_context_items);
 
-    Ok(sources)
+    // Bolt: Convert to ContextSource, performing expensive formatting only for winners.
+    Ok(candidates
+        .into_iter()
+        .map(ScoredCandidate::into_context_source)
+        .collect())
+}
+
+/// Intermediate candidate structure to defer string formatting.
+struct ScoredCandidate {
+    relevance: f32,
+    data: CandidateData,
+}
+
+enum CandidateData {
+    Entity(Entity),
+    RecentMessage(Message),
+    HistoricalMessage(Message),
+    Snapshot(Snapshot),
+}
+
+impl ScoredCandidate {
+    fn into_context_source(self) -> ContextSource {
+        match self.data {
+            CandidateData::Entity(e) => ContextSource {
+                source_type: ContextSourceType::Knowledge,
+                content: format!("{}: {:?}", e.name, e.properties),
+                relevance: self.relevance,
+                entity_id: Some(e.id),
+            },
+            CandidateData::RecentMessage(msg) => ContextSource {
+                source_type: ContextSourceType::Conversation,
+                content: format!("{:?}: {}", msg.role, msg.content),
+                relevance: self.relevance,
+                entity_id: None,
+            },
+            CandidateData::HistoricalMessage(msg) => ContextSource {
+                source_type: ContextSourceType::Conversation,
+                content: msg.content,
+                relevance: self.relevance,
+                entity_id: None,
+            },
+            CandidateData::Snapshot(s) => ContextSource {
+                source_type: ContextSourceType::SystemState,
+                content: format!(
+                    "Snapshot '{}' at {}: {} processes, {} config items",
+                    s.name,
+                    s.timestamp,
+                    s.state.processes.len(),
+                    s.state.config.len()
+                ),
+                relevance: self.relevance,
+                entity_id: None,
+            },
+        }
+    }
 }
 
 /// Retrieve from knowledge graph.
@@ -70,7 +127,7 @@ async fn retrieve_knowledge(
     knowledge: &Arc<dyn KnowledgeService>,
     _query: &AnalyzedQuery,
     config: &RagConfig,
-    sources: &mut Vec<ContextSource>,
+    candidates: &mut Vec<ScoredCandidate>,
 ) -> ChronosResult<()> {
     info!("Retrieving from knowledge graph");
 
@@ -83,11 +140,9 @@ async fn retrieve_knowledge(
         .map_err(ChronosError::Common)?;
 
     for e in entities {
-        sources.push(ContextSource {
-            source_type: ContextSourceType::Knowledge,
-            content: format!("{}: {:?}", e.name, e.properties),
+        candidates.push(ScoredCandidate {
             relevance: 0.8, // TODO: Actual relevance score
-            entity_id: Some(e.id),
+            data: CandidateData::Entity(e),
         });
     }
 
@@ -100,7 +155,7 @@ async fn retrieve_conversation(
     conversation: &Arc<dyn ConversationService>,
     _query: &AnalyzedQuery,
     config: &RagConfig,
-    sources: &mut Vec<ContextSource>,
+    candidates: &mut Vec<ScoredCandidate>,
 ) -> ChronosResult<()> {
     info!("Retrieving from conversation history");
 
@@ -112,11 +167,9 @@ async fn retrieve_conversation(
             .map_err(ChronosError::Common)?;
 
         for msg in messages {
-            sources.push(ContextSource {
-                source_type: ContextSourceType::Conversation,
-                content: format!("{:?}: {}", msg.role, msg.content),
+            candidates.push(ScoredCandidate {
                 relevance: 0.9, // Recent messages are highly relevant
-                entity_id: None,
+                data: CandidateData::RecentMessage(msg),
             });
         }
     }
@@ -129,11 +182,9 @@ async fn retrieve_conversation(
         .map_err(ChronosError::Common)?;
 
     for msg in historical {
-        sources.push(ContextSource {
-            source_type: ContextSourceType::Conversation,
-            content: msg.content,
+        candidates.push(ScoredCandidate {
             relevance: 0.7,
-            entity_id: None,
+            data: CandidateData::HistoricalMessage(msg),
         });
     }
 
@@ -146,7 +197,7 @@ async fn retrieve_system_state(
     system_state: &Arc<dyn SystemStateService>,
     query: &AnalyzedQuery,
     _config: &RagConfig,
-    sources: &mut Vec<ContextSource>,
+    candidates: &mut Vec<ScoredCandidate>,
 ) -> ChronosResult<()> {
     info!("Retrieving from system state");
 
@@ -161,17 +212,9 @@ async fn retrieve_system_state(
             .await
             .map_err(ChronosError::Common)?
         {
-            sources.push(ContextSource {
-                source_type: ContextSourceType::SystemState,
-                content: format!(
-                    "Snapshot '{}' at {}: {} processes, {} config items",
-                    snapshot.name,
-                    snapshot.timestamp,
-                    snapshot.state.processes.len(),
-                    snapshot.state.config.len()
-                ),
+            candidates.push(ScoredCandidate {
                 relevance: 0.6,
-                entity_id: None,
+                data: CandidateData::Snapshot(snapshot),
             });
         }
     }


### PR DESCRIPTION
⚡ Bolt: Lazy Formatting for Retrieval Candidates

💡 **What:** Refactored `chronos/src/pipeline/retriever.rs` to use an intermediate `ScoredCandidate` struct that holds raw data (`Entity`, `Message`, `Snapshot`) instead of fully formatted `ContextSource` strings. The expensive `format!` calls (especially for `Entity.properties` HashMap) are now performed only for the top-k candidates *after* sorting and truncation.

🎯 **Why:** The previous implementation eagerly formatted every retrieved candidate (N) into a `String` before sorting and keeping only the top K. Since N is typically 3x larger than K (due to fetching from multiple sources), this resulted in unnecessary allocations and processing for items that were immediately discarded.

📊 **Impact:** 
- Reduces heap allocations by roughly `(N - K)` per query where N is total candidates and K is `max_context_items`.
- Improves retrieval latency by avoiding `serde_json` formatting for discarded entities.
- Reduces memory churn.

🔬 **Measurement:**
- Verified with `cargo test -p tardis-chronos`.
- Verified with `cargo clippy`.

---
*PR created automatically by Jules for task [9663969820176429813](https://jules.google.com/task/9663969820176429813) started by @madmax983*