### PR TITLE
🗺️ Atlas: Enforce strict typing for Message IDs

### DIFF
--- a/chronos/src/experimental/dreamer.rs
+++ b/chronos/src/experimental/dreamer.rs
@@ -154,6 +154,7 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use serde_json::json;
+    use tardis_common::id::MessageId;
     use tardis_gallifrey::domain::{Message, Role};
     use tardis_vortex::ModelLoadConfig;
 
@@ -166,7 +167,7 @@ mod tests {
         let session_id = gallifrey.conversation().create_session().unwrap();
 
         let msg1 = Message {
-            id: EntityId::new(),
+            id: MessageId::new(),
             session_id,
             role: Role::User,
             content: "My name is Nova and I like Rust.".to_string(),

--- a/chronos/tests/retriever_repro.rs
+++ b/chronos/tests/retriever_repro.rs
@@ -6,7 +6,7 @@ mod tests {
     use std::sync::Arc;
     use tardis_chronos::pipeline::{retrieve, AnalyzedQuery, QueryIntent, RagConfig};
     use tardis_common::domain::{Change, Entity, Message, Session, Snapshot};
-    use tardis_common::id::{EntityId, SessionId};
+    use tardis_common::id::{EntityId, MessageId, SessionId};
     use tardis_common::traits::{ConversationService, KnowledgeService, SystemStateService};
     use tardis_common::Result;
 
@@ -59,8 +59,8 @@ mod tests {
         async fn end_session(&self, _id: SessionId) -> Result<()> {
             Ok(())
         }
-        async fn add_message(&self, _message: Message) -> Result<EntityId> {
-            Ok(EntityId::new())
+        async fn add_message(&self, _message: Message) -> Result<MessageId> {
+            Ok(MessageId::new())
         }
         async fn get_recent_messages(
             &self,

--- a/common/src/domain/conversation.rs
+++ b/common/src/domain/conversation.rs
@@ -1,6 +1,6 @@
 //! Conversation entities.
 
-use crate::id::{EntityId, SessionId};
+use crate::id::{EntityId, MessageId, SessionId};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -24,11 +24,11 @@ pub enum Role {
 ///
 /// ```
 /// use tardis_common::domain::{Message, Role};
-/// use tardis_common::id::{EntityId, SessionId};
+/// use tardis_common::id::{EntityId, MessageId, SessionId};
 /// use chrono::Utc;
 ///
 /// let message = Message {
-///     id: EntityId::new(),
+///     id: MessageId::new(),
 ///     session_id: SessionId::new(),
 ///     role: Role::User,
 ///     content: "Explain the bootstrap paradox.".to_string(),
@@ -40,7 +40,7 @@ pub enum Role {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     /// Unique identifier for this message.
-    pub id: EntityId,
+    pub id: MessageId,
     /// The session this message belongs to.
     ///
     /// Messages are grouped by session to maintain conversation context.

--- a/common/src/id.rs
+++ b/common/src/id.rs
@@ -208,6 +208,12 @@ impl MessageId {
         Self(Uuid::new_v4())
     }
 
+    /// Create a message ID from a UUID.
+    #[must_use]
+    pub const fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+
     /// Get the underlying UUID.
     #[must_use]
     pub const fn as_uuid(&self) -> Uuid {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -22,5 +22,5 @@ pub mod traits;
 
 // Re-export commonly used items
 pub use error::{Error, Result};
-pub use id::{EntityId, ModelHandle, SessionId, SnapshotId};
+pub use id::{EntityId, MessageId, ModelHandle, SessionId, SnapshotId};
 pub use temporal::{BiTemporalInterval, TemporalQuery, TimeRange};

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -49,7 +49,7 @@
 //! ```
 
 use crate::domain::{Change, Entity, Message, Session, Snapshot};
-use crate::id::{EntityId, SessionId};
+use crate::id::{EntityId, MessageId, SessionId};
 use crate::llm::InferenceParams;
 use crate::Result;
 use async_trait::async_trait;
@@ -147,7 +147,7 @@ pub trait ConversationService: Send + Sync + Debug {
     async fn end_session(&self, id: SessionId) -> Result<()>;
 
     /// Add a message to the store.
-    async fn add_message(&self, message: Message) -> Result<EntityId>;
+    async fn add_message(&self, message: Message) -> Result<MessageId>;
 
     /// Get recent messages from a session.
     ///

--- a/gallifrey/src/services.rs
+++ b/gallifrey/src/services.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use tardis_common::domain::{Change, Entity, Message, Session, Snapshot};
-use tardis_common::id::{EntityId, SessionId};
+use tardis_common::id::{EntityId, MessageId, SessionId};
 use tardis_common::traits::{ConversationService, KnowledgeService, SystemStateService};
 use tardis_common::Result;
 
@@ -120,7 +120,7 @@ impl ConversationService for ConversationStore {
         self.end_session(id).map_err(tardis_common::Error::from)
     }
 
-    async fn add_message(&self, message: Message) -> Result<EntityId> {
+    async fn add_message(&self, message: Message) -> Result<MessageId> {
         self.add_message(message)
             .map_err(tardis_common::Error::from)
     }

--- a/gallifrey/src/stores/conversation.rs
+++ b/gallifrey/src/stores/conversation.rs
@@ -10,7 +10,7 @@ use crate::error::{GallifreyError, GallifreyResult};
 use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::RwLock;
-use tardis_common::{EntityId, SessionId};
+use tardis_common::{MessageId, SessionId};
 
 /// The conversation store.
 #[derive(Debug)]
@@ -96,7 +96,7 @@ impl ConversationStore {
     /// # Errors
     ///
     /// Returns an error if the lock is poisoned.
-    pub fn add_message(&self, message: Message) -> GallifreyResult<EntityId> {
+    pub fn add_message(&self, message: Message) -> GallifreyResult<MessageId> {
         let id = message.id;
         let session_id = message.session_id;
 


### PR DESCRIPTION
Enforce strict typing for Message IDs by replacing `EntityId` with `MessageId` in the `Message` struct and associated services. This aligns with the "New Type" pattern to prevent ID confusion and improve type safety.
    
    Changes:
    - `common/src/domain/conversation.rs`: `Message.id` is now `MessageId`.
    - `common/src/id.rs`: Added `MessageId::from_uuid`.
    - `common/src/lib.rs`: Re-exported `MessageId`.
    - `common/src/traits.rs`: `ConversationService::add_message` returns `Result<MessageId>`.
    - `gallifrey/src/services.rs`: Updated implementation.
    - `gallifrey/src/stores/conversation.rs`: Updated store implementation.
    - `chronos/src/experimental/dreamer.rs`: Updated usage.
    - `chronos/tests/retriever_repro.rs`: Updated mock implementation.

---
*PR created automatically by Jules for task [17212515570954302784](https://jules.google.com/task/17212515570954302784) started by @madmax983*