### PR TITLE
feat: Add Saga narrative engine

### DIFF
--- a/chronos/src/experimental/mod.rs
+++ b/chronos/src/experimental/mod.rs
@@ -34,3 +34,6 @@ pub mod prism;
 
 #[cfg(feature = "nova")]
 pub mod cartographer;
+
+#[cfg(feature = "nova")]
+pub mod saga;

--- a/chronos/src/experimental/saga.rs
+++ b/chronos/src/experimental/saga.rs
@@ -1,0 +1,136 @@
+//! The Saga 📜
+//!
+//! A narrative engine that tells the story of the journey between two entities.
+//!
+//! It uses the Astrolabe to find a semantic path and the LLM to narrate the transitions.
+
+use crate::experimental::astrolabe::Astrolabe;
+use anyhow::{anyhow, Result};
+use std::fmt::Write;
+use std::sync::Arc;
+use tardis_common::id::ModelHandle;
+use tardis_common::llm::InferenceParams;
+use tardis_common::traits::LlmService;
+use tardis_gallifrey::Gallifrey;
+
+/// The Saga engine.
+#[derive(Debug)]
+pub struct Saga {
+    astrolabe: Astrolabe,
+    llm: Arc<dyn LlmService>,
+    model: Option<ModelHandle>,
+}
+
+impl Saga {
+    /// Create a new Saga instance.
+    #[must_use]
+    pub fn new(
+        gallifrey: Arc<Gallifrey>,
+        llm: Arc<dyn LlmService>,
+        model: Option<ModelHandle>,
+    ) -> Self {
+        Self {
+            astrolabe: Astrolabe::new(gallifrey),
+            llm,
+            model,
+        }
+    }
+
+    /// Tell the saga of the journey between two entities.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if pathfinding fails or inference fails.
+    pub async fn tell(&self, start_name: &str, end_name: &str) -> Result<String> {
+        let path = self
+            .astrolabe
+            .navigate(start_name, end_name)
+            .map_err(|e| anyhow!(e.to_string()))?;
+
+        if path.is_empty() {
+            return Ok(format!(
+                "There is no path from {start_name} to {end_name}."
+            ));
+        }
+
+        // Construct the prompt
+        let mut narrative_prompt = String::new();
+        narrative_prompt
+            .push_str("<s>[INST] You are The Bard, a legendary storyteller for the Tardis OS.\n");
+        narrative_prompt.push_str(
+            "Recount the saga of the journey from the start to the end based on this path:\n\n",
+        );
+
+        for (i, segment) in path.iter().enumerate() {
+            let step_number = i + 1;
+            let entity = &segment.entity;
+            let via = segment.via.as_deref().unwrap_or("connected to");
+
+            let _ = write!(
+                narrative_prompt,
+                "{step_number}. [{}] ({})\n   -> via [{via}] ->\n",
+                entity.name, entity.entity_type
+            );
+        }
+
+        narrative_prompt.push_str("\nWeave these steps into a cohesive, epic, short story (max 200 words). Focus on the causal links and the meaning of the journey.\n");
+        narrative_prompt.push_str("The Saga: [/INST]");
+
+        let mut params = InferenceParams::default()
+            .with_temperature(0.7)
+            .with_max_tokens(300);
+
+        if let Some(model) = self.model {
+            params = params.with_model(model);
+        }
+
+        let story = self
+            .llm
+            .infer(&narrative_prompt, params)
+            .await
+            .map_err(|e| anyhow!(e.to_string()))?;
+
+        Ok(story)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::any::Any;
+
+    #[derive(Debug)]
+    struct MockLlm;
+
+    #[async_trait]
+    impl LlmService for MockLlm {
+        async fn infer(
+            &self,
+            _prompt: &str,
+            _params: InferenceParams,
+        ) -> tardis_common::Result<String> {
+            Ok("This is a mock saga.".to_string())
+        }
+
+        async fn embed(&self, _text: &str) -> tardis_common::Result<Vec<f32>> {
+            Ok(vec![0.0; 384])
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[tokio::test]
+    async fn test_saga_creation() {
+        let gallifrey = Arc::new(Gallifrey::new());
+        let llm = Arc::new(MockLlm);
+        let saga = Saga::new(gallifrey, llm, None);
+
+        // We can't easily test `tell` without populating Gallifrey with data that Astrolabe can navigate.
+        // But we can verify it compiles and instantiates.
+        assert!(format!("{:?}", saga).contains("Saga"));
+    }
+}

--- a/shell/src/commands/experimental.rs
+++ b/shell/src/commands/experimental.rs
@@ -11,6 +11,7 @@
 //! - **Curiosity**: Active learning.
 //! - **Time Capsule**: Backup and restore entity subgraphs.
 //! - **Medium**: Seance with past system states.
+//! - **Saga**: Narrative journey between entities.
 
 use crate::commands::traits::{CommandContext, CommandResult, ShellCommand};
 use anyhow::Result;
@@ -31,6 +32,8 @@ use tardis_chronos::experimental::dreamer::Dreamer;
 use tardis_chronos::experimental::medium::Medium;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::prism::Prism;
+#[cfg(feature = "nova")]
+use tardis_chronos::experimental::saga::Saga;
 #[cfg(feature = "nova")]
 use tardis_chronos::experimental::weaver::Weaver;
 #[cfg(feature = "nova")]
@@ -836,6 +839,59 @@ impl ShellCommand for PrismCommand {
             }
         } else {
             println!("Prism needs a loaded model. Use 'models load <path>'.");
+        }
+        Ok(CommandResult::Continue)
+    }
+}
+
+/// Saga command.
+///
+/// Tells the saga of the journey between two entities.
+///
+/// # Usage
+///
+/// ```text
+/// saga <start> <end>
+/// ```
+#[cfg(feature = "nova")]
+#[derive(Debug)]
+pub struct SagaCommand;
+
+#[cfg(feature = "nova")]
+#[async_trait]
+impl ShellCommand for SagaCommand {
+    fn name(&self) -> &'static str {
+        "saga"
+    }
+
+    fn description(&self) -> &'static str {
+        "Tell the saga of the journey between entities"
+    }
+
+    async fn execute(&self, args: &[String], context: &CommandContext) -> Result<CommandResult> {
+        if args.len() < 2 {
+            println!("Usage: saga <start> <end>");
+            return Ok(CommandResult::Continue);
+        }
+
+        let start_name = &args[0];
+        let end_name = &args[1];
+
+        let loaded_models = context.chronos.vortex().list_loaded_models();
+        if let Some((handle, _)) = loaded_models.first() {
+            let saga = Saga::new(
+                Arc::clone(&context.gallifrey),
+                context.chronos.llm(),
+                Some(*handle),
+            );
+
+            println!("📜 The Bard is clearing their throat...");
+            match saga.tell(start_name, end_name).await {
+                Ok(story) => println!("\n{story}\n"),
+                Err(e) => println!("The saga is lost: {e}"),
+            }
+        } else {
+            println!("The Bard needs a loaded model. Use 'models load <path>'.");
         }
         Ok(CommandResult::Continue)
     }

--- a/shell/src/repl.rs
+++ b/shell/src/repl.rs
@@ -123,6 +123,7 @@ impl Repl {
             registry.register(Box::new(commands::experimental::MediumCommand));
             registry.register(Box::new(commands::experimental::AstrolabeCommand));
             registry.register(Box::new(commands::experimental::PrismCommand));
+            registry.register(Box::new(commands::experimental::SagaCommand));
         }
     }
 


### PR DESCRIPTION
Implemented the "Saga" feature, which allows users to generate a narrative story connecting two entities in the knowledge graph. It uses `Astrolabe` to find a semantic path and then prompts the LLM to weave a story based on the entities and relationships along the path.

Key changes:
- Created `chronos/src/experimental/saga.rs` implementing the `Saga` struct.
- Updated `chronos/src/experimental/mod.rs` to export the module.
- Added `SagaCommand` to `shell/src/commands/experimental.rs`.
- Registered the command in `shell/src/repl.rs`.

Testing:
- Added unit tests for `Saga` creation.
- Verified manual compilation and linting with `cargo check/clippy --features nova`.
- Verified `saga` command is registered.

---
*PR created automatically by Jules for task [15949519551914602604](https://jules.google.com/task/15949519551914602604) started by @madmax983*